### PR TITLE
⚡ compose.yaml と backend/Dockerfile で WORKDIR を同期する, 実行 USER 指定

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -4,6 +4,9 @@ FROM python:3.13
 
 WORKDIR /pong
 
+# 新規userを作成。この時点ではuserはroot
+RUN useradd -ms /bin/bash pong
+
 COPY requirements.txt .
 RUN pip install --upgrade pip && \
     pip3 install --no-cache-dir -r requirements.txt
@@ -11,7 +14,9 @@ RUN pip install --upgrade pip && \
 COPY ./tools/entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh
 
-# todo: USER設定
+RUN chown -R pong:pong /pong
+# root権限が必要なinstall等を終えたら作成したuserに切り替え
+USER pong
 
 EXPOSE 8000
 


### PR DESCRIPTION
## タスクやディスカッションのリンク
- #43 

## やったこと
- backend コンテナを起動する際の user を指定し、権限もその user にしました
今後、コンテナ内で 新規で app を作っていく際に root user でファイルを生成したりすると、local でそのファイルが変更などできないためです (確か macOS なら特に問題なく変更などできた気がします)


## やらないこと
- タイトル 1 つ目の `WORKDIR` について、必要ないかも？と思い、していません (元：https://github.com/42-pong/42-pong/pull/21#discussion_r1834800564)

  理由は、compose.yml と Dockerfile で共通の `WORKDIR` を使用したい場合、`.env` を使うしかないと思っているのですが ( `.env` を使わなくてもできる場合は教えていただきたいです！)、
  - `backend/pong` は Django project を始める際に確定したもので今後変更がないと思われる
  - ↑ の Django progect 名に合わせて `WORKDIR` を指定している
 
  ため、環境変数にして変更可能にする必要はないのではないか？と思いました
  意見聞きたいです🙏

## 動作確認
- 再 build してコンテナ内の user が変わっているか
- ファイルの所有者が指定した user になってるか
- コンテナ内で作成したファイルをローカルで編集・保存などできるか
```sh
make build-up
make exec-be
whoami
ls -l
```


## 特にレビューをお願いしたい箇所
- 動作確認
- 今コンテナ内の working dir と user を同じ `pong` にしているのですが、分かりやすいように変えた方が良かったりしたら user 名の案を教えていただきたいです🙏

## その他
- なし

## 参考リンク
- なし

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a non-root user `pong` for enhanced security in the application.
	- Adjusted permissions for the `/pong` directory to ensure proper access for the new user.

- **Bug Fixes**
	- Improved security by minimizing root user usage during runtime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->