### PR TITLE
🌱 (FE) サーバーの設定ファイル追加

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -19,7 +19,6 @@ FROM nginxinc/nginx-unprivileged:${NGINX_TAG} AS production
 
 COPY --from=builder --chown=nginx:nginx /app/dist /usr/share/nginx/html
 
-# TODO
-# COPY --chown=nginx:nginx nginx.conf /etc/nginx/nginx.conf
+COPY --chown=nginx:nginx nginx.conf /etc/nginx/nginx.conf
 
 CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,0 +1,26 @@
+worker_processes auto;
+
+error_log /var/log/nginx/error.log warn;
+pid /tmp/nginx.pid;
+
+events {
+  worker_connections 1024;
+}
+
+http {
+  include       /etc/nginx/mime.types;
+  default_type  application/octet-stream;
+
+  server {
+    # TODO: https 対応
+    listen 8080;
+
+    # TODO: SERVER_NAME などで環境変数より定まるように設定
+    server_name localhost;
+  
+    location / {
+        root /usr/share/nginx/html;
+        try_files $uri $uri/ /index.html;
+    }
+  }
+}

--- a/frontend/pong/package.json
+++ b/frontend/pong/package.json
@@ -11,11 +11,13 @@
     "start": "npm run build && npm run preview",
     "prebuild": "npm run clean",
     "build": "vite build",
+    "postbuild": "npm run msw:clean",
     "preview": "vite preview",
     "format": "biome format --write",
     "lint:check": "biome lint",
     "check": "biome check",
-    "clean": "rimraf ./dist"
+    "clean": "rimraf ./dist",
+    "msw:clean": "rm ./dist/mockServiceWorker.js"
   },
   "devDependencies": {
     "@biomejs/biome": "1.9.4",


### PR DESCRIPTION
## タスクやディスカッションのリンク
- #148 

## やったこと
- production ビルド後に mock のための js コードが残っていたため、除外する工程を 'scripts' に追加して対応
- #148 対応のため `try_files` を含めての `nginx.conf` ファイルを追加

## やらないこと
- カスタム設定ファイルというものの、`try_files` 以外は一旦デフォルトそのままにしておこうという方針でした。

## 動作確認
- `make build-up` 後、`http://localhost:8080/no-exist` などの接続で `http:localhost:8080/` と同様に `index.html` が表示されることを確認
### 参考
- コンテナの中からの操作でしたら、
例えば`docker exec -it frontend /bin/sh` で入り、 `cat /etc/nginx/nginx.conf` などで様々なファイルの中身が確認できると思います。
- conf ファイルを更新しながら動作を見てみたい時は、
`docker exec -it -uroot frontend /bin/sh` でルートユーザで入り、`apk add vim` などでエディターを入れて、
`nginx -s reload` でリロードしながら色々試せる方法があると思います。

## 特にレビューをお願いしたい箇所
- カスタム設定ファイルを入れてなかった今までは、次のデフォルトの設定になっていたと思います。カスタム設定ファイルへの移行において、何か漏れやアドバイス、おすすめありましたらぜひコメントお願いします。

- `/etc/nginx/nginx.conf`
```
worker_processes  auto;

error_log  /var/log/nginx/error.log notice;
pid        /tmp/nginx.pid;


events {
    worker_connections  1024;
}


http {
    proxy_temp_path /tmp/proxy_temp;
    client_body_temp_path /tmp/client_temp;
    fastcgi_temp_path /tmp/fastcgi_temp;
    uwsgi_temp_path /tmp/uwsgi_temp;
    scgi_temp_path /tmp/scgi_temp;

    include       /etc/nginx/mime.types;
    default_type  application/octet-stream;

    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
                      '$status $body_bytes_sent "$http_referer" '
                      '"$http_user_agent" "$http_x_forwarded_for"';

    access_log  /var/log/nginx/access.log  main;

    sendfile        on;
    #tcp_nopush     on;

    keepalive_timeout  65;

    #gzip  on;

    include /etc/nginx/conf.d/*.conf;
}
```

- `/etc/nginx/conf.d/default.conf` (すぐ上の `/etc/nginx/nginx.conf`の `include` より)
```
server {
    listen       8080;
    server_name  localhost;

    #access_log  /var/log/nginx/host.access.log  main;

    location / {
        root   /usr/share/nginx/html;
        index  index.html index.htm;
    }

    #error_page  404              /404.html;

    # redirect server error pages to the static page /50x.html
    #
    error_page   500 502 503 504  /50x.html;
    location = /50x.html {
        root   /usr/share/nginx/html;
    }

    # proxy the PHP scripts to Apache listening on 127.0.0.1:80
    #
    #location ~ \.php$ {
    #    proxy_pass   http://127.0.0.1;
    #}

    # pass the PHP scripts to FastCGI server listening on 127.0.0.1:9000
    #
    #location ~ \.php$ {
    #    root           html;
    #    fastcgi_pass   127.0.0.1:9000;
    #    fastcgi_index  index.php;
    #    fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
    #    include        fastcgi_params;
    #}

    # deny access to .htaccess files, if Apache's document root
    # concurs with nginx's one
    #
    #location ~ /\.ht {
    #    deny  all;
    #}
}
```
## その他
- 特になし

## 参考リンク
- https://github.com/mswjs/msw/issues/291
- https://nginx.org/en/docs/http/ngx_http_core_module.html#try_files


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 新しいNginx設定ファイル`nginx.conf`が追加され、ポート8080でリッスンするサーバーが設定されました。
  
- **バグ修正**
  - Dockerfileの修正により、`nginx.conf`が最終的なプロダクションイメージに正しくコピーされるようになりました。

- **ドキュメント**
  - `package.json`に新しいスクリプト`postbuild`と`msw:clean`が追加され、ビルドプロセス後のクリーンアップが改善されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->