### PR TITLE
🌱 backend_unit_test.yml 追加。BE unit-test が actions で走るように DB コンテナの設定を追加したものにする

### DIFF
--- a/.github/workflows/backend_unit_test.yml
+++ b/.github/workflows/backend_unit_test.yml
@@ -16,3 +16,16 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      # GitHubリポジトリの設定で定義した変数を.envファイルに書き込む
+      - name: Create .env file
+        run: |
+          echo "FRONT_SERVER_PORT=${{ vars.FRONT_SERVER_PORT }}" >> .env
+          echo "BACKEND_SERVER_PORT=${{ vars.BACKEND_SERVER_PORT }}" >> .env
+          echo "SECRET_KEY=${{ secrets.SECRET_KEY }}" >> .env
+          echo "SUPERUSER_NAME=${{ secrets.SUPERUSER_NAME }}" >> .env
+          echo "SUPERUSER_EMAIL=${{ secrets.SUPERUSER_EMAIL }}" >> .env
+          echo "SUPERUSER_PASSWORD=${{ secrets.SUPERUSER_PASSWORD }}" >> .env
+          echo "DB_NAME=${{ secrets.DB_NAME }}" >> .env
+          echo "DB_USER=${{ secrets.DB_USER }}" >> .env
+          echo "DB_PASSWORD=${{ secrets.DB_PASSWORD }}" >> .env

--- a/.github/workflows/backend_unit_test.yml
+++ b/.github/workflows/backend_unit_test.yml
@@ -20,15 +20,15 @@ jobs:
       # GitHubリポジトリの設定で定義した変数を.envファイルに書き込む
       - name: Create .env file
         run: |
-          echo "FRONT_SERVER_PORT=${{ vars.FRONT_SERVER_PORT }}" >> .env
-          echo "BACKEND_SERVER_PORT=${{ vars.BACKEND_SERVER_PORT }}" >> .env
-          echo "SECRET_KEY=${{ secrets.SECRET_KEY }}" >> .env
-          echo "SUPERUSER_NAME=${{ secrets.SUPERUSER_NAME }}" >> .env
-          echo "SUPERUSER_EMAIL=${{ secrets.SUPERUSER_EMAIL }}" >> .env
-          echo "SUPERUSER_PASSWORD=${{ secrets.SUPERUSER_PASSWORD }}" >> .env
-          echo "DB_NAME=${{ secrets.DB_NAME }}" >> .env
-          echo "DB_USER=${{ secrets.DB_USER }}" >> .env
-          echo "DB_PASSWORD=${{ secrets.DB_PASSWORD }}" >> .env
+          echo "FRONT_SERVER_PORT=\"${{ vars.FRONT_SERVER_PORT }}\"" >> .env
+          echo "BACKEND_SERVER_PORT=\"${{ vars.BACKEND_SERVER_PORT }}\"" >> .env
+          echo "SECRET_KEY=\"${{ secrets.SECRET_KEY }}\"" >> .env
+          echo "SUPERUSER_NAME=\"${{ secrets.SUPERUSER_NAME }}\"" >> .env
+          echo "SUPERUSER_EMAIL=\"${{ secrets.SUPERUSER_EMAIL }}\"" >> .env
+          echo "SUPERUSER_PASSWORD=\"${{ secrets.SUPERUSER_PASSWORD }}\"" >> .env
+          echo "DB_NAME=\"${{ secrets.DB_NAME }}\"" >> .env
+          echo "DB_USER=\"${{ secrets.DB_USER }}\"" >> .env
+          echo "DB_PASSWORD=\"${{ secrets.DB_PASSWORD }}\"" >> .env
 
       # backendコンテナのunit-testがDBコンテナに依存しているため、DBコンテナを先に起動する
       - name: Set up db container with docker compose

--- a/.github/workflows/backend_unit_test.yml
+++ b/.github/workflows/backend_unit_test.yml
@@ -29,3 +29,35 @@ jobs:
           echo "DB_NAME=${{ secrets.DB_NAME }}" >> .env
           echo "DB_USER=${{ secrets.DB_USER }}" >> .env
           echo "DB_PASSWORD=${{ secrets.DB_PASSWORD }}" >> .env
