### PR TITLE
⚡ [accounts] api/accounts/, POST の integration test 作成

### DIFF
--- a/backend/pong/accounts/admin.py
+++ b/backend/pong/accounts/admin.py
@@ -1,10 +1,10 @@
 from django.contrib import admin
 
+from . import models
 from .constants import PlayerFields, UserFields
-from .models import Player
 
 
-@admin.register(Player)
+@admin.register(models.Player)
 class AccountAdmin(admin.ModelAdmin):
     """
     Playerモデルの管理画面をカスタマイズする

--- a/backend/pong/accounts/admin.py
+++ b/backend/pong/accounts/admin.py
@@ -6,6 +6,10 @@ from .models import Player
 
 @admin.register(Player)
 class AccountAdmin(admin.ModelAdmin):
+    """
+    Playerモデルの管理画面をカスタマイズする
+    """
+
     list_display = (
         PlayerFields.ID,
         PlayerFields.USER,

--- a/backend/pong/accounts/models.py
+++ b/backend/pong/accounts/models.py
@@ -4,6 +4,11 @@ from django.db import models
 
 # todo: 表示名・アバター画像PATHなどがfieldに追加される予定
 class Player(models.Model):
+    """
+    Playerモデル
+    Userモデルと1対1の関係を持つ
+    """
+
     user = models.OneToOneField(
         User, on_delete=models.CASCADE, related_name="player"
     )

--- a/backend/pong/accounts/serializers.py
+++ b/backend/pong/accounts/serializers.py
@@ -1,8 +1,8 @@
 from django.contrib.auth.models import User
 from rest_framework import serializers
 
+from . import models
 from .constants import PlayerFields, UserFields
-from .models import Player
 
 
 class UserSerializer(serializers.ModelSerializer):
@@ -80,7 +80,7 @@ class PlayerSerializer(serializers.ModelSerializer):
     user: UserSerializer = UserSerializer()
 
     class Meta:
-        model = Player
+        model = models.Player
         fields = (
             PlayerFields.ID,  # todo: UserかPlayerどちらかだけで良さそう
             PlayerFields.USER,
@@ -96,7 +96,7 @@ class PlayerSerializer(serializers.ModelSerializer):
 
     # AccountCreateViewのserializer.save()の内部で呼ばれる
     # todo: 多分トランザクションの処理が必要。User,Playerのどちらかが作成されなかった場合はロールバック
-    def create(self, validated_data: dict) -> Player:
+    def create(self, validated_data: dict) -> models.Player:
         """
         新規Playerを作成する
         UserSerializerを使用してUserを作成し、そのUserと関連付けたPlayerを作成する
@@ -110,5 +110,5 @@ class PlayerSerializer(serializers.ModelSerializer):
         new_user: User = user_serializer.save()
 
         # Userを作成した後でPlayerを作成する
-        player: Player = Player.objects.create(user=new_user)
+        player: models.Player = models.Player.objects.create(user=new_user)
         return player

--- a/backend/pong/accounts/tests/integration/test_accounts.py
+++ b/backend/pong/accounts/tests/integration/test_accounts.py
@@ -1,0 +1,52 @@
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.response import Response
+from rest_framework.test import APITestCase
+
+from ... import models
+from ...constants import UserFields
+
+
+# todo: 認証付きのテスト追加？
+class AccountsTests(APITestCase):
+    def setUp(self) -> None:
+        """
+        APITestCaseのsetUpメソッドのオーバーライド
+        各テストメソッドの実行前に毎回自動実行される
+        """
+        self.url: str = reverse("accounts")
+
+    # -------------------------------------------------------------------------
+    # 正常ケース
+    # -------------------------------------------------------------------------
+    def test_create_account_with_valid_data(self) -> None:
+        """
+        有効なデータでアカウントを作成するテスト
+        status 201, username, email が返されることを確認
+        """
+        account_data: dict = {
+            "user": {
+                UserFields.USERNAME: "testuser",
+                UserFields.EMAIL: "testuser@example.com",
+                UserFields.PASSWORD: "testpassword12345",
+            }
+        }
+        response: Response = self.client.post(
+            self.url, account_data, format="json"
+        )
+
+        # responseの内容を確認
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.data[UserFields.USERNAME], "testuser")
+        self.assertEqual(
+            response.data[UserFields.EMAIL], "testuser@example.com"
+        )
+        # passwordは返されない
+        self.assertNotIn(UserFields.PASSWORD, response.data)
+
+        # DBの状態を確認
+        self.assertEqual(models.Player.objects.count(), 1)
+        player: models.Player = models.Player.objects.get(
+            user__username="testuser"
+        )
+        self.assertEqual(player.user.email, "testuser@example.com")

