### PR TITLE
:zap:(compose.yml)backendのhealthcheckオプションを追加

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -14,6 +14,11 @@ services:
       - ./backend/pong:/pong
     networks:
       - transcendence
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/api/health/"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
 
   # todo: DBが必要になってから追加
   # db:


### PR DESCRIPTION
## タスクやディスカッションのリンク
- #68 

## やったこと
- comopse.yamlのbackendコンテナにhealthcheckオプションを追加しました。
- 今後frontendコンテナがdepends_onオプションでbackendを指定するときに使うと思います。

## やらないこと
- なし

## 動作確認
- healthcheckで実行されている`curl -f "http://localhost:8000/api/health/"`を実行し、status: OKが返ってくることを確認しました。
- CMDを使うかCMD-SHELLを使うかはどちらでも結果は同じだったので、CMDを使いました。
```sh
# CMDを使ったときの挙動
$ docker exec backend curl -f http://localhost:8000/api/health/
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100    15  100    15    0     0   5347      0 --:--:-- --:--:-- --:--:--  7500
{"status":"OK"}

# CMD-SHELLを使ったときの挙動
$ docker exec backend /bin/bash -c "curl -f http://localhost:8000/api/health/"
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100    15  100    15    0     0   5315      0 --:--:-- --:--:-- --:--:--  7500
{"status":"OK"}
```

## 特にレビューをお願いしたい箇所
- このコメントの説明で疑問や間違いを感じた点があれば教えていただきたいです。

## その他
- healthcheckの成功・失敗はコマンドの返り値で判定しているみたいです。
> そのコマンドの終了ステータスが、対象となるコンテナのヘルスステータスになります。可能性のある値は、次の通りです。
0: 成功success コンテナは正常
1: 障害unhealthy
2: 予約済みreserved - この終了コードは使いません


## 参考リンク
- [Dockerfileのhealthcheckについての公式ドキュメント](https://docs.docker.jp/engine/reference/builder.html#builder-healthcheck)
- [compose.yamlのhealthcheckについての公式ドキュメント](https://docs.docker.jp/compose/compose-file/index.html#healthcheck)
