### PR TITLE
⚡  [workflow] job の timeout 設定追加, Makefile 微修正

### DIFF
--- a/.github/workflows/backend_code_check.yml
+++ b/.github/workflows/backend_code_check.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   backend-code-check:
     runs-on: ubuntu-latest  # GitHub Actionsで使用する環境
+    timeout-minutes: 30
     # PR元が 'feature/backend/*' のブランチからの場合にトリガー
     if: startsWith(github.head_ref, 'feature-backend')
 

--- a/.github/workflows/backend_unit_test.yml
+++ b/.github/workflows/backend_unit_test.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   backend-unit-test:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     services:
       docker:
         image: docker:19.03.12

--- a/.github/workflows/discord_PR_review.yml
+++ b/.github/workflows/discord_PR_review.yml
@@ -6,6 +6,7 @@ on:
 jobs:
   PR-discord-notification:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: post message via discord-webhook-url
         run: |

--- a/.github/workflows/discord_discussion.yml
+++ b/.github/workflows/discord_discussion.yml
@@ -6,6 +6,7 @@ on:
 jobs:
   discussion-discord-notification:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: post message via discord-webhook-url
         run: |

--- a/.github/workflows/frontend_code_check.yml
+++ b/.github/workflows/frontend_code_check.yml
@@ -12,6 +12,7 @@ on:
 jobs:
   frontend-code-check:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/frontend_unit_test.yml
+++ b/.github/workflows/frontend_unit_test.yml
@@ -13,6 +13,7 @@ on:
 jobs:
   frontend-unit-test:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     defaults:
       run:
         working-directory: frontend/pong

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 # docker compose
 COMPOSE_FILE		:=	compose.yaml
+DOCKER_COMPOSE		:=	docker compose -f $(COMPOSE_FILE)
 
 BACKEND_SERVICE		:=	backend
 DATABASE_SERVICE	:=	db
@@ -13,24 +14,24 @@ all: up
 # -------------------------------------------------------
 .PHONY: up
 up:
-	@docker compose up -d
+	@$(DOCKER_COMPOSE) up -d
 
 # rm container,network
 .PHONY: down
 down:
-	@docker compose down
+	@$(DOCKER_COMPOSE) down
 
 .PHONY: build-up
 build-up:
-	@docker compose up --build -d
+	@$(DOCKER_COMPOSE) up --build -d
 
 .PHONY: start
 start:
-	@docker compose start
+	@$(DOCKER_COMPOSE) start
 
 .PHONY: stop
 stop:
-	@docker compose stop
+	@$(DOCKER_COMPOSE) stop
 
 # -------------------------------------------------------
 # docker ps
@@ -48,19 +49,19 @@ psa:
 # -------------------------------------------------------
 .PHONY: exec-be
 exec-be:
-	@docker compose -f $(COMPOSE_FILE) exec -it $(BACKEND_SERVICE) /bin/bash
+	@$(DOCKER_COMPOSE) exec -it $(BACKEND_SERVICE) /bin/bash
 
 .PHONY: exec-db
 exec-db:
-	@docker compose -f $(COMPOSE_FILE) exec -it $(DATABASE_SERVICE) /bin/bash
+	@$(DOCKER_COMPOSE) exec -it $(DATABASE_SERVICE) /bin/bash
 
 # -------------------------------------------------------
 # docker compose logs
 # -------------------------------------------------------
 .PHONY: logs-be
 logs-be:
-	@docker compose -f $(COMPOSE_FILE) logs $(BACKEND_SERVICE)
+	@$(DOCKER_COMPOSE) logs $(BACKEND_SERVICE)
 
 .PHONY: logs-db
 logs-db:
-	@docker compose -f $(COMPOSE_FILE) logs $(DATABASE_SERVICE)
+	@$(DOCKER_COMPOSE) logs $(DATABASE_SERVICE)