--- a/backend/pong/accounts/tests/serializers/test_player_serializer.py
+++ b/backend/pong/accounts/tests/serializers/test_player_serializer.py
@@ -57,12 +57,12 @@ class PlayerSerializerTests(TestCase):
         PlayerSerializerのcreate()メソッドが複数回呼ばれた場合に正常に動作することを確認する
         """
         # 2人目のアカウント情報
-        user_data_2 = {
+        user_data_2: dict = {
             UserFields.USERNAME: "testuser_2",
             UserFields.EMAIL: "testuser_2@example.com",
             UserFields.PASSWORD: "testpassword",
         }
-        player_data_2 = {
+        player_data_2: dict = {
             PlayerFields.USER: user_data_2,
         }
 

--- a/backend/pong/accounts/tests/serializers/test_player_serializer.py
+++ b/backend/pong/accounts/tests/serializers/test_player_serializer.py
@@ -1,8 +1,7 @@
 from django.test import TestCase
 
+from ... import models, serializers
 from ...constants import PlayerFields, UserFields
-from ...models import Player
-from ...serializers import PlayerSerializer
 
 
 class PlayerSerializerTests(TestCase):
@@ -28,7 +27,9 @@ class PlayerSerializerTests(TestCase):
         """
         正常なデータが渡された場合にエラーにならないことを確認する
         """
-        serializer: PlayerSerializer = PlayerSerializer(data=self.player_data)
+        serializer: serializers.PlayerSerializer = (
+            serializers.PlayerSerializer(data=self.player_data)
+        )
 
         self.assertTrue(serializer.is_valid())
 
@@ -36,11 +37,13 @@ class PlayerSerializerTests(TestCase):
         """
         PlayerSerializerのcreate()メソッドが正常に動作することを確認する
         """
-        serializer: PlayerSerializer = PlayerSerializer(data=self.player_data)
+        serializer: serializers.PlayerSerializer = (
+            serializers.PlayerSerializer(data=self.player_data)
+        )
         if not serializer.is_valid():
             # このテストではerrorにならない想定
             raise AssertionError(serializer.errors)
-        player: Player = serializer.save()
+        player: models.Player = serializer.save()
 
         # todo: 現在Player独自のfieldがないため、紐づくUserのfieldのみ確認している
         #       今後Player独自のfieldが追加された時にテストも追加する
@@ -65,11 +68,13 @@ class PlayerSerializerTests(TestCase):
 
         # 2人共アカウントを作成し,正常に1対1で紐づいているか確認
         for player_data in (self.player_data, player_data_2):
-            serializer: PlayerSerializer = PlayerSerializer(data=player_data)
+            serializer: serializers.PlayerSerializer = (
+                serializers.PlayerSerializer(data=player_data)
+            )
             if not serializer.is_valid():
                 # このテストではerrorにならない想定
                 raise AssertionError(serializer.errors)
-            player: Player = serializer.save()
+            player: models.Player = serializer.save()
 
             # todo: Player独自のfieldが追加された時にテストも追加する
             self.assertEqual(

--- a/backend/pong/accounts/tests/serializers/test_user_serializer.py
+++ b/backend/pong/accounts/tests/serializers/test_user_serializer.py
@@ -3,8 +3,8 @@ from typing import Final
 from django.contrib.auth.models import User
 from django.test import TestCase
 
+from ... import serializers
 from ...constants import UserFields
-from ...serializers import UserSerializer
 
 ID: Final[str] = UserFields.ID
 USERNAME: Final[str] = UserFields.USERNAME
@@ -32,7 +32,9 @@ class UserSerializerTests(TestCase):
         """
         正常なデータが渡された場合にエラーにならないことを確認する
         """
-        serializer: UserSerializer = UserSerializer(data=self.user_data)
+        serializer: serializers.UserSerializer = serializers.UserSerializer(
+            data=self.user_data
+        )
 
         self.assertTrue(serializer.is_valid())
 
@@ -40,7 +42,9 @@ class UserSerializerTests(TestCase):
         """
         UserSerializerのcreate()メソッドが正常に動作することを確認する
         """
-        serializer: UserSerializer = UserSerializer(data=self.user_data)
+        serializer: serializers.UserSerializer = serializers.UserSerializer(
+            data=self.user_data
+        )
         if not serializer.is_valid():
             # このテストではerrorにならない想定
             raise AssertionError(serializer.errors)
@@ -61,7 +65,9 @@ class UserSerializerTests(TestCase):
         必須フィールド"username"が空の場合にエラーになることを確認する
         """
         self.user_data[USERNAME] = ""
