### PR TITLE
:zap: discord 通知: PR レビュー依頼のメッセージ

### DIFF
--- a/.github/workflows/discord_PR_review.yml
+++ b/.github/workflows/discord_PR_review.yml
@@ -16,12 +16,27 @@ jobs:
             echo "${INPUT_ARRAY[RANDOM%${#INPUT_ARRAY[@]}]}"
           }
 
+          # echo file content with replacing all the double quotes: " -> \"
+          echo_file_content_with_escaped_double_quotes(){
+            INPUT_FILE="$1"
+            cat <"$INPUT_FILE" | sed 's/"/\\&/g'
+          }
+
           # temporary files
           TEMP_CURL_DATA="data_for_curl.json"
+          TEMP_EMBED_TITLE="embed_title.txt"
 
           # 'GitHub' Bot 
           BOT_USERNAME="GitHub"
           BOT_AVATAR_URL="https://github.githubassets.com/assets/GitHub-Mark-ea2971cee799.png"
+
+          # PR_USER
+          PR_USER_LOGIN='${{ github.event.pull_request.user.login }}'
+          PR_USER_URL='${{ github.event.pull_request.user.html_url }}'
+          PR_USER_AVATAR_URL='${{ github.event.pull_request.user.avatar_url }}'
+          PR_USER_INFO="$(echo '${{ vars.MEMBERS }}' | jq -r .\"${PR_USER_LOGIN}\")"
+          PR_USER_INTRA="$(echo "${PR_USER_INFO}" | jq -r .\"intra\")"
+          PR_USER_COLOR="$(echo "${PR_USER_INFO}" | jq -r .\"color\")"
 
           # REVIEWER
           REVIEWER_LOGIN="${{ github.event.requested_reviewer.login }}"
@@ -34,13 +49,34 @@ jobs:
           NOTIFICATION_CATEGORY="Pull Request"
           NOTIFICATION_MESSAGE="**[${NOTIFICATION_CATEGORY}]**\n${RANDOM_EMOJI} <@${REVIEWER_DISCORD_ID}> レビュー依頼がありました。"
 
