### PR TITLE
:seedling: (workflow) FE ユニットテストの追加

### DIFF
--- a/.github/workflows/frontend_unit_test.yml
+++ b/.github/workflows/frontend_unit_test.yml
@@ -1,0 +1,39 @@
+name: Frontend Unit Test
+
+on:
+  push:
+    branches: [main, dev]
+  pull_request:
+    paths:
+      - 'frontend/pong/**.js'
+      - '.github/workflows/frontend_unit_test.yml'
+      - 'frontend/pong/package.json'
+      - 'frontend/pong/package-lock.json'
+
+jobs:
+  frontend-unit-test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend/pong
+
+    strategy:
+      matrix:
+        node-version: [22.x]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
+          cache-dependency-path: 'frontend/pong/package-lock.json'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm run test:unit


### PR DESCRIPTION
## タスクやディスカッションのリンク
- #74 #88 

## やったこと
- FE ユニットテスト workflow の追加

## やらないこと
- 特になし

## 動作確認
- 特になし
- #86 , gitlab mr !3 で導入済み

## 特にレビューをお願いしたい箇所
- なし

## その他
- 移行のタイミングの問題で、この workflow だけ復活ができなかったですので、今ファイルのみで PR を作成しました。

## 参考リンク
- 内容に関しては、#86 , gitlab mr !3 を参考にしていただければと思います。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - フロントエンドのユニットテストを自動化する新しいGitHub Actionsワークフロー `frontend_unit_test.yml` を追加しました。
  
この変更により、コードのプッシュやプルリクエスト時にユニットテストが自動的に実行され、継続的インテグレーションが強化されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->