-        serializer: UserSerializer = UserSerializer(data=self.user_data)
+        serializer: serializers.UserSerializer = serializers.UserSerializer(
+            data=self.user_data
+        )
 
         self.assertFalse(serializer.is_valid())
         self.assertIn(USERNAME, serializer.errors)
@@ -71,7 +77,9 @@ class UserSerializerTests(TestCase):
         必須フィールド"email"が空の場合にエラーになることを確認する
         """
         self.user_data[EMAIL] = ""
-        serializer: UserSerializer = UserSerializer(data=self.user_data)
+        serializer: serializers.UserSerializer = serializers.UserSerializer(
+            data=self.user_data
+        )
 
         self.assertFalse(serializer.is_valid())
         self.assertIn(EMAIL, serializer.errors)
@@ -81,7 +89,9 @@ class UserSerializerTests(TestCase):
         必須フィールド"password"が空の場合にエラーになることを確認する
         """
         self.user_data[PASSWORD] = ""
-        serializer: UserSerializer = UserSerializer(data=self.user_data)
+        serializer: serializers.UserSerializer = serializers.UserSerializer(
+            data=self.user_data
+        )
 
         self.assertFalse(serializer.is_valid())
         self.assertIn(PASSWORD, serializer.errors)
@@ -92,7 +102,9 @@ class UserSerializerTests(TestCase):
         実装はしていない。models.EmailField()が自動でチェックしてくれている
         """
         self.user_data[EMAIL] = "invalid_email@none"
-        serializer: UserSerializer = UserSerializer(data=self.user_data)
+        serializer: serializers.UserSerializer = serializers.UserSerializer(
+            data=self.user_data
+        )
 
         self.assertFalse(serializer.is_valid())
         self.assertIn(EMAIL, serializer.errors)
@@ -107,7 +119,9 @@ class UserSerializerTests(TestCase):
             email="non-exist-email@example.com",
             password="testpassword",
         )
-        serializer: UserSerializer = UserSerializer(data=self.user_data)
+        serializer: serializers.UserSerializer = serializers.UserSerializer(
+            data=self.user_data
+        )
 
         self.assertFalse(serializer.is_valid())
         self.assertIn(USERNAME, serializer.errors)

--- a/backend/pong/accounts/urls.py
+++ b/backend/pong/accounts/urls.py
@@ -1,8 +1,8 @@
 from django.urls import path
 
-from .views import AccountCreateView
+from . import views
 
 urlpatterns = [
     # api/accounts/
-    path("", AccountCreateView.as_view(), name="accounts")
+    path("", views.AccountCreateView.as_view(), name="accounts")
 ]

--- a/backend/pong/accounts/views.py
+++ b/backend/pong/accounts/views.py
@@ -18,6 +18,10 @@ from .serializers import PlayerSerializer
 
 
 class AccountCreateView(APIView):
+    """
+    新規アカウントを作成するビュー
+    """
+
     serializer_class: type[PlayerSerializer] = PlayerSerializer
     # todo: 認証機能を実装したら多分IsAuthenticatedに変更
     permission_classes = (AllowAny,)
@@ -70,6 +74,11 @@ class AccountCreateView(APIView):
     )
     # todo: try-exceptを書いて予期せぬエラー(実装上のミスを含む)の場合に500を返す
     def post(self, request: Request, *args: tuple, **kwargs: dict) -> Response:
+        """
+        新規アカウントを作成するPOSTメソッド
+        requestをPlayerSerializerに渡してvalidationを行い、
+        有効な場合はPlayerとUserを作成してDBに追加し、作成されたアカウント情報をresponseとして返す
+        """
         # requestをserializerに渡して変換とバリデーションを行う
         player_serializer = self.serializer_class(data=request.data)
         if not player_serializer.is_valid():

--- a/backend/pong/accounts/views.py
+++ b/backend/pong/accounts/views.py
@@ -81,7 +81,9 @@ class AccountCreateView(APIView):
         有効な場合はPlayerとUserを作成してDBに追加し、作成されたアカウント情報をresponseとして返す
         """
         # requestをserializerに渡して変換とバリデーションを行う
