### PR TITLE
🐛  formatterのworkflowがエラーを出すよう修正

### DIFF
--- a/.github/workflows/backend_code_check.yml
+++ b/.github/workflows/backend_code_check.yml
@@ -32,12 +32,12 @@ jobs:
 
       # RuffによるLinterチェック
       - name: Run Ruff Linter
-        run: make lint -C backend/pong
+        run: make -s lint -C backend/pong
 
       # Ruffによるフォーマットチェック
       - name: Run Ruff Formatter
-        run: make formatcheck -C backend/pong
+        run: make -s formatcheck -C backend/pong
 
       # Mypyによる型チェック
       - name: Run Mypy Type Checker
-        run: make typecheck -C backend/pong
+        run: make -s typecheck -C backend/pong

--- a/.github/workflows/backend_code_check.yml
+++ b/.github/workflows/backend_code_check.yml
@@ -36,7 +36,10 @@ jobs:
 
       # Ruffによるフォーマットチェック
       - name: Run Ruff Formatter
-        run: make format -C backend/pong
+        # エラーがあれば修正せずに警告を出す
+        run: |
+          ruff format --check backend/pong
+          ruff check --select I backend/pong # isort
 
       # Mypyによる型チェック
       - name: Run Mypy Type Checker

--- a/.github/workflows/backend_code_check.yml
+++ b/.github/workflows/backend_code_check.yml
@@ -36,10 +36,7 @@ jobs:
 
       # Ruffによるフォーマットチェック
       - name: Run Ruff Formatter
-        # エラーがあれば修正せずに警告を出す
-        run: |
-          ruff format --check backend/pong
-          ruff check --select I backend/pong # isort
+        run: make formatcheck -C backend/pong
 
       # Mypyによる型チェック
       - name: Run Mypy Type Checker

--- a/backend/pong/Makefile
+++ b/backend/pong/Makefile
@@ -27,6 +27,11 @@ format:
 	@ruff format . # black
 	@ruff check --select I --fix . # isort
 
+.PHONY: formatcheck
+formatcheck:
+	@ruff format --check .
+	@ruff check --select I .
+
 # -------------------------------------------------------
 # static type checker
 # -------------------------------------------------------

--- a/backend/pong/Makefile
+++ b/backend/pong/Makefile
@@ -7,7 +7,7 @@ all: check
 check:
 	@make -s lint
 	$(SEPARATOR)
-	@make -s format
+	@make -s formatcheck
 	$(SEPARATOR)
 	@make -s typecheck
 	$(SEPARATOR)


### PR DESCRIPTION
## タスクやディスカッションのリンク
- #48 

## やったこと
- .github/workflow/backend_code_check.ymlのformatter部分がテスト環境のコードをフォーマットするだけでエラーを出さないようになってしまっていたので、フォーマッターが修正せずに警告だけ出すように変更しました。

## やらないこと
- mypyが変数の型ヒントがなければ警告を出すようにする -> それができるようであれば別ブランチで実行します。

## 動作確認
make formatで確認する事項を修正せずに警告だけだすようにできるか確認しました。
```python
# formatter

$ make exec-be
root@bc16d1ba0b2b:/pong# ruff format --check .
Would reformat: pong/settings.py
1 file would be reformatted, 8 files already formatted
root@bc16d1ba0b2b:/pong# echo $?
1
```

```python
isort

root@bc16d1ba0b2b:/pong# ruff check --select I .
pong/settings.py:13:1: I001 [*] Import block is un-sorted or un-formatted
   |
11 |   """
12 |
13 | / from pathlib import Path
14 | |
15 | | import os
16 | | # Build paths inside the project like this: BASE_DIR / 'subdir'.
   | |_^ I001
17 |   BASE_DIR = Path(__file__).resolve().parent.parent
   |
   = help: Organize imports

Found 1 error.
[*] 1 fixable with the `--fix` option.
root@bc16d1ba0b2b:/pong# echo $?
1
```

## 特にレビューをお願いしたい箇所
一応動作確認はしているので大丈夫ですが、気になる方は以下を実行してもらうとMakefileのformatコマンドとは違って、修正せずに警告だけ出すことがわかるかと思います。
```python
$ make exec-be
# 何か行を長くするなどファイルを変更してください
$ ruff format --check .
# import 分の並びをばらばらにするなどしてください
$ ruff check --select I .
```

## その他
- isortがファイルに連続してimport文などがあれば並び替えてくれますが、一つだけ最後の行に書かれているなどしたら修正しないことに気づきました。おそらく使う場所の近くにimport文を置きたいなどの場合もあるからかもしれません。

## 参考リンク
- [ruff formatter](https://docs.astral.sh/ruff/formatter/)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
  - リンティングプロセスの明確化を図るため、フォーマットチェックとインポートソートチェックを分離しました。  
- **Chores**
  - GitHub Actionsのワークフローが改善され、コードレビュー時のフィードバックが向上しました。
  - 新しいフォーマットチェックターゲットが追加され、コードの整形確認が容易になりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->