### PR TITLE
Djangoの初期設定

### DIFF
--- a/backend/pong/pong/settings.py
+++ b/backend/pong/pong/settings.py
@@ -105,7 +105,7 @@ AUTH_PASSWORD_VALIDATORS = [
 
 LANGUAGE_CODE = "en-us"
 
-TIME_ZONE = "UTC"
+TIME_ZONE = "Asia/Tokyo"
 
 USE_I18N = True
 

--- a/backend/pong/pong/settings.py
+++ b/backend/pong/pong/settings.py
@@ -19,6 +19,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/5.1/howto/deployment/checklist/
 
+# todo: 本番環境用を作成する場合、django-environ or python-dotenvを使って.envでSECRET_KEYを設定する。
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = "django-insecure-lqyo8yy!fs!kyqr408#rk@gs-%svxh43d2r4$nt@1vh46dtd-4"
 

--- a/backend/tools/entrypoint.sh
+++ b/backend/tools/entrypoint.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
-# todo: createsuperuser, migrate など
+python3 manage.py migrate --noinput
+
 
 exec "$@"

--- a/backend/tools/entrypoint.sh
+++ b/backend/tools/entrypoint.sh
@@ -2,5 +2,16 @@
 
 python3 manage.py migrate --noinput
 
+# todo: username, email. passwordの環境変数で登録
+python3 manage.py shell <<EOF
+from django.contrib.auth import get_user_model
+
+username = 'admin'
+email = 'admin@example.com'
+password = 'password'
+
+User = get_user_model()
+User.objects.create_superuser(username=username, email=email, password=password)
+EOF
 
 exec "$@"


### PR DESCRIPTION
## タスクやディスカッションのリンク
- #32 

## やったこと
- superuserの作成
- timezoneを日本時間（JST）に変更

## やらないこと
`.env`もしくは環境変数からSECRET＿KEYを取得
以下を決めてからやる
- `.env`か環境変数 / インストールするパッケージが変わるため
-  python-dotenv かdjango-envirsion / 依存関係が変わるため

## 動作確認
- superuserが作成できているかの確認
1. `make up` or `make build-up`
2. `make exec-be`
3. `python3 manage.py shell`
```
from django.contrib.auth.models import User
superuser = User.objects.filter(is_superuser=True).first()
if superuser:
	print("super user name:", superuser.username)
	print("super user mail:", superuser.email)
else:
	print("The superuser doesn't exist")
```
- timezoneが日本時間かどうかの確認
1. `make up` or `make build-up`
2. `make exec-be`
3. `python3 manage.py shell`
```
from django.utils import timezone
print(timezone.localtime(timezone.now()))
```
## 特にレビューをお願いしたい箇所
したことができているかどうか確認お願いします。

## その他
- サマリーはPRを作成したタイミングで作成が始まります。
- ポエムは面白いので出しています。邪魔だったら消します笑

## 参考リンク