### PR TITLE
♻️ : OAuth2.0のエンドポイントをリファクタリング

### DIFF
--- a/backend/pong/oauth2/urls.py
+++ b/backend/pong/oauth2/urls.py
@@ -2,11 +2,15 @@ from typing import Final
 
 from django.urls import path
 
-from .views import OAuth2AuthorizeView, OAuth2CallbackView
+from . import views
 
 app_name: Final[str] = "oauth2"
 urlpatterns = [
     # 'api/oauth2/'
-    path("authorize/", OAuth2AuthorizeView.as_view(), name="oauth2_authorize"),
-    path("callback/", OAuth2CallbackView.as_view(), name="oauth2_callback"),
+    path(
+        "authorize/",
+        views.OAuth2AuthorizeView.as_view(),
+        name="authorize",
+    ),
+    path("callback/", views.OAuth2CallbackView.as_view(), name="callback"),
 ]

--- a/backend/pong/oauth2/urls.py
+++ b/backend/pong/oauth2/urls.py
@@ -1,9 +1,9 @@
 from django.urls import path
 
-from .views import oauth2_authorize, oauth2_callback
+from .views import OAuth2AuthorizeView, OAuth2CallbackView
 
 urlpatterns = [
     # 'api/oauth2/'
-    path("authorize/", oauth2_authorize, name="oauth2_authorize"),
-    path("callback/", oauth2_callback, name="oauth2_callback"),
+    path("authorize/", OAuth2AuthorizeView.as_view(), name="oauth2_authorize"),
+    path("callback/", OAuth2CallbackView.as_view(), name="oauth2_callback"),
 ]

--- a/backend/pong/oauth2/views.py
+++ b/backend/pong/oauth2/views.py
@@ -3,7 +3,9 @@ from urllib.parse import urlencode
 
 import requests
 from django.urls import reverse
-from rest_framework.decorators import api_view
+# todo: IsAuthenticatedが追加されたらAllowAnyは不要?
+from rest_framework.permissions import AllowAny
+from rest_framework.views import APIView
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -15,70 +17,67 @@ from pong.settings import (
     PONG_ORIGIN,
 )
 
+class OAuth2AuthorizeView(APIView):
+    permission_classes = (AllowAny,)
 
-@api_view(["GET"])
-def oauth2_authorize(request: Request) -> Response:
-    """
-    認可エンドポイントを呼ぶ関数
-    この関数はクライアント(42pong)が認可サーバーの認可エンドポイントにアクセスし、認可コードを取得するために使用する。
-    認可サーバーに接続する際に、redirect_uriを設定する理由は、認可サーバーはクライアントではなくブラウザーにレスポンスを返すため、
-    ブラウザからクライアントにリダイレクトし、認可コードを取得する必要があるため。
+    def get(self, request: Request, *args: tuple, **kwargs: dict) -> Response:
+        """
+        認可エンドポイントを呼ぶ関数
+        この関数はクライアント(42pong)が認可サーバーの認可エンドポイントにアクセスし、認可コードを取得するために使用する。
+        認可サーバーに接続する際に、redirect_uriを設定する理由は、認可サーバーはクライアントではなくブラウザーにレスポンスを返すため、
+        ブラウザからクライアントにリダイレクトし、認可コードを取得する必要があるため。
 
-    認可エンドポイントを呼ぶケース
-    - ユーザーが新規アカウントを作成した時
-    - ユーザーが明示的にログアウトした時(ログアウト時にアクセストークンを削除する場合)
-    - リフレッシュトークンの有効期限が切れた時
-    """
+        認可エンドポイントを呼ぶケース
+        - ユーザーが新規アカウントを作成した時
+        - ユーザーが明示的にログアウトした時(ログアウト時にアクセストークンを削除する場合)
+        - リフレッシュトークンの有効期限が切れた時
+        """
+        query_params = {
+            "client_id": OAUTH2_CLIENT_ID,
+            "redirect_uri": PONG_ORIGIN + reverse("oauth2_callback"),
+            "response_type": "code",
+        }
+        query_string = urlencode(query_params)
 
