### PR TITLE
♻️ Django / app に名前空間を付与

### DIFF
--- a/backend/pong/accounts/urls.py
+++ b/backend/pong/accounts/urls.py
@@ -1,7 +1,10 @@
+from typing import Final
+
 from django.urls import path
 
 from .views import AccountCreateView
 
+app_name: Final[str] = "accounts"
 urlpatterns = [
     # api/accounts/
     path("", AccountCreateView.as_view(), name="accounts")

--- a/backend/pong/accounts/urls.py
+++ b/backend/pong/accounts/urls.py
@@ -7,5 +7,5 @@ from .views import AccountCreateView
 app_name: Final[str] = "accounts"
 urlpatterns = [
     # api/accounts/
-    path("", AccountCreateView.as_view(), name="accounts")
+    path("", AccountCreateView.as_view(), name="account_create")
 ]

--- a/backend/pong/jwt_token/urls.py
+++ b/backend/pong/jwt_token/urls.py
@@ -1,3 +1,5 @@
+from typing import Final
+
 from django.urls import path
 from rest_framework_simplejwt.views import (
     TokenObtainPairView,
@@ -5,6 +7,7 @@ from rest_framework_simplejwt.views import (
     TokenVerifyView,
 )
 
+app_name: Final[str] = "jwt_token"
 urlpatterns = [
     # 'api/token/'
     path("", TokenObtainPairView.as_view(), name="token_obtain_pair"),

--- a/backend/pong/oauth2/urls.py
+++ b/backend/pong/oauth2/urls.py
@@ -1,7 +1,10 @@
+from typing import Final
+
 from django.urls import path
 
 from .views import oauth2_authorize, oauth2_callback
 
+app_name: Final[str] = "oauth2"
 urlpatterns = [
     # 'api/oauth2/'
     path("authorize/", oauth2_authorize, name="oauth2_authorize"),

--- a/backend/pong/oauth2/views.py
+++ b/backend/pong/oauth2/views.py
@@ -32,7 +32,7 @@ def oauth2_authorize(request: Request) -> Response:
 
     query_params = {
         "client_id": OAUTH2_CLIENT_ID,
-        "redirect_uri": PONG_ORIGIN + reverse("oauth2_callback"),
+        "redirect_uri": PONG_ORIGIN + reverse("oauth2:oauth2_callback"),
         "response_type": "code",
         # todo: csrf対策の為にstate追加するかも
     }
@@ -64,7 +64,7 @@ def oauth2_callback(request: Request) -> Response:
     request_data = {
         "code": code,
         "grant_type": "authorization_code",
-        "redirect_uri": PONG_ORIGIN + reverse("oauth2_callback"),
+        "redirect_uri": PONG_ORIGIN + reverse("oauth2:oauth2_callback"),
         "client_id": OAUTH2_CLIENT_ID,
         "client_secret": OAUTH2_CLIENT_SECRET_KEY,
     }
@@ -78,7 +78,7 @@ def oauth2_callback(request: Request) -> Response:
     # return Response({"message": "Home page"}, status=200, headers={"Host": app_home_url})
     return Response(
         {
-            f"Callback: {PONG_ORIGIN + reverse("oauth2_callback")}, Token: {tokens}"
+            f"Callback: {PONG_ORIGIN + reverse("oauth2:oauth2_callback")}, Token: {tokens}"
         },
         status=200,
     )

--- a/backend/pong/pong/health_check/tests.py
+++ b/backend/pong/pong/health_check/tests.py
@@ -1,4 +1,5 @@
 from django.test import TestCase
+from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.test import APIRequestFactory
@@ -16,5 +17,5 @@ class HealthCheckUnitTests(TestCase):
         request: Request = factory.get("/health/")
         response: Response = health_check(request)
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data, {"status": "OK"})

--- a/backend/pong/pong/urls.py
+++ b/backend/pong/pong/urls.py
@@ -25,7 +25,7 @@ urlpatterns = [
     # swagger-ui
     path("api/schema/", include("swagger_ui.urls")),
     # health check
-    path("api/health/", health_check, name="health-check"),
+    path("api/health/", health_check, name="health_check"),
     # jwt_token
     path("api/token/", include("jwt_token.urls")),
     # oauth2


### PR DESCRIPTION
## タスクやディスカッションのリンク
- #121 

## やったこと
- URL を逆引きする際にもし名前衝突があっても問題ないように、アプリに名前空間 (`app_name`) を付与しました
使い方 : `url: str = reverse("app_name:name")`
- 今まで衝突しないように既存の `name` に prefix のようなものをつけていたと思うのですが、`app_name` の方が django っぽいと思ったので取り入れてみました
`app_name` と `name` で重複しているのが気になる場合は、各自適当なタイミングでよりシンプルな `name` に変えていただければと思います🙏
(この PR で一緒に変更するのが良ければ一緒でも大丈夫です！)
- ついでにテスト・命名の小さなリファクタ

## やらないこと
- `jwt_token`, `oauth2` の `name` の変更

## 動作確認
- 特に挙動に変更はなし
```sh
make build-up
make exec-be
make check
make unit-test
```

## 特にレビューをお願いしたい箇所
- `app_name` を取り入れたことについて何かあれば

## その他
- @s1-haya `oauth2` ではまたコンフリクト起こしそうな変更で申し訳ないです。後から merge する側がコンフリクト解消時に合わせるので良いと思います！

## 参考リンク
- [URL の名前空間](https://docs.djangoproject.com/ja/5.1/topics/http/urls/#url-namespaces)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- アカウント作成用のURLパターン名を「account_create」に変更。
	- 各アプリケーションの名前を明示的に定義するための新しい定数を追加（accounts、jwt_token、oauth2）。
	- OAuth2コールバックのリダイレクトURIを名前付きURLパターンに更新。

- **バグ修正**
	- 健康チェックエンドポイントのURLパターン名を「health_check」に変更。

- **テスト**
	- テスト内のHTTPステータスコードのアサーションを定数を使用するように更新。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->