### PR TITLE
🌱 (FE, workflow) リンターとフォーマッターとして biome の導入

### DIFF
--- a/.github/workflows/frontend_code_check.yml
+++ b/.github/workflows/frontend_code_check.yml
@@ -1,0 +1,24 @@
+name: Frontend Code Check
+
+on:
+  push:
+    branches: [main, dev]
+  pull_request:
+    paths:
+      - 'frontend/pong/**'
+      - '.github/workflows/frontend_code_check.yml'
+
+
+jobs:
+  frontend-code-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Biome
+        uses: biomejs/setup-biome@v2
+        with:
+          version: 1.9.4
+      - name: Run Biome
+        run: biome ci .
+        working-directory: frontend/pong

--- a/frontend/pong/biome.json
+++ b/frontend/pong/biome.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "./node_modules/@biomejs/biome/configuration_schema.json",
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
+  "files": {
+    "ignore": []
+  },
+  "organizeImports": {
+    "enabled": true
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space"
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true
+    }
+  }
+}

--- a/frontend/pong/package-lock.json
+++ b/frontend/pong/package-lock.json
@@ -9,8 +9,173 @@
       "version": "0.0.0",
       "license": "MIT",
       "devDependencies": {
+        "@biomejs/biome": "1.9.4",
         "rimraf": "^6.0.1",
         "vite": "^5.4.10"
+      }
+    },
+    "node_modules/@biomejs/biome": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-1.9.4.tgz",
+      "integrity": "sha512-1rkd7G70+o9KkTn5KLmDYXihGoTaIGO9PIIN2ZB7UJxFrWw04CZHPYiMRjYsaDvVV7hP1dYNRLxSANLaBFGpog==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT OR Apache-2.0",
+      "bin": {
+        "biome": "bin/biome"
+      },
+      "engines": {
+        "node": ">=14.21.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/biome"
+      },
+      "optionalDependencies": {
+        "@biomejs/cli-darwin-arm64": "1.9.4",
+        "@biomejs/cli-darwin-x64": "1.9.4",
+        "@biomejs/cli-linux-arm64": "1.9.4",
+        "@biomejs/cli-linux-arm64-musl": "1.9.4",
+        "@biomejs/cli-linux-x64": "1.9.4",
+        "@biomejs/cli-linux-x64-musl": "1.9.4",
+        "@biomejs/cli-win32-arm64": "1.9.4",
+        "@biomejs/cli-win32-x64": "1.9.4"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-arm64": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-1.9.4.tgz",
+      "integrity": "sha512-bFBsPWrNvkdKrNCYeAp+xo2HecOGPAy9WyNyB/jKnnedgzl4W4Hb9ZMzYNbf8dMCGmUdSavlYHiR01QaYR58cw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-x64": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-1.9.4.tgz",
+      "integrity": "sha512-ngYBh/+bEedqkSevPVhLP4QfVPCpb+4BBe2p7Xs32dBgs7rh9nY2AIYUL6BgLw1JVXV8GlpKmb/hNiuIxfPfZg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-1.9.4.tgz",
+      "integrity": "sha512-fJIW0+LYujdjUgJJuwesP4EjIBl/N/TcOX3IvIHJQNsAqvV2CHIogsmA94BPG6jZATS4Hi+xv4SkBBQSt1N4/g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64-musl": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-1.9.4.tgz",
+      "integrity": "sha512-v665Ct9WCRjGa8+kTr0CzApU0+XXtRgwmzIf1SeKSGAv+2scAlW6JR5PMFo6FzqqZ64Po79cKODKf3/AAmECqA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-1.9.4.tgz",
+      "integrity": "sha512-lRCJv/Vi3Vlwmbd6K+oQ0KhLHMAysN8lXoCI7XeHlxaajk06u7G+UsFSO01NAs5iYuWKmVZjmiOzJ0OJmGsMwg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64-musl": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-1.9.4.tgz",
+      "integrity": "sha512-gEhi/jSBhZ2m6wjV530Yy8+fNqG8PAinM3oV7CyO+6c3CEh16Eizm21uHVsyVBEB6RIM8JHIl6AGYCv6Q6Q9Tg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-arm64": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-1.9.4.tgz",
+      "integrity": "sha512-tlbhLk+WXZmgwoIKwHIHEBZUwxml7bRJgk0X2sPyNR3S93cdRq6XulAZRQJ17FYGGzWne0fgrXBKpl7l4M87Hg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-x64": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-1.9.4.tgz",
+      "integrity": "sha512-8Y5wMhVIPaWe6jw2H+KlEm4wP/f7EW3810ZLmDlrEEy5KvBsb9ECEfu/kMWD484ijfQ8+nIi0giMgu9g1UAuuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/frontend/pong/package.json
+++ b/frontend/pong/package.json
@@ -13,6 +13,7 @@
     "clean": "rimraf ./dist"
   },
   "devDependencies": {
+    "@biomejs/biome": "1.9.4",
     "rimraf": "^6.0.1",
     "vite": "^5.4.10"
   }

--- a/frontend/pong/package.json
+++ b/frontend/pong/package.json
@@ -10,6 +10,9 @@
     "prebuild": "npm run clean",
     "build": "vite build",
     "preview": "vite preview",
+    "format": "biome format --write",
+    "lint:check": "biome lint",
+    "check": "biome check",
     "clean": "rimraf ./dist"
   },
   "devDependencies": {


### PR DESCRIPTION
## タスクやディスカッションのリンク
- #74 

## やったこと
- リンターとフォーマッターとして、biome[^biome] を導入
- 役に立ちそうな npm scripts を追加
  - ```format```
  - ```lint:check```
  - ```check```
- コードチェック用の workflow 作成 

## やらないこと
- リンターやフォーマッターの具体的なオプションはほぼ設定していません。

## 動作確認
- ```frontend/pong``` に移動後、```npm install``` で必要なパッケージを全てインストール
- ```npm run``` で ```format```, ```lint:check```, ```check``` を確認
  - ```format``` は修正してくれると思いますが、
  - ```lint:check``` はチェックのみです。もし何かあった場合は、手動で対応すれば良いのかな、と思って強制的に修正する script は追加していないです。
  - ```check``` は ```biome check```[^biome-cli-check] に記載があるように、フォーマッター、リンター、import の整列が走ります。
- ```npx biome check```, ```npx biome ci``` など、biome cli[^biome-cli] を参考に他のコマンドも必要に応じてテスト可能

## 特にレビューをお願いしたい箇所
- リンターやフォーマッターの設定のところで、やっておいたほうが良いよ、など何かあればぜひお願いします。
- workflow はコミットにも残していますが、biome 公式ページのものをそのまま利用し、トリガーは次で定めました。このフィルタリングで良いか確認いただければ幸いです。
  - push では、main, dev に向けての push のみ
  - pull request では、frontend/pong の中の更新があった場合のみ

## その他
- なし

## 参考リンク
- https://biomejs.dev/reference/configuration/#vcsenabled
- https://biomejs.dev/ja/recipes/continuous-integration/#github-actions

[^biome]: https://biomejs.dev/ja/
[^biome-cli]: https://biomejs.dev/ja/reference/cli/#biome
[^biome-cli-check]: https://biomejs.dev/ja/reference/cli/#biome-check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- 新しいGitHub Actionsワークフロー `frontend_code_check.yml` が追加され、コードチェックが自動化されました。
	- `biome.json` 設定ファイルが追加され、開発環境の構成が整備されました。
	- `package.json` に新しいスクリプト（フォーマット、リント、チェック）が追加され、開発ツールが強化されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->