-    query_params = {
-        "client_id": OAUTH2_CLIENT_ID,
-        "redirect_uri": PONG_ORIGIN + reverse("oauth2_callback"),
-        "response_type": "code",
-        # todo: csrf対策の為にstate追加するかも
-    }
-    query_string = urlencode(query_params)
+        authorization_url = f"{OAUTH2_AUTHORIZATION_ENDPOINT}?{query_string}"
 
-    authorization_url = f"{OAUTH2_AUTHORIZATION_ENDPOINT}?{query_string}"
-
-    return Response(
-        status=302,
-        headers={"Location": authorization_url},
-    )
+        return Response(
+            status=302,
+            headers={"Location": authorization_url},
+        )
 
 
-@api_view(["GET"])
-def oauth2_callback(request: Request) -> Response:
-    """
-    認可サーバーからのレスポンスを受け取る関数
-    この関数は認可サーバーからのレスポンスを受け取り、認可コードを取得するために使用する。
-    """
-    # todo: Result型で定義する？
-    code = request.GET.get("code")
-    if not code:
+class OAuth2CallbackView(APIView):
+    permission_classes = (AllowAny,)
+    def get(self, request: Request, *args: tuple, **kwargs: dict) -> Response:
+        """
+        認可サーバーからのレスポンスを受け取る関数
+        この関数は認可サーバーからのレスポンスを受け取り、認可コードを取得するために使用する。
+        """
+        code = request.GET.get("code")
+        if not code:
+            return Response(
+                {
+                    "error": "Authorization code is None. Please check your authentication process."
+                },
+                status=400,
+            )
+        request_data = {
+            "code": code,
+            "grant_type": "authorization_code",
+            "redirect_uri": PONG_ORIGIN + reverse("oauth2_callback"),
+            "client_id": OAUTH2_CLIENT_ID,
+            "client_secret": OAUTH2_CLIENT_SECRET_KEY,
+        }
+        response = requests.post(
+            OAUTH2_TOKEN_ENDPOINT,
+            data=request_data,
+        )
+        tokens = response.json()
         return Response(
             {
-                "error": "Authorization code is None. Please check your authentication process."
+                "Callback URL": PONG_ORIGIN + reverse("oauth2_callback"),
+                "Token": tokens,
             },
-            status=400,
+            status=200,
         )
-    request_data = {
-        "code": code,
-        "grant_type": "authorization_code",
-        "redirect_uri": PONG_ORIGIN + reverse("oauth2_callback"),
-        "client_id": OAUTH2_CLIENT_ID,
-        "client_secret": OAUTH2_CLIENT_SECRET_KEY,
-    }
-    response = requests.post(
-        OAUTH2_TOKEN_ENDPOINT,
-        data=request_data,
-    )
-    tokens = response.json()
-    # todo アプリケーションのホームURLを設定する(仮)
-    # app_home_url = ""
-    # return Response({"message": "Home page"}, status=200, headers={"Host": app_home_url})
-    return Response(
-        {
-            f"Callback: {PONG_ORIGIN + reverse("oauth2_callback")}, Token: {tokens}"
-        },
-        status=200,
-    )

--- a/backend/pong/oauth2/views.py
+++ b/backend/pong/oauth2/views.py
@@ -155,3 +155,8 @@ class OAuth2CallbackView(OAuth2BaseView):
             },
             status=response.status_code,
         )
+
+# todo: 以下のエンドポイントは後で実装する
+# - oauth2/refresh
+# - oauth2/revoke
+# - oauth2/account

--- a/backend/pong/oauth2/views.py
+++ b/backend/pong/oauth2/views.py
@@ -8,21 +8,15 @@ from drf_spectacular.utils import (
     OpenApiResponse,
     extend_schema,
 )
-from rest_framework import status
 
 # todo: IsAuthenticatedが追加されたらAllowAnyは不要?