+
+      # backendコンテナのunit-testがDBコンテナに依存しているため、DBコンテナを先に起動する
+      - name: Set up db container with docker compose
+        run: |
+          docker compose -f compose.yaml up -d db
+
+      # DBコンテナが起動するまで一定時間待機する
+      - name: Wait for db service to be ready
+        run: |
+          timeout=30
+          until docker compose -f compose.yaml exec -T db pg_isready -U user || [ $timeout -le 0 ]; do
+            echo "Waiting for database... ($timeout seconds left)"
+            sleep 1
+            timeout=$((timeout-1))
+          done
+          if [ $timeout -le 0 ]; then
+            echo "Database failed to start"
+            exit 1
+          fi
+
+      # backendコンテナを起動する
+      - name: Set up backend container with docker compose
+        run: |
+          docker compose -f compose.yaml up -d backend
+
+      # backendのunit-testを実行
+      - name: Run Backend Unit Test
+        run: docker compose -f compose.yaml exec -T backend make unit-test
+
+      # docker composeを停止してクリーンアップする
+      - name: Tear down docker compose
+        run: docker compose -f compose.yaml down

--- a/.github/workflows/backend_unit_test.yml
+++ b/.github/workflows/backend_unit_test.yml
@@ -35,6 +35,10 @@ jobs:
         run: |
           docker compose -f compose.yaml up -d db
 
+      # DBコンテナのログを確認する
+      - name: Check db container logs
+        run: docker compose -f compose.yaml logs db
+
       # DBコンテナが起動するまで一定時間待機する
       - name: Wait for db service to be ready
         run: |
@@ -53,6 +57,10 @@ jobs:
       - name: Set up backend container with docker compose
         run: |
           docker compose -f compose.yaml up -d backend
+
+      # backendコンテナのログを確認する
+      - name: Check backend container logs
+        run: docker compose -f compose.yaml logs backend
 
       # backendのunit-testを実行
       - name: Run Backend Unit Test

--- a/.github/workflows/backend_unit_test.yml
+++ b/.github/workflows/backend_unit_test.yml
@@ -20,15 +20,17 @@ jobs:
       # GitHubリポジトリの設定で定義した変数を.envファイルに書き込む
       - name: Create .env file
         run: |
-          echo "FRONT_SERVER_PORT=\"${{ vars.FRONT_SERVER_PORT }}\"" >> .env
-          echo "BACKEND_SERVER_PORT=\"${{ vars.BACKEND_SERVER_PORT }}\"" >> .env
-          echo "SECRET_KEY=\"${{ secrets.SECRET_KEY }}\"" >> .env
-          echo "SUPERUSER_NAME=\"${{ secrets.SUPERUSER_NAME }}\"" >> .env
-          echo "SUPERUSER_EMAIL=\"${{ secrets.SUPERUSER_EMAIL }}\"" >> .env
-          echo "SUPERUSER_PASSWORD=\"${{ secrets.SUPERUSER_PASSWORD }}\"" >> .env
-          echo "DB_NAME=\"${{ secrets.DB_NAME }}\"" >> .env
-          echo "DB_USER=\"${{ secrets.DB_USER }}\"" >> .env
-          echo "DB_PASSWORD=\"${{ secrets.DB_PASSWORD }}\"" >> .env
+          cat <<-EOF > .env
+            FRONT_SERVER_PORT="${{ vars.FRONT_SERVER_PORT }}"
+            BACKEND_SERVER_PORT="${{ vars.BACKEND_SERVER_PORT }}"
+            SECRET_KEY="${{ secrets.SECRET_KEY }}"
+            SUPERUSER_NAME="${{ secrets.SUPERUSER_NAME }}"
+            SUPERUSER_EMAIL="${{ secrets.SUPERUSER_EMAIL }}"
+            SUPERUSER_PASSWORD="${{ secrets.SUPERUSER_PASSWORD }}"
+            DB_NAME="${{ secrets.DB_NAME }}"
+            DB_USER="${{ secrets.DB_USER }}"
+            DB_PASSWORD="${{ secrets.DB_PASSWORD }}"
+          EOF
 
       # backendコンテナのunit-testがDBコンテナに依存しているため、DBコンテナを先に起動する
       - name: Set up db container with docker compose

