### PR TITLE
⚡  discord 通知: Discussion 作成時

### DIFF
--- a/.github/workflows/discord_discussion.yml
+++ b/.github/workflows/discord_discussion.yml
@@ -63,7 +63,7 @@ jobs:
 
            # temporary text file for EMBED_TITLE
           cat <<EOF >"${TEMPFILE_EMBED_TITLE}"
-          ${{ github.event.discussion.title }}
+          [Discussion #${{ github.event.discussion.number }}] ${{ github.event.discussion.title }}
           EOF
 
            # temporary text file for EMBED_DESCRIPTION

--- a/.github/workflows/discord_discussion.yml
+++ b/.github/workflows/discord_discussion.yml
@@ -16,18 +16,66 @@ jobs:
             echo "${INPUT_ARRAY[RANDOM%${#INPUT_ARRAY[@]}]}"
           }
 
+          # echo file content with replacing all the double quotes: " -> \"
+          echo_file_content_with_escaped_double_quotes(){
+            INPUT_FILE="$1"
+            cat <"$INPUT_FILE" | sed 's/"/\\&/g'
+          }
+
+          # usage: trim_lines <input_file> <output_file> <maximal_line_count>
+          # - if <input_file> has more than <maximal_line_count>,
+          #   replace the rest part with '...'
+          trim_lines(){
+            INPUT_FILE="$1"
+            OUTPUT_FILE="$2"
+            LINE_LIMIT="$3"
+            if [[ $(cat <"$INPUT_FILE" | wc -l) -gt "$LINE_LIMIT" ]];
+              then
+                cat <"$INPUT_FILE" | head >"$OUTPUT_FILE" -n "$LINE_LIMIT"
+                echo "..." >>"$OUTPUT_FILE"
+              else
+                cat <"$INPUT_FILE" >"$OUTPUT_FILE"
+            fi
+          }
+
           # temporary files
           TEMPFILE_CURL_DATA="data_for_curl.json"
+          TEMPFILE_EMBED_TITLE="discussion_title.txt"
+          TEMPFILE_EMBED_DESCRIPTION="discussion_body.txt"
+          TEMPFILE_EMBED_DESCRIPTION_TRIMMED="discussion_body_trimmed.txt"
 
           # 'GitHub' Bot
           BOT_USERNAME="GitHub"
           BOT_AVATAR_URL="https://github.githubassets.com/assets/GitHub-Mark-ea2971cee799.png"
+
+          # DISCUSSION_USER
+          DISCUSSION_USER_LOGIN='${{ github.event.discussion.user.login }}'
+          DISCUSSION_USER_URL='${{ github.event.discussion.user.html_url }}'
+          DISCUSSION_USER_AVATAR_URL='${{ github.event.discussion.user.avatar_url }}'
+          DISCUSSION_USER_INFO="$(echo '${{ vars.MEMBERS }}' | jq -r .\"${DISCUSSION_USER_LOGIN}\")"
+          DISCUSSION_USER_COLOR="$(echo "${DISCUSSION_USER_INFO}" | jq -r .\"color\")"
 
           # random adjective
           RANDOM_ADJECTIVE="$(echo_one_random_element '${{ vars.ADJECTIVE_SET }}')"
 
           # discussion
           DISCUSSION_CATEGORY='${{ github.event.discussion.category.emoji }} ${{ github.event.discussion.category.name }}'
+
+           # temporary text file for EMBED_TITLE
+          cat <<EOF >"${TEMPFILE_EMBED_TITLE}"
+          ${{ github.event.discussion.title }}
+          EOF
+
+           # temporary text file for EMBED_DESCRIPTION
+          cat <<EOF >"${TEMPFILE_EMBED_DESCRIPTION}"
+          ${{ github.event.discussion.body }}
+          EOF
+          trim_lines "${TEMPFILE_EMBED_DESCRIPTION}" "${TEMPFILE_EMBED_DESCRIPTION_TRIMMED}" 10
+
+          # EMBED
+          EMBED_TITLE="$(echo_file_content_with_escaped_double_quotes "${TEMPFILE_EMBED_TITLE}")"
+          EMBED_DESCRIPTION="$(echo_file_content_with_escaped_double_quotes "${TEMPFILE_EMBED_DESCRIPTION_TRIMMED}")"
+          EMBED_URL='${{ github.event.discussion.html_url }}'
 
           # notification message
           NOTIFICATION_CATEGORY="Discussion"
@@ -38,7 +86,18 @@ jobs:
           {
               "username": "${BOT_USERNAME}",
               "avatar_url": "${BOT_AVATAR_URL}",
-              "content": "${NOTIFICATION_MESSAGE}"
+              "content": "${NOTIFICATION_MESSAGE}",
+              "embeds": [{
+                  "author": {
+                      "name": "${DISCUSSION_USER_LOGIN}",
+                      "url": "${DISCUSSION_USER_URL}",
+                      "icon_url": "${DISCUSSION_USER_AVATAR_URL}"
+                  },
+                  "color": "${DISCUSSION_USER_COLOR}",
+                  "title": "${EMBED_TITLE}",
+                  "description": "${EMBED_DESCRIPTION}",
+                  "url": "${EMBED_URL}"
+              }]
           }
           EOF
 