+from rest_framework import status
 from rest_framework.permissions import AllowAny
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from pong.settings import (
-    OAUTH2_AUTHORIZATION_ENDPOINT,
-    OAUTH2_CLIENT_ID,
-    OAUTH2_CLIENT_SECRET_KEY,
-    OAUTH2_TOKEN_ENDPOINT,
-    PONG_ORIGIN,
-)
+from pong import settings
 
 
 class OAuth2BaseView(APIView):
@@ -34,7 +28,7 @@ class OAuth2BaseView(APIView):
 
     @property
     def redirect_uri(self) -> str:
-        return PONG_ORIGIN + reverse("oauth2_callback")
+        return settings.PONG_ORIGIN + reverse("oauth2:callback")
 
 
 class OAuth2AuthorizeView(OAuth2BaseView):
@@ -68,14 +62,14 @@ class OAuth2AuthorizeView(OAuth2BaseView):
         - リフレッシュトークンの有効期限が切れた時
         """
         query_params: dict[str, str] = {
-            "client_id": OAUTH2_CLIENT_ID,
+            "client_id": settings.OAUTH2_CLIENT_ID,
             "redirect_uri": self.redirect_uri,
             "response_type": "code",
         }
         query_string: str = urlencode(query_params)
 
         authorization_url: str = (
-            f"{OAUTH2_AUTHORIZATION_ENDPOINT}?{query_string}"
+            f"{settings.OAUTH2_AUTHORIZATION_ENDPOINT}?{query_string}"
         )
 
         return Response(
@@ -153,11 +147,11 @@ class OAuth2CallbackView(OAuth2BaseView):
             "code": code,
             "grant_type": "authorization_code",
             "redirect_uri": self.redirect_uri,
-            "client_id": OAUTH2_CLIENT_ID,
-            "client_secret": OAUTH2_CLIENT_SECRET_KEY,
+            "client_id": settings.OAUTH2_CLIENT_ID,
+            "client_secret": settings.OAUTH2_CLIENT_SECRET_KEY,
         }
         response: requests.models.Response = requests.post(
-            OAUTH2_TOKEN_ENDPOINT,
+            settings.OAUTH2_TOKEN_ENDPOINT,
             data=request_data,
         )
         tokens = response.json()

--- a/backend/pong/oauth2/views.py
+++ b/backend/pong/oauth2/views.py
@@ -8,6 +8,7 @@ from rest_framework.permissions import AllowAny
 from rest_framework.views import APIView
 from rest_framework.request import Request
 from rest_framework.response import Response
+from rest_framework import status
 
 from pong.settings import (
     OAUTH2_AUTHORIZATION_ENDPOINT,
@@ -42,7 +43,7 @@ class OAuth2AuthorizeView(APIView):
         authorization_url = f"{OAUTH2_AUTHORIZATION_ENDPOINT}?{query_string}"
 
         return Response(
-            status=302,
+            status=status.HTTP_302_FOUND,
             headers={"Location": authorization_url},
         )
 
@@ -60,7 +61,7 @@ class OAuth2CallbackView(APIView):
                 {
                     "error": "Authorization code is None. Please check your authentication process."
                 },
-                status=400,
+                status=status.HTTP_400_BAD_REQUEST,
             )
         request_data = {
             "code": code,
@@ -79,5 +80,5 @@ class OAuth2CallbackView(APIView):
                 "Callback URL": PONG_ORIGIN + reverse("oauth2_callback"),
                 "Token": tokens,
             },
-            status=200,
+            status=response.status_code,
         )

--- a/backend/pong/oauth2/views.py
+++ b/backend/pong/oauth2/views.py
@@ -76,6 +76,54 @@ class OAuth2AuthorizeView(OAuth2BaseView):
 
 
 class OAuth2CallbackView(OAuth2BaseView):
+    @extend_schema(
+        responses={
+            200: OpenApiResponse(
+                examples=[
+                    OpenApiExample(
+                        "Example 200 Response",
+                        value={
+                            "Token": {
+                                "access_token": "abc123",
+                                "token_type": "bearer",
+                                "expires_in": 3600,
+                                "refresh_token": "abc123",
+                                "scope": "public",
+                                "created_at": 1734675524,
+                                "secret_valid_until": 1736304711
+                            }
+                        },
+                    )
+                ]
+            ),
+            400: OpenApiResponse(
+                description="Error when no code is provided",
+                examples=[
+                    OpenApiExample(
+                        "Example 400 Response",
+                        value={
+                            "error": "Authorization code is None. Please check your authentication process."
+                        },
+                    )
+                ],
+            ),
+            401: OpenApiResponse(
+                description="Error when the provided authorization grant is invalid",
+                examples=[
+                    OpenApiExample(
+                        "Example 401 Response",
+                        value={
+                            "Token": {
+                                "error": "invalid_grant",
+                                "error_description": "The provided authorization grant is invalid, expired, revoked, does not match the redirection URI used in the authorization request, or was issued to another client."
+                            }
+                        },
+                    )
+                ],
+            ),
+            # todo: 他にもあるかも
+        }
+    )
     def get(self, request: Request, *args: tuple, **kwargs: dict) -> Response:
         """
         認可サーバーからのレスポンスを受け取る関数

