### PR TITLE
:bug: (workflow) discord 通知の改善

### DIFF
--- a/.github/workflows/discord_PR_review.yml
+++ b/.github/workflows/discord_PR_review.yml
@@ -35,13 +35,13 @@ jobs:
           PR_USER_LOGIN='${{ github.event.pull_request.user.login }}'
           PR_USER_URL='${{ github.event.pull_request.user.html_url }}'
           PR_USER_AVATAR_URL='${{ github.event.pull_request.user.avatar_url }}'
-          PR_USER_INFO="$(echo '${{ vars.MEMBERS }}' | jq -r .\"${PR_USER_LOGIN}\")"
+          PR_USER_INFO="$(echo '${{ secrets.MEMBERS }}' | jq -r .\"${PR_USER_LOGIN}\")"
           PR_USER_INTRA="$(echo "${PR_USER_INFO}" | jq -r .\"intra\")"
           PR_USER_COLOR="$(echo "${PR_USER_INFO}" | jq -r .\"color\")"
 
           # REVIEWER
           REVIEWER_LOGIN="${{ github.event.requested_reviewer.login }}"
-          REVIEWER_DISCORD_ID="$(echo '${{ vars.MEMBERS }}' | jq -r .\"${REVIEWER_LOGIN}\".\"discord_id\")"
+          REVIEWER_DISCORD_ID="$(echo '${{ secrets.MEMBERS }}' | jq -r .\"${REVIEWER_LOGIN}\".\"discord_id\")"
 
           # random emoji
           RANDOM_EMOJI="$(echo_one_random_element '${{ vars.EMOJI_SET }}')"

--- a/.github/workflows/discord_PR_review.yml
+++ b/.github/workflows/discord_PR_review.yml
@@ -1,4 +1,4 @@
-name: 'Discord Notification: Pull Rquest: review requested'
+name: 'Discord Notification: Pull Request: review requested'
 on:
   pull_request:
     types: [review_requested]

--- a/.github/workflows/discord_PR_review.yml
+++ b/.github/workflows/discord_PR_review.yml
@@ -8,6 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: post message via discord-webhook-url
+        if: ${{ github.event.requested_reviewer.login != '' }}
         run: |
           # echo one random element from the first input argument
           # - the first input argument should be space-separated string

--- a/.github/workflows/discord_discussion.yml
+++ b/.github/workflows/discord_discussion.yml
@@ -58,7 +58,7 @@ jobs:
           DISCUSSION_USER_LOGIN='${{ github.event.discussion.user.login }}'
           DISCUSSION_USER_URL='${{ github.event.discussion.user.html_url }}'
           DISCUSSION_USER_AVATAR_URL='${{ github.event.discussion.user.avatar_url }}'
-          DISCUSSION_USER_INFO="$(echo '${{ vars.MEMBERS }}' | jq -r .\"${DISCUSSION_USER_LOGIN}\")"
+          DISCUSSION_USER_INFO="$(echo '${{ secrets.MEMBERS }}' | jq -r .\"${DISCUSSION_USER_LOGIN}\")"
           DISCUSSION_USER_COLOR="$(echo "${DISCUSSION_USER_INFO}" | jq -r .\"color\")"
 
           # random adjective


### PR DESCRIPTION
## タスクやディスカッションのリンク
- #118 

## やったこと
- #118 より

> - [x] PR のレビュワーがチームでなく、ユーザだった場合のみ、通知されるように修正
> - [x] 誤字修正: Rquest -> Request
> - [x] MEMBERS を vars -> secrets に移行

## やらないこと
- 特になし

## 動作確認
- PR レビュワー通知は、この PR でレビュワーを選択してテスト

## 特にレビューをお願いしたい箇所
- 他の誤字や改善できるところありましたら、ここで対応したいと思います。

## その他
- 特になし

## 参考リンク
- https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#pull_request
- https://docs.github.com/en/webhooks/webhook-events-and-payloads?actionType=review_requested#pull_request
- https://stackoverflow.com/questions/75180202/is-there-a-way-to-run-workflow-when-pr-review-is-requested-from-a-specific-user


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - Discord通知ワークフローの名称を明確に変更しました。
  - ディスカッション作成時の通知に関する変数をより安全な秘密情報に変更しました。

- **バグ修正**
  - 条件文を追加し、レビュアーが指定されている場合のみ通知を送信するようにしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->