--- a/Makefile
+++ b/Makefile
@@ -48,11 +48,11 @@ psa:
 # -------------------------------------------------------
 .PHONY: exec-be
 exec-be:
-	@docker compose exec -it $(BACKEND_SERVICE) /bin/bash
+	@docker compose -f $(COMPOSE_FILE) exec -it $(BACKEND_SERVICE) /bin/bash
 
 .PHONY: exec-db
 exec-db:
-	@docker compose exec -it $(DATABASE_SERVICE) /bin/bash
+	@docker compose -f $(COMPOSE_FILE) exec -it $(DATABASE_SERVICE) /bin/bash
 
 # -------------------------------------------------------
 # docker compose logs

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
-# image/container
-BACKEND		:=	backend
-DATABASE	:=	postgres
+# docker compose
+COMPOSE_FILE		:=	compose.yaml
+
+BACKEND_SERVICE		:=	backend
+DATABASE_SERVICE	:=	db
+
 
 .PHONY: all
 all: up
@@ -41,23 +44,23 @@ psa:
 	@docker ps -a
 
 # -------------------------------------------------------
-# docker exec
+# docker compose exec
 # -------------------------------------------------------
 .PHONY: exec-be
 exec-be:
-	@docker exec -it $(BACKEND) /bin/bash
+	@docker compose exec -it $(BACKEND_SERVICE) /bin/bash
 
 .PHONY: exec-db
 exec-db:
-	@docker exec -it $(DATABASE) /bin/bash
+	@docker compose exec -it $(DATABASE_SERVICE) /bin/bash
 
 # -------------------------------------------------------
-# docker logs
+# docker compose logs
 # -------------------------------------------------------
 .PHONY: logs-be
 logs-be:
-	@docker logs $(BACKEND)
+	@docker compose -f $(COMPOSE_FILE) logs $(BACKEND_SERVICE)
 
 .PHONY: logs-db
 logs-db:
-	@docker logs $(DATABASE)
+	@docker compose -f $(COMPOSE_FILE) logs $(DATABASE_SERVICE)


### PR DESCRIPTION
## タスクやディスカッションのリンク
- #128 

## やったこと
- workflows
  -  actions で `job` の `timeout` の default が `360 分`らしく長すぎるので、少し短く `30 分` に設定
- Makefile
  - コンテナ名などは `compose.yaml` ファイル依存だったので、Makefile ではなるべく `docker` ではなく `docker compose` コマンドを使うように微修正 (全体に多少関係あったのでついでにこの PR でしてしまいました)


## やらないこと
- `job` の中の各 `steps` に対しても `timeout` を設定できるのですが、特に必要ではないと思い、していません

## 動作確認
- workflows
  -   timeout は実際には試してないので特にないです…
- Makefile
  - 各ルールが今まで通り使えるか
  `docker compose` を使って logs を出力したことにより、色付きで左にコンテナ名も出力されるようになってます…！

## 特にレビューをお願いしたい箇所
- 動作確認と、何か他にあれば何でも

## その他
ちなみに Makefile のルールに追加はしていないのですが、`docker compose -f compose.yaml logs -f` で全てのコンテナの logs をフォアグランドで見られるみたいです
開発時に良いかも

![image](https://github.com/user-attachments/assets/31326aad-bcc6-4707-904f-7a33417d43a6)


## 参考リンク
- [actions / ワークフロー構文 / jobs.<job_id>.timeout-minutes](https://docs.github.com/ja/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes)
- [GitHub Actions にタイムアウトを設定しておいた方が良い](https://qiita.com/chihiro/items/341b579a07fac35fd1d7)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
	- GitHub Actionsの各ワークフローに30分のタイムアウト設定を追加しました。
	- フロントエンドおよびバックエンドのユニットテスト、コードチェック、Discord通知ワークフローが対象です。

- **変更**
	- DockerコマンドからDocker Composeへの移行に伴い、Makefileを更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->