--- a/backend/pong/oauth2/views.py
+++ b/backend/pong/oauth2/views.py
@@ -8,12 +8,13 @@ from drf_spectacular.utils import (
     OpenApiResponse,
     extend_schema,
 )
+from rest_framework import status
+
 # todo: IsAuthenticatedが追加されたらAllowAnyは不要?
 from rest_framework.permissions import AllowAny
-from rest_framework.views import APIView
 from rest_framework.request import Request
 from rest_framework.response import Response
-from rest_framework import status
+from rest_framework.views import APIView
 
 from pong.settings import (
     OAUTH2_AUTHORIZATION_ENDPOINT,
@@ -23,15 +24,18 @@ from pong.settings import (
     PONG_ORIGIN,
 )
 
+
 class OAuth2BaseView(APIView):
     """
     OAuth2関連の共通の変数を定義する基底クラス
     """
+
     permission_classes = (AllowAny,)
 
     @property
-    def redirect_uri(self):
+    def redirect_uri(self) -> str:
         return PONG_ORIGIN + reverse("oauth2_callback")
+
 
 class OAuth2AuthorizeView(OAuth2BaseView):
     @extend_schema(
@@ -41,13 +45,14 @@ class OAuth2AuthorizeView(OAuth2BaseView):
                 examples=[
                     OpenApiExample(
                         "Example 302 Redirect",
-                        value={"Location": "https://example.com/oauth2/authorize?code=abc123..."},
+                        value={
+                            "Location": "https://example.com/oauth2/authorize?code=abc123..."
+                        },
                     ),
                 ],
             ),
         }
     )
-
     def get(self, request: Request, *args: tuple, **kwargs: dict) -> Response:
         """
         認可エンドポイントを呼ぶ関数
@@ -90,7 +95,7 @@ class OAuth2CallbackView(OAuth2BaseView):
                                 "refresh_token": "abc123",
                                 "scope": "public",
                                 "created_at": 1734675524,
-                                "secret_valid_until": 1736304711
+                                "secret_valid_until": 1736304711,
                             }
                         },
                     )
@@ -115,7 +120,7 @@ class OAuth2CallbackView(OAuth2BaseView):
                         value={
                             "Token": {
                                 "error": "invalid_grant",
-                                "error_description": "The provided authorization grant is invalid, expired, revoked, does not match the redirection URI used in the authorization request, or was issued to another client."
+                                "error_description": "The provided authorization grant is invalid, expired, revoked, does not match the redirection URI used in the authorization request, or was issued to another client.",
                             }
                         },
                     )
@@ -155,6 +160,7 @@ class OAuth2CallbackView(OAuth2BaseView):
             },
             status=response.status_code,
         )
+
 
 # todo: 以下のエンドポイントは後で実装する
 # - oauth2/refresh

--- a/backend/pong/oauth2/views.py
+++ b/backend/pong/oauth2/views.py
@@ -39,9 +39,13 @@ class OAuth2BaseView(APIView):
 
 class OAuth2AuthorizeView(OAuth2BaseView):
     @extend_schema(
+        request=None,
         responses={
             302: OpenApiResponse(
                 description="Redirect to OAuth2 authorization URL",
+                response=[
+                    ("Location", str),
+                ],
                 examples=[
                     OpenApiExample(
                         "Example 302 Redirect",
@@ -51,7 +55,7 @@ class OAuth2AuthorizeView(OAuth2BaseView):
                     ),
                 ],
             ),
-        }
+        },
     )
     def get(self, request: Request, *args: tuple, **kwargs: dict) -> Response:
         """