--- a/.github/workflows/discord_discussion.yml
+++ b/.github/workflows/discord_discussion.yml
@@ -1,0 +1,50 @@
+name: 'Discord Notification: Discussion: created'
+on:
+  discussion:
+    types: [created]
+
+jobs:
+  discussion-discord-notification:
+    runs-on: ubuntu-latest
+    steps:
+      - name: post message via discord-webhook-url
+        run: |
+          # echo one random element from the first input argument
+          # - the first input argument should be space-separated string
+          echo_one_random_element(){
+            INPUT_ARRAY=($1)
+            echo "${INPUT_ARRAY[RANDOM%${#INPUT_ARRAY[@]}]}"
+          }
+
+          # temporary files
+          TEMPFILE_CURL_DATA="data_for_curl.json"
+
+          # 'GitHub' Bot
+          BOT_USERNAME="GitHub"
+          BOT_AVATAR_URL="https://github.githubassets.com/assets/GitHub-Mark-ea2971cee799.png"
+
+          # random adjective
+          RANDOM_ADJECTIVE="$(echo_one_random_element '${{ vars.ADJECTIVE_SET }}')"
+
+          # discussion
+          DISCUSSION_CATEGORY='${{ github.event.discussion.category.emoji }} ${{ github.event.discussion.category.name }}'
+
+          # notification message
+          NOTIFICATION_CATEGORY="Discussion"
+          NOTIFICATION_MESSAGE="**[${NOTIFICATION_CATEGORY}]**\n**${DISCUSSION_CATEGORY}** に*${RANDOM_ADJECTIVE}*ディスカッションが作成されました。"
+
+          # temporary data file for 'curl' with POST
+          cat <<EOF >"${TEMPFILE_CURL_DATA}"
+          {
+              "username": "${BOT_USERNAME}",
+              "avatar_url": "${BOT_AVATAR_URL}",
+              "content": "${NOTIFICATION_MESSAGE}"
+          }
+          EOF
+
+          # notify the message to 'secrets.DISCORD_WEBHOOK_URL_DISCUSSION_NOTIFICATION'
+          curl \
+            -H "Content-Type: application/json" \
+            -X POST \
+            -d @${TEMPFILE_CURL_DATA} \
+            ${{ secrets.DISCORD_WEBHOOK_URL_DISCUSSION_NOTIFICATION }}

--- a/.github/workflows/discord_discussion.yml
+++ b/.github/workflows/discord_discussion.yml
@@ -38,6 +38,12 @@ jobs:
             fi
           }
 
+          # replace crlf with escaped newline: \r\n -> '\n'
+          echo_with_crlf_as_escaped_newline(){
+            INPUT_STR="$1"
+            echo "${INPUT_STR}" | sed -z 's/\r\n/\\n/g'
+          }
+
           # temporary files
           TEMPFILE_CURL_DATA="data_for_curl.json"
           TEMPFILE_EMBED_TITLE="discussion_title.txt"
@@ -74,7 +80,7 @@ jobs:
 
           # EMBED
           EMBED_TITLE="$(echo_file_content_with_escaped_double_quotes "${TEMPFILE_EMBED_TITLE}")"
-          EMBED_DESCRIPTION="$(echo_file_content_with_escaped_double_quotes "${TEMPFILE_EMBED_DESCRIPTION_TRIMMED}")"
+          EMBED_DESCRIPTION="$(echo_with_crlf_as_escaped_newline "$(echo_file_content_with_escaped_double_quotes "${TEMPFILE_EMBED_DESCRIPTION_TRIMMED}")")"
           EMBED_URL='${{ github.event.discussion.html_url }}'
 
           # notification message


### PR DESCRIPTION
## タスクのリンク
- #2 

## やったこと
- 上記の Issue #2 より
> - [ ] ランダム絵文字
> - [x] ランダム形容詞
> - [x] アナウンスの文章
> - [ ] everyone 通知
> - [x] 10行目以降は ```...``` で置き換え
> - [x] category がわかるように

- dicussion 作成をトリガーとして今回作成した workflow が走ります。
- PR レビューと同様に、自動通知メッセージを discord チャンネルの WEBHOOK URL に curl の post で送っています。
#9 
- 通知案内文にランダムな形容詞をつけてみました。
- discussion の本文の行数が 10 より大きい場合は、11 行目以降は '...' に置き換えています。

## やらないこと
-  discussion の作成のみが今回の workflow のトリガーです。他のときは走りません。

## 動作確認
- [Actions scerets and variables](https://github.com/42-pong/42-pong/settings/secrets/actions) に決まった形での変数を前提としています。
- 別の [test 用のレポジトリー](https://github.com/42-pong/workflow-test) で新しい discussion を作成してテストできるかと思います。

## 特にレビューをお願いしたい箇所
- 通知に載せる内容や形など、確認いただければと思います。
- Discussion のタイトルと本文には、ダブルクォート、シングルクォートが含まれていても問題ないと思います。他のところはダブルクォートなどとは相性が良くなく、問題あるかもしれません。

## その他
- [Actions scerets and variables](https://github.com/42-pong/42-pong/settings/secrets/actions) の variables を変えれば、以下はカスタマイズできると思います。
  - ランダム形容詞の種類
  - 通知先の discord チャンネルの webhook url
  - 個人ごとの埋め込みメッセージのの色設定
