### PR TITLE
⚡  Djagno の version を上げて問題ないか確認してから上げる (Dependabot alerts)

### DIFF
--- a/backend/tools/requirements.in
+++ b/backend/tools/requirements.in
@@ -1,4 +1,4 @@
-django==5.1.2
+django==5.1.4
 django-stubs
 ruff==0.7.3
 mypy==1.13.0

--- a/backend/tools/requirements.txt
+++ b/backend/tools/requirements.txt
@@ -20,7 +20,7 @@ charset-normalizer==3.4.0
     # via requests
 cryptography==44.0.0
     # via djangorestframework-simplejwt
-django==5.1.2
+django==5.1.4
     # via
     #   -r requirements.in
     #   django-stubs
@@ -76,7 +76,7 @@ referencing==0.35.1
     #   jsonschema-specifications
 requests==2.32.3
     # via djangorestframework-stubs
-rpds-py==0.21.0
+rpds-py==0.22.3
     # via
     #   jsonschema
     #   referencing


### PR DESCRIPTION
## タスクやディスカッションのリンク
- #98 

## やったこと
[github の dependabot](https://github.com/42-pong/42-pong/security/dependabot/3) が Django のバージョンについて古いとアラートを出してくれたので、バージョンを上げても動作するか確認の上、バージョンを上げました (Django 5.1.2 -> Django 5.1.4)

## やらないこと
- 特になし

## 動作確認
- バージョン確認
```sh
make build-up
make exec-be
python -m django --version 
# 5.1.4
```
- 新しいバージョンで backend が今まで通り動くか確認
  - ブラウザで swagger-ui, admin サイトを見る
  - BE コンテナ内で型チェック・unit test
  ```sh
  make check
  make unit-test
  ```

もし `5.1.2` のまま変わっていなさそうであれば、backend の docker image を消してから再度 `make build-up` すると大丈夫かもです

## 特にレビューをお願いしたい箇所
- 各自の環境でも Django 5.1.4 になり、今まで通り動作するかどうか

## その他
- 特になし

## 参考リンク
- [Django releases 5.1.4](https://docs.djangoproject.com/ja/5.1/releases/5.1.4/)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- Djangoパッケージのバージョンを5.1.2から5.1.4に更新しました。
	- rpds-pyパッケージのバージョンを0.21.0から0.22.3に更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->