### PR TITLE
⚡♻️ [accounts] ユーザーを一意に識別する際に使う ID を、player_id ではなく user_id で統一する

### DIFF
--- a/backend/pong/accounts/admin.py
+++ b/backend/pong/accounts/admin.py
@@ -1,7 +1,31 @@
 from django.contrib import admin
+from django.contrib.auth import admin as auth_admin
+from django.contrib.auth import models as auth_models
 
 from .constants import PlayerFields, UserFields
 from .models import Player
+
+
+# todo: Userモデルに関するカスタマイズは専用のファイルに移動した方が良いのかも
+class CustomUserAdmin(auth_admin.UserAdmin):
+    """
+    adminサイトのUsersに表示されるカラムをカスタマイズ
+    """
+
+    list_display: tuple = (
+        UserFields.ID,
+        UserFields.USERNAME,
+        UserFields.EMAIL,
+        "is_superuser",
+        "is_staff",
+        "is_active",
+    )
+
+
+# デフォルトのUserModelの登録を解除して、カスタマイズしたUserAdminクラスで再登録
+# adminサイトにカスタマイズされたlist_displayが表示されるようになる
+admin.site.unregister(auth_models.User)
+admin.site.register(auth_models.User, CustomUserAdmin)
 
 
 @admin.register(Player)

--- a/backend/pong/accounts/admin.py
+++ b/backend/pong/accounts/admin.py
@@ -20,10 +20,7 @@ class AccountAdmin(admin.ModelAdmin):
         PlayerFields.UPDATED_AT,
     )
     list_filter: tuple = (PlayerFields.UPDATED_AT,)
