### PR TITLE
⚡ API openapi.yaml /health の部分を書く

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -1,0 +1,26 @@
+openapi: 3.0.0
+info:
+  title: Sample API
+  description: Optional multiline or single-line description in [CommonMark](http://commonmark.org/help/) or HTML.
+  version: 0.1.9
+
+servers:
+  - url: http://api.example.com/v1
+    description: Optional server description, e.g. Main (production) server
+  - url: http://staging-api.example.com
+    description: Optional server description, e.g. Internal staging server for testing
+
+paths:
+  /users:
+    get:
+      summary: Returns a list of users.
+      description: Optional extended description in CommonMark or HTML.
+      responses:
+        "200": # status code
+          description: A JSON array of user names
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string

--- a/openapi.yml
+++ b/openapi.yml
@@ -33,6 +33,23 @@ paths:
                     type: string
                     format: date-time
                     example: "2024-11-09T12:00:00Z"
+        "503":
+          description: The service is unhealthy and unable to handle requests.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    example: "unhealthy"
+                  message:
+                    type: string
+                    example: "The service is unhealthy and unable to handle requests."
+                  timestamp:
+                    type: string
+                    format: date-time
+                    example: "2024-11-09T12:01:00Z"
         "500":
           description: Internal server error occurred during health check.
           content:

--- a/openapi.yml
+++ b/openapi.yml
@@ -33,9 +33,20 @@ paths:
                     type: string
                     format: date-time
                     example: "2024-11-09T12:00:00Z"
+        "500":
+          description: Internal server error occurred during health check.
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  type: string
+                type: object
+                properties:
+                  status:
+                    type: string
+                    example: "error"
+                  message:
+                    type: string
+                    example: "Health check failure due to unexpected error."
+                  timestamp:
+                    type: string
+                    format: date-time
+                    example: "2024-11-09T12:02:00Z"

--- a/openapi.yml
+++ b/openapi.yml
@@ -1,15 +1,19 @@
 openapi: 3.0.0
+
+# todo: APIのタイトル
 info:
   title: Sample API
   description: Optional multiline or single-line description in [CommonMark](http://commonmark.org/help/) or HTML.
   version: 0.1.9
 
+# todo: serverのurlと詳細
 servers:
   - url: http://api.example.com/v1
     description: Optional server description, e.g. Main (production) server
   - url: http://staging-api.example.com
     description: Optional server description, e.g. Internal staging server for testing
 
+# todo: postなどの他のメソッドの定義（他のメソッドも定義する場合、/components/schemasを使用してresponseのcontentをまとめる）
 paths:
   /health:
     get:

--- a/openapi.yml
+++ b/openapi.yml
@@ -1,17 +1,13 @@
 openapi: 3.0.0
 
-# todo: APIのタイトル
 info:
   title: Backend API
   description: Optional multiline or single-line description in [CommonMark](http://commonmark.org/help/) or HTML.
   version: 1.0.0
 
-# todo: serverのurlと詳細
 servers:
-  - url: http://api.example.com/v1
+  - url: http://localhost:8000/api
     description: Optional server description, e.g. Main (production) server
-  - url: http://staging-api.example.com
-    description: Optional server description, e.g. Internal staging server for testing
 
 # todo: postなどの他のメソッドの定義（他のメソッドも定義する場合、/components/schemasを使用してresponseのcontentをまとめる）
 paths:

--- a/openapi.yml
+++ b/openapi.yml
@@ -16,8 +16,23 @@ paths:
       summary: Health check endpoint
       description: This endpoint checks the health of the service instance by performing various checks, such as infrastructure connections, host status, and application-specific logic.
       responses:
-        "200": # status code
-          description: A JSON array of user names
+        "200":
+          description: The service is healthy and capable of handling requests.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    example: "healthy"
+                  message:
+                    type: string
+                    example: "The service is healthy and capable of handling requests."
+                  timestamp:
+                    type: string
+                    format: date-time
+                    example: "2024-11-09T12:00:00Z"
           content:
             application/json:
               schema:

--- a/openapi.yml
+++ b/openapi.yml
@@ -2,9 +2,9 @@ openapi: 3.0.0
 
 # todo: APIのタイトル
 info:
-  title: Sample API
+  title: Backend API
   description: Optional multiline or single-line description in [CommonMark](http://commonmark.org/help/) or HTML.
-  version: 0.1.9
+  version: 1.0.0
 
 # todo: serverのurlと詳細
 servers:

--- a/openapi.yml
+++ b/openapi.yml
@@ -11,10 +11,10 @@ servers:
     description: Optional server description, e.g. Internal staging server for testing
 
 paths:
-  /users:
+  /health:
     get:
-      summary: Returns a list of users.
-      description: Optional extended description in CommonMark or HTML.
+      summary: Health check endpoint
+      description: This endpoint checks the health of the service instance by performing various checks, such as infrastructure connections, host status, and application-specific logic.
       responses:
         "200": # status code
           description: A JSON array of user names


### PR DESCRIPTION
## タスクのリンク
*close #23 

## やったこと
- OpenAPIについて調べた
- openapi.yamlで`/healh`を定義した
  - 200: サービスが正常な場合
  - 503: サービスが問題がある場合
  - 500: 予期せぬエラーの場合

## やらないこと
- GET以外のメソッド定義
- responseのcontentをまとめる
- 認証認可の設定

## 相談して決めたいこと
- [x] APIのタイトル
- [x] serverのurlと詳細
- [x] postなどの他のメソッドの定義（他のメソッドも定義する場合、/components/schemasを使用してresponseのcontentをまとめる）

## 動作確認
[swagger editor](https://editor.swagger.io/?_gl=1*hno8cp*_gcl_au*MjkyMTg0NzQuMTczMDE4ODQ4Ng..)でopenapi.yamlをコピペし、確認する

## 特にレビューをお願いしたい箇所
- ヘルスチェックの役割が定義できているかどうか。
- ヘルスチェックのパラメータや文章について違和感ないかどうか。

## その他
OpenAPIとは？
https://github.com/orgs/42-pong/discussions/30

参考にしたページ
[health check endpointの作成](https://microservices.io/patterns/observability/health-check-api.html)