@@ -81,6 +85,7 @@ class OAuth2AuthorizeView(OAuth2BaseView):
 
 
 class OAuth2CallbackView(OAuth2BaseView):
+    # todo callbackのエンドポイントのレスポンスが決まったら、request,responseを追加する
     @extend_schema(
         responses={
             200: OpenApiResponse(

--- a/backend/pong/oauth2/views.py
+++ b/backend/pong/oauth2/views.py
@@ -3,6 +3,11 @@ from urllib.parse import urlencode
 
 import requests
 from django.urls import reverse
+from drf_spectacular.utils import (
+    OpenApiExample,
+    OpenApiResponse,
+    extend_schema,
+)
 # todo: IsAuthenticatedが追加されたらAllowAnyは不要?
 from rest_framework.permissions import AllowAny
 from rest_framework.views import APIView
@@ -29,6 +34,20 @@ class OAuth2BaseView(APIView):
         return PONG_ORIGIN + reverse("oauth2_callback")
 
 class OAuth2AuthorizeView(OAuth2BaseView):
+    @extend_schema(
+        responses={
+            302: OpenApiResponse(
+                description="Redirect to OAuth2 authorization URL",
+                examples=[
+                    OpenApiExample(
+                        "Example 302 Redirect",
+                        value={"Location": "https://example.com/oauth2/authorize?code=abc123..."},
+                    ),
+                ],
+            ),
+        }
+    )
+
     def get(self, request: Request, *args: tuple, **kwargs: dict) -> Response:
         """
         認可エンドポイントを呼ぶ関数

--- a/backend/pong/oauth2/views.py
+++ b/backend/pong/oauth2/views.py
@@ -65,14 +65,16 @@ class OAuth2AuthorizeView(OAuth2BaseView):
         - ユーザーが明示的にログアウトした時(ログアウト時にアクセストークンを削除する場合)
         - リフレッシュトークンの有効期限が切れた時
         """
-        query_params = {
+        query_params: dict[str, str] = {
             "client_id": OAUTH2_CLIENT_ID,
             "redirect_uri": self.redirect_uri,
             "response_type": "code",
         }
-        query_string = urlencode(query_params)
+        query_string: str = urlencode(query_params)
 
-        authorization_url = f"{OAUTH2_AUTHORIZATION_ENDPOINT}?{query_string}"
+        authorization_url: str = (
+            f"{OAUTH2_AUTHORIZATION_ENDPOINT}?{query_string}"
+        )
 
         return Response(
             status=status.HTTP_302_FOUND,
@@ -134,6 +136,7 @@ class OAuth2CallbackView(OAuth2BaseView):
         認可サーバーからのレスポンスを受け取る関数
         この関数は認可サーバーからのレスポンスを受け取り、認可コードを取得するために使用する。
         """
+        # todo Optional[str]?
         code = request.GET.get("code")
         if not code:
             return Response(
@@ -142,14 +145,14 @@ class OAuth2CallbackView(OAuth2BaseView):
                 },
                 status=status.HTTP_400_BAD_REQUEST,
             )
-        request_data = {
+        request_data: dict[str, str] = {
             "code": code,
             "grant_type": "authorization_code",
             "redirect_uri": self.redirect_uri,
             "client_id": OAUTH2_CLIENT_ID,
             "client_secret": OAUTH2_CLIENT_SECRET_KEY,
         }
-        response = requests.post(
+        response: requests.models.Response = requests.post(
             OAUTH2_TOKEN_ENDPOINT,
             data=request_data,
         )

--- a/backend/pong/oauth2/views.py
+++ b/backend/pong/oauth2/views.py
@@ -57,8 +57,6 @@ class OAuth2AuthorizeView(OAuth2BaseView):
         """
         認可エンドポイントを呼ぶ関数
         この関数はクライアント(42pong)が認可サーバーの認可エンドポイントにアクセスし、認可コードを取得するために使用する。
-        認可サーバーに接続する際に、redirect_uriを設定する理由は、認可サーバーはクライアントではなくブラウザーにレスポンスを返すため、
-        ブラウザからクライアントにリダイレクトし、認可コードを取得する必要があるため。
 
         認可エンドポイントを呼ぶケース
         - ユーザーが新規アカウントを作成した時
@@ -134,7 +132,8 @@ class OAuth2CallbackView(OAuth2BaseView):
     def get(self, request: Request, *args: tuple, **kwargs: dict) -> Response:
         """
         認可サーバーからのレスポンスを受け取る関数
-        この関数は認可サーバーからのレスポンスを受け取り、認可コードを取得するために使用する。
+        この関数は認可エンドポイント(`/api/oauth2/authorize`)のレスポンスを受け取り、認可コードを取得するために使用する。
+        そのため、このエンドポイントはFEから呼ばれることはありません。
         """
         # todo Optional[str]?
         code = request.GET.get("code")

--- a/backend/pong/oauth2/views.py
+++ b/backend/pong/oauth2/views.py
@@ -88,7 +88,7 @@ class OAuth2CallbackView(OAuth2BaseView):
                     OpenApiExample(
                         "Example 200 Response",
                         value={
-                            "Token": {
+                            "token": {
                                 "access_token": "abc123",
                                 "token_type": "bearer",
                                 "expires_in": 3600,
@@ -118,7 +118,7 @@ class OAuth2CallbackView(OAuth2BaseView):
                     OpenApiExample(
                         "Example 401 Response",
                         value={
-                            "Token": {
+                            "token": {
                                 "error": "invalid_grant",
                                 "error_description": "The provided authorization grant is invalid, expired, revoked, does not match the redirection URI used in the authorization request, or was issued to another client.",
                             }
@@ -158,7 +158,7 @@ class OAuth2CallbackView(OAuth2BaseView):
         tokens = response.json()
         return Response(
             {
-                "Token": tokens,
+                "token": tokens,
             },
             status=response.status_code,
         )


### PR DESCRIPTION
## タスクやディスカッションのリンク
- #132 

## やったこと
- エンドポイントの定義をdecorator関数からクラス定義
- Django Rest Freameworkのステータスコードを使用
- OpenAPIのスキーマを定義
- アノテーション追加
- 今後の作成予定のエンドポイントをコメント追加

## やらないこと
- このタスクでやらないことはなにか？（やらない場合いつやるのか？無ければ「なし」を記述）
- 例外処理
- テスト

## 動作確認
- 今回、リファクタリングのため https://github.com/42-pong/42-pong/pull/107 のPRと動作確認は同じ

## 特にレビューをお願いしたい箇所
- https://github.com/42-pong/42-pong/pull/107 のPRと動作確認は同じかどうか
- アノテーションの定義はこれでいいかどうか

## その他
今後、42のユーザーテーブルを作成しようと思います。具体的にはOAuth2.0で認証した後、`callback/`ないでアクセストークンを使って、ユーザーの情報を取得し、アカウントとOAuth2.0のテーブルをデータベースに保存する処理を書く予定です

## 参考リンク
- https://www.notion.so/OAuth2-0-2a2cca46cc00470eac1d895bff609a11 にある処理の流れを見て頂ければなと思います！

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - OAuth2 認証とコールバック処理にクラスベースのビューを導入しました。
  - 認証 URL の構築とリダイレクト機能が改善されました。

- **バグ修正**
  - 認証コードがない場合に適切なエラーメッセージを返すようになりました。

- **ドキュメント**
  - OpenAPI ドキュメントを追加し、API のレスポンスを詳細に記述しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->