-    search_fields: tuple = (
-        f"{PlayerFields.USER}__{UserFields.USERNAME}",
-        f"{PlayerFields.USER}__{UserFields.EMAIL}",
-    )
+    search_fields: tuple = (f"{PlayerFields.USER}__{UserFields.USERNAME}",)
 
     def user_id(self, obj: Player) -> int:
         """

--- a/backend/pong/accounts/admin.py
+++ b/backend/pong/accounts/admin.py
@@ -6,14 +6,33 @@ from .models import Player
 
 @admin.register(Player)
 class AccountAdmin(admin.ModelAdmin):
-    list_display = (
-        PlayerFields.ID,
-        PlayerFields.USER,
+    """
+    adminサイトでPlayersに表示されるカラムをカスタマイズ
+    """
+
+    # Playerに紐づくUserの情報をadminサイトで表示する為にはメソッド名をそのまま指定
+    # メソッド名はアンダースコアがスペースに変換されてカラム名として扱われる
+    # todo: Player特有のfieldが追加されたらそれらも追加する
+    list_display: tuple = (
+        "user_id",
+        "username",
         PlayerFields.CREATED_AT,
         PlayerFields.UPDATED_AT,
     )
-    list_filter = (PlayerFields.UPDATED_AT,)
-    search_fields = (
+    list_filter: tuple = (PlayerFields.UPDATED_AT,)
+    search_fields: tuple = (
         f"{PlayerFields.USER}__{UserFields.USERNAME}",
         f"{PlayerFields.USER}__{UserFields.EMAIL}",
     )
+
+    def user_id(self, obj: Player) -> int:
+        """
+        Playerと1対1関係にあるUserのIDをlist_displayで表示するためのメソッド
+        """
+        return obj.user.id
+
+    def username(self, obj: Player) -> str:
+        """
+        Playerと1対1関係にあるUserのusernameをlist_displayで表示するためのメソッド
+        """
+        return obj.user.username

--- a/backend/pong/accounts/constants.py
+++ b/backend/pong/accounts/constants.py
@@ -1,7 +1,5 @@
 from dataclasses import dataclass
 
-# todo: はPlayerかUserどちらかだけで良さそう
-
 
 @dataclass(frozen=True)
 class UserFields:
@@ -13,7 +11,6 @@ class UserFields:
 
 @dataclass(frozen=True)
 class PlayerFields:
-    ID: str = "id"
     USER: str = "user"
     CREATED_AT: str = "created_at"
     UPDATED_AT: str = "updated_at"

--- a/backend/pong/accounts/serializers.py
+++ b/backend/pong/accounts/serializers.py
@@ -10,7 +10,7 @@ class UserSerializer(serializers.ModelSerializer):
     class Meta:
         model = User
         fields = (
-            UserFields.ID,  # todo: UserかPlayerどちらかだけで良さそう
+            UserFields.ID,
             UserFields.USERNAME,
             UserFields.EMAIL,
             UserFields.PASSWORD,
@@ -66,7 +66,6 @@ class PlayerSerializer(serializers.ModelSerializer):
     class Meta:
         model = Player
         fields = (
-            PlayerFields.ID,  # todo: UserかPlayerどちらかだけで良さそう
             PlayerFields.USER,
             PlayerFields.CREATED_AT,
             PlayerFields.UPDATED_AT,

--- a/backend/pong/accounts/views.py
+++ b/backend/pong/accounts/views.py
@@ -45,7 +45,7 @@ class AccountCreateView(APIView):
                     OpenApiExample(
                         "Example 201 response",
                         value={
-                            "player_id": 1,  # todo: Player,UserどちらのIDを返すか決めて変更
+                            UserFields.ID: 1,
                             UserFields.USERNAME: "username",
                             UserFields.EMAIL: "user@example.com",
                         },
@@ -82,7 +82,7 @@ class AccountCreateView(APIView):
         player: Player = player_serializer.save()
         return Response(
             {
-                "player_id": player.id,  # todo: Player,UserどちらのIDを返すか決めて変更
+                UserFields.ID: player.user.id,
                 UserFields.USERNAME: player.user.username,
                 UserFields.EMAIL: player.user.email,
             },

--- a/backend/pong/accounts/views.py
+++ b/backend/pong/accounts/views.py
@@ -45,9 +45,11 @@ class AccountCreateView(APIView):
                     OpenApiExample(
                         "Example 201 response",
                         value={
-                            UserFields.ID: 1,
-                            UserFields.USERNAME: "username",
-                            UserFields.EMAIL: "user@example.com",
+                            PlayerFields.USER: {
+                                UserFields.ID: 1,
+                                UserFields.USERNAME: "username",
+                                UserFields.EMAIL: "user@example.com",
+                            }
                         },
                     ),
                 ],
@@ -82,9 +84,11 @@ class AccountCreateView(APIView):
         player: Player = player_serializer.save()
         return Response(
             {
-                UserFields.ID: player.user.id,
-                UserFields.USERNAME: player.user.username,
-                UserFields.EMAIL: player.user.email,
+                PlayerFields.USER: {
+                    UserFields.ID: player.user.id,
+                    UserFields.USERNAME: player.user.username,
+                    UserFields.EMAIL: player.user.email,
+                }
             },
             status=status.HTTP_201_CREATED,
         )


### PR DESCRIPTION
## タスクやディスカッションのリンク
-  #142 

## やったこと
- `accounts / views, serializers`
  - `before` : アカウント作成時に、`User` テーブルと `Player` テーブルに 1 つずつレコードが追加されるが、どちらもユニークな ID (`user_id`, `player_id`) が存在していて、1 ユーザーを扱う際に混乱しそうだった
  - `after` : mtg で一律 `user_id` を使おうと決めたため、`player_id` を使用していた箇所を `user_id` に置き換えた
- `accounts / admin`
  - Django admin サイトの `Players`, `Users` に表示されるカラムの内容をカスタマイズして少し分かりやすくした

## やらないこと
- 上記以外

## 動作確認
- `make build-up`
- swagger-ui (`http://localhost:8000/api/schema/swagger-ui/`) の `api/accounts/` などからアカウントを新規追加
- django admin サイト (`http://localhost:8000/admin/`) の `Players`, `Users` に追加したユーザーが存在することを確認
カラムの表示内容・種類も確認


## 特にレビューをお願いしたい箇所
- 動作確認と、何かあれば何でも

## その他
- 特になし

## 参考リンク
- 特になし


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新機能**
  - Django管理インターフェースでのユーザー表示のカスタマイズを強化。
  - プレイヤーアカウント作成時のレスポンス構造を改善し、ユーザー関連フィールドを整理。

- **バグ修正**
  - シリアライザーにおけるフィールドの明示的な含有を修正し、バリデーションプロセスを強化。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->