--- a/.github/workflows/backend_unit_test.yml
+++ b/.github/workflows/backend_unit_test.yml
@@ -1,0 +1,18 @@
+name: Backend Unit Test
+
+on:
+  pull_request:
+    paths:
+      - 'backend/pong/**'
+      - '.github/workflows/backend_unit_test.yml'
+
+jobs:
+  backend-unit-test:
+    runs-on: ubuntu-latest
+    services:
+      docker:
+        image: docker:19.03.12
+        options: --privileged
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4

--- a/.github/workflows/backend_unit_test.yml
+++ b/.github/workflows/backend_unit_test.yml
@@ -69,3 +69,8 @@ jobs:
       # docker composeを停止してクリーンアップする
       - name: Tear down docker compose
         run: docker compose -f compose.yaml down
+
+      # .envファイルを削除
+      - name: Cleanup sensitive file
+        if: always()
+        run: rm -f .env

--- a/backend/tools/entrypoint.sh
+++ b/backend/tools/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # エラーが発生した場合にスクリプトの実行を停止する
-set -e
+set -eux
 
 migrate_db() {
     # todo: makemigrationsなど


### PR DESCRIPTION
## タスクやディスカッションのリンク
- #92 

## やったこと
- backend の `make unit-test` を github actions で動かせるようにしました
- backend コンテナ内の unit test を正常に動かすためには、db コンテナが起動している必要があるため、actions 用の yml で `docker compose` を使って 2 つのコンテナを順に起動しています
- コンテナ起動時に `.env` を使用するが actions 内には `.env` は存在しないため、gitlab の時と同じような方法で以下の Settings に環境変数を設定し、使用しています
-> [Settings -> Actions secrets and variables の secrets, variables](https://github.com/42-pong/42-pong/settings/secrets/actions)
  - secrets : 機密性のあるもの
  - variables : 機密性のないもの

## やらないこと
- docker buildx などを使うと actions 内で image をキャッシュできたりするようですが、キャッシュする必要が出てきたらすれば良いかと思い、していません (多分今後もしなさそう)

## 動作確認
PR 作成段階でしたことを書いておきます
- yml に指定した `paths` に変更があった場合に、actions が走る
- 環境変数 (試せたのは `DB_PASSWORD`) が空の場合に db コンテナの起動に失敗する
- db コンテナの起動に失敗すると actions が落ちる
- actions のログで `docker logs` の結果が見れらる

## 特にレビューをお願いしたい箇所
- unit-test の actions が走るトリガーはこれで良いか
- `compose.yaml` を使って 2 つのコンテナを起動してテストしているが、この方法で良いかどうか

## その他
- backend コンテナと db コンテナを同時に立ち上げる (`docker compose -f compose.yaml up -d db backend`) ことをしなかったのは、エラー時にどちらのコンテナのエラーなのか分かりづらいため

## 参考リンク
- [GitHub Actions でのシークレットの使用](https://docs.github.com/ja/actions/security-for-github-actions/security-guides/using-secrets-in-github-actions)
- [docker docs: github actions: always()](https://docs.github.com/ja/actions/writing-workflows/choosing-what-your-workflow-does/evaluate-expressions-in-workflows-and-actions#always)
- [GitHub Actions で機密性の無い変数を設定できるようになったので試してみる](https://zenn.dev/kou_pg_0131/articles/gh-actions-configurations-variables)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **新機能**
  - 新しいGitHub Actionsワークフロー`backend_unit_test.yml`を追加し、バックエンドユニットテストの自動化を実現。

- **改善**
  - `entrypoint.sh`スクリプトのエラーハンドリングを強化し、環境変数のチェックを厳密に行うように変更。スーパーユーザー作成時のフィードバックを改善。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->