-        player_serializer = self.serializer_class(data=request.data)
+        player_serializer: serializers.PlayerSerializer = (
+            self.serializer_class(data=request.data)
+        )
         if not player_serializer.is_valid():
             return Response(
                 player_serializer.errors,

--- a/backend/pong/accounts/views.py
+++ b/backend/pong/accounts/views.py
@@ -12,9 +12,8 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from . import models, serializers
 from .constants import PlayerFields, UserFields
-from .models import Player
-from .serializers import PlayerSerializer
 
 
 class AccountCreateView(APIView):
@@ -22,13 +21,15 @@ class AccountCreateView(APIView):
     新規アカウントを作成するビュー
     """
 
-    serializer_class: type[PlayerSerializer] = PlayerSerializer
+    serializer_class: type[serializers.PlayerSerializer] = (
+        serializers.PlayerSerializer
+    )
     # todo: 認証機能を実装したら多分IsAuthenticatedに変更
     permission_classes = (AllowAny,)
 
     @extend_schema(
         request=OpenApiRequest(
-            PlayerSerializer,
+            serializers.PlayerSerializer,
             examples=[
                 OpenApiExample(
                     "Example request",
@@ -44,7 +45,7 @@ class AccountCreateView(APIView):
         ),
         responses={
             201: OpenApiResponse(
-                response=PlayerSerializer,
+                response=serializers.PlayerSerializer,
                 examples=[
                     OpenApiExample(
                         "Example 201 response",
@@ -88,7 +89,7 @@ class AccountCreateView(APIView):
             )
 
         # Account(PlayerとUser)を新規作成してDBに追加し、作成された情報を返す
-        player: Player = player_serializer.save()
+        player: models.Player = player_serializer.save()
         return Response(
             {
                 "player_id": player.id,  # todo: Player,UserどちらのIDを返すか決めて変更


### PR DESCRIPTION
## タスクやディスカッションのリンク
- #116 

## やったこと
- `api/accounts/, POST` の integration test 追加
  - 関数単体のテストではなく、request・response を使った API エンドポイントのテストです
  - DB に保存されているかも見ています
- ついでに `accounts` アプリ内のリファクタ
  - `docstring` 追加
  - `import` を修正し、外部ファイルの変数を 1 階層上の指定付きで使えるように変更
e.g. `Player` -> `models.Player`
  - 型ヒントつけられる箇所に追加

## やらないこと
- より細かいテストは実装と一緒に追加していく予定です

## 動作確認
```sh
make build-up
make exec-be
make unit-test
```

## 特にレビューをお願いしたい箇所
- 動作確認
- ざっくりとしたテストの追加なので、さらっと見ていただけると🙏

## その他
- 特になし

## 参考リンク
- 特になし


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **新機能**
	- アカウント作成機能に関する新しいテストスイートを追加しました。

- **バグ修正**
	- なし

- **ドキュメント**
	- 各クラスおよびメソッドに詳細なドキュメントストリングを追加し、機能を明確に説明しました。
	- プレイヤーモデルに関するドキュメントを追加しました。

- **テスト**
	- 有効なデータと無効なデータに対するアカウント作成のテストを追加しました。
	- プレイヤーシリアライザに関するテストを更新し、名前空間を明示化しました。
	- ユーザーシリアライザのインポートと使用方法を修正しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->