+          # temporary text file for EMBED_TITLE
+          cat <<EOF >"${TEMP_EMBED_TITLE}"
+          [PR #${{ github.event.pull_request.number }}] ${{ github.event.pull_request.title }}
+          EOF
+
+          # EMBED
+          EMBED_TITLE="$(echo_file_content_with_escaped_double_quotes "${TEMP_EMBED_TITLE}")"
+          EMBED_DESCRIPTION='> `${{ github.event.pull_request.base.ref }}` <- `${{ github.event.pull_request.head.ref }}`'
+          EMBED_URL='${{ github.event.pull_request.html_url }}'
+
           # temporary data file for 'curl' with POST
           cat <<EOF >"${TEMP_CURL_DATA}"
           { 
                 "username": "${BOT_USERNAME}",
                 "avatar_url": "${BOT_AVATAR_URL}",
                 "content": "${NOTIFICATION_MESSAGE}",
-                "allowed_mentions": { "parse": ["users"] }
+                "allowed_mentions": { "parse": ["users"] },
+                "embeds": [{
+                      "author": {
+                            "name": "${PR_USER_LOGIN}",
+                            "url": "${PR_USER_URL}",
+                            "icon_url": "${PR_USER_AVATAR_URL}"
+                      },
+                      "color": "${PR_USER_COLOR}",
+                      "title": "${EMBED_TITLE}",
+                      "description": "${EMBED_DESCRIPTION}",
+                      "url": "${EMBED_URL}"
+                }]
           }
           EOF
 

--- a/.github/workflows/discord_PR_review.yml
+++ b/.github/workflows/discord_PR_review.yml
@@ -1,0 +1,37 @@
+name: 'Discord Notification: Pull Rquest: review requested'
+on:
+  pull_request:
+    types: [review_requested]
+
+jobs:
+  PR-discord-notification:
+    runs-on: ubuntu-latest
+    steps:
+      - name: post message via discord-webhook-url
+        run: |
+          # temporary files
+          TEMP_CURL_DATA="data_for_curl.json"
+
+          # 'GitHub' Bot 
+          BOT_USERNAME="GitHub"
+          BOT_AVATAR_URL="https://github.githubassets.com/assets/GitHub-Mark-ea2971cee799.png"
+
+          # notification message
+          NOTIFICATION_CATEGORY="Pull Request"
+          NOTIFICATION_MESSAGE="**[${NOTIFICATION_CATEGORY}]**\nHello World"
+
+          # temporary data file for 'curl' with POST
+          cat <<EOF >"${TEMP_CURL_DATA}"
+          { 
+                "username": "${BOT_USERNAME}",
+                "avatar_url": "${BOT_AVATAR_URL}",
+                "content": "${NOTIFICATION_MESSAGE}"
+          }
+          EOF
+
+          # notify the message to 'secrets.DISCORD_WEBHOOK_URL'
+          curl \
+            -H "Content-Type: application/json" \
+            -X POST \
+            -d @${TEMP_CURL_DATA} \
+            ${{ secrets.DISCORD_WEBHOOK_URL }}

--- a/.github/workflows/discord_PR_review.yml
+++ b/.github/workflows/discord_PR_review.yml
@@ -62,21 +62,21 @@ jobs:
           # temporary data file for 'curl' with POST
           cat <<EOF >"${TEMPFILE_CURL_DATA}"
           { 
-                "username": "${BOT_USERNAME}",
-                "avatar_url": "${BOT_AVATAR_URL}",
-                "content": "${NOTIFICATION_MESSAGE}",
-                "allowed_mentions": { "parse": ["users"] },
-                "embeds": [{
-                      "author": {
-                            "name": "${PR_USER_LOGIN}",
-                            "url": "${PR_USER_URL}",
-                            "icon_url": "${PR_USER_AVATAR_URL}"
-                      },
-                      "color": "${PR_USER_COLOR}",
-                      "title": "${EMBED_TITLE}",
-                      "description": "${EMBED_DESCRIPTION}",
-                      "url": "${EMBED_URL}"
-                }]
+              "username": "${BOT_USERNAME}",
+              "avatar_url": "${BOT_AVATAR_URL}",
+              "content": "${NOTIFICATION_MESSAGE}",
+              "allowed_mentions": { "parse": ["users"] },
+              "embeds": [{
+                  "author": {
+                      "name": "${PR_USER_LOGIN}",
+                      "url": "${PR_USER_URL}",
+                      "icon_url": "${PR_USER_AVATAR_URL}"
+                  },
+                  "color": "${PR_USER_COLOR}",
+                  "title": "${EMBED_TITLE}",
+                  "description": "${EMBED_DESCRIPTION}",
+                  "url": "${EMBED_URL}"
+              }]
           }
           EOF
 

--- a/.github/workflows/discord_PR_review.yml
+++ b/.github/workflows/discord_PR_review.yml
@@ -23,8 +23,8 @@ jobs:
           }
 
           # temporary files
-          TEMP_CURL_DATA="data_for_curl.json"
-          TEMP_EMBED_TITLE="embed_title.txt"
+          TEMPFILE_CURL_DATA="data_for_curl.json"
+          TEMPFILE_EMBED_TITLE="embed_title.txt"
 
           # 'GitHub' Bot 
           BOT_USERNAME="GitHub"
@@ -50,17 +50,17 @@ jobs:
           NOTIFICATION_MESSAGE="**[${NOTIFICATION_CATEGORY}]**\n${RANDOM_EMOJI} <@${REVIEWER_DISCORD_ID}> レビュー依頼がありました。"
 
           # temporary text file for EMBED_TITLE
