### PR TITLE
♻️  jwtとswagger-uiのurlsをimportなしのincludeで統一する

### DIFF
--- a/backend/pong/pong/settings.py
+++ b/backend/pong/pong/settings.py
@@ -147,7 +147,7 @@ STATIC_URL = "static/"
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
 
-# drf_spectacular for Swagger UI
+# Django REST framework
 # https://drf-spectacular.readthedocs.io/en/latest/readme.html
 
 REST_FRAMEWORK = {

--- a/backend/pong/pong/urls.py
+++ b/backend/pong/pong/urls.py
@@ -17,19 +17,13 @@ Including another URLconf
 
 from django.contrib import admin
 from django.urls import include, path
-from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
 
 from .health_check.views import health_check
 
 urlpatterns = [
     path("admin/", admin.site.urls),
     # swagger-ui
-    path("api/schema/", SpectacularAPIView.as_view(), name="schema"),
-    path(
-        "api/schema/swagger-ui/",
-        SpectacularSwaggerView.as_view(url_name="schema"),
-        name="swagger-ui",
-    ),
+    path("api/schema/", include("swagger_ui.urls")),
     # health check
     path("api/health/", health_check, name="health-check"),
     # jwt_token

--- a/backend/pong/pong/urls.py
+++ b/backend/pong/pong/urls.py
@@ -19,8 +19,6 @@ from django.contrib import admin
 from django.urls import include, path
 from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
 
-import jwt_token.urls as jwt_urls
-
 from .health_check.views import health_check
 
 urlpatterns = [
@@ -35,5 +33,5 @@ urlpatterns = [
     # health check
     path("api/health/", health_check, name="health-check"),
     # jwt_token
-    path("api/token/", include(jwt_urls)),
+    path("api/token/", include("jwt_token.urls")),
 ]

--- a/backend/pong/swagger_ui/urls.py
+++ b/backend/pong/swagger_ui/urls.py
@@ -1,0 +1,12 @@
+from django.urls import path
+from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
+
+urlpatterns = [
+    # 'api/schema/'
+    path("", SpectacularAPIView.as_view(), name="schema"),
+    path(
+        "swagger-ui/",
+        SpectacularSwaggerView.as_view(url_name="schema"),
+        name="swagger-ui",
+    ),
+]


### PR DESCRIPTION
## タスクやディスカッションのリンク
- #108 

## やったこと
別の PR 作成時に気付いたリファクタのみです
[チュートリアルのこのリンクの少し下](https://docs.djangoproject.com/ja/5.1/intro/tutorial01/#id3) に以下のように書いてあったので、2 点更新して統一しました

> [include()](https://docs.djangoproject.com/ja/5.1/ref/urls/#django.urls.include) を使うとき
> You should always use include() when you include other URL patterns. The only exception is admin.site.urls, which is a pre-built URLconf provided by Django for the default admin site.

- `swagger-ui` が `include()` を使っていなかったので使うように更新
- `include()` は自動で動的に検索してくれるもので import が不要だったため、`jwt_token` の import を削除


## やらないこと
- 特になし

## 動作確認
- 変わらず swagger-ui が見れるか・使えるか

## 特にレビューをお願いしたい箇所
- 特に挙動に問題ないかどうか

## その他
- 特になし

## 参考リンク
- [他の URLconfs をインクルードする](https://docs.djangoproject.com/ja/5.1/topics/http/urls/#including-other-urlconfs)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- Swagger UIの統合に関するURL設定が更新され、APIドキュメントの生成と表示が容易になりました。
	- 新しいURLパターンが追加され、APIスキーマとSwagger UIにアクセスできるようになりました。

- **ドキュメンテーション**
	- Django RESTフレームワークに関連する設定のコメントが明確化されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->