-          cat <<EOF >"${TEMP_EMBED_TITLE}"
+          cat <<EOF >"${TEMPFILE_EMBED_TITLE}"
           [PR #${{ github.event.pull_request.number }}] ${{ github.event.pull_request.title }}
           EOF
 
           # EMBED
-          EMBED_TITLE="$(echo_file_content_with_escaped_double_quotes "${TEMP_EMBED_TITLE}")"
+          EMBED_TITLE="$(echo_file_content_with_escaped_double_quotes "${TEMPFILE_EMBED_TITLE}")"
           EMBED_DESCRIPTION='> `${{ github.event.pull_request.base.ref }}` <- `${{ github.event.pull_request.head.ref }}`'
           EMBED_URL='${{ github.event.pull_request.html_url }}'
 
           # temporary data file for 'curl' with POST
-          cat <<EOF >"${TEMP_CURL_DATA}"
+          cat <<EOF >"${TEMPFILE_CURL_DATA}"
           { 
                 "username": "${BOT_USERNAME}",
                 "avatar_url": "${BOT_AVATAR_URL}",
@@ -84,5 +84,5 @@ jobs:
           curl \
             -H "Content-Type: application/json" \
             -X POST \
-            -d @${TEMP_CURL_DATA} \
+            -d @${TEMPFILE_CURL_DATA} \
             ${{ secrets.DISCORD_WEBHOOK_URL }}

--- a/.github/workflows/discord_PR_review.yml
+++ b/.github/workflows/discord_PR_review.yml
@@ -9,6 +9,13 @@ jobs:
     steps:
       - name: post message via discord-webhook-url
         run: |
+          # echo one random element from the first input argument
+          # - the first input argument should be space-separated string
+          echo_one_random_element(){
+            INPUT_ARRAY=($1)
+            echo "${INPUT_ARRAY[RANDOM%${#INPUT_ARRAY[@]}]}"
+          }
+
           # temporary files
           TEMP_CURL_DATA="data_for_curl.json"
 
@@ -16,16 +23,24 @@ jobs:
           BOT_USERNAME="GitHub"
           BOT_AVATAR_URL="https://github.githubassets.com/assets/GitHub-Mark-ea2971cee799.png"
 
+          # REVIEWER
+          REVIEWER_LOGIN="${{ github.event.requested_reviewer.login }}"
+          REVIEWER_DISCORD_ID="$(echo '${{ vars.MEMBERS }}' | jq -r .\"${REVIEWER_LOGIN}\".\"discord_id\")"
+
+          # random emoji
+          RANDOM_EMOJI="$(echo_one_random_element '${{ vars.EMOJI_SET }}')"
+
           # notification message
           NOTIFICATION_CATEGORY="Pull Request"
-          NOTIFICATION_MESSAGE="**[${NOTIFICATION_CATEGORY}]**\nHello World"
+          NOTIFICATION_MESSAGE="**[${NOTIFICATION_CATEGORY}]**\n${RANDOM_EMOJI} <@${REVIEWER_DISCORD_ID}> レビュー依頼がありました。"
 
           # temporary data file for 'curl' with POST
           cat <<EOF >"${TEMP_CURL_DATA}"
           { 
                 "username": "${BOT_USERNAME}",
                 "avatar_url": "${BOT_AVATAR_URL}",
-                "content": "${NOTIFICATION_MESSAGE}"
+                "content": "${NOTIFICATION_MESSAGE}",
+                "allowed_mentions": { "parse": ["users"] }
           }
           EOF
 


### PR DESCRIPTION
## タスクのリンク
- #2 

## やったこと
- 任意の Pull Request ページでレビュワーを選択すれば、それをトリガーとして今回作成した workflow が走ります。自動通知メッセージを discord チャンネルの WEBHOOK URL に curl の post で送っています。

## やらないこと
-  レビュワーを選択するアクションのみがトリガーになっています。他のタイミングでは特に動作を加えていません。

## 動作確認
- [Actions scerets and variables](https://github.com/42-pong/42-pong/settings/secrets/actions) に決まった形での変数を前提としています。
- 別の [test 用のレポジトリー](https://github.com/42-pong/workflow-test) を作成してみました。必要に応じて、[テストPR](https://github.com/42-pong/workflow-test/pull/2) よりレビュワーを選択するなど、自由にテストしていただければと思います。
- この PR に対しても今回作成した workflow が正常に走れば該当の discord  チャンネルに通知されるかと思います。

## 特にレビューをお願いしたい箇所
- 通知に載せる内容や形など、確認いただければと思います。
- PR タイトルには、ダブルクォート、シングルクォートが含まれていても動くと思います。他のところはダブルクォートなどとは相性が良くなく、問題あるかもしれません。

## その他
- github settings の variables を変えれば、以下はカスタマイズできると思います。
  - ランダム絵文字の種類
  - 個人ごとの埋め込みメッセージのの色設定
