### PR TITLE
:zap: 衝突判定用の関数とそのテストを作成

### DIFF
--- a/backend/pong/match/geometry_utils.py
+++ b/backend/pong/match/geometry_utils.py
@@ -1,0 +1,93 @@
+import numpy as np
+
+
+def cross2d(vec1: np.ndarray, vec2: np.ndarray) -> int:
+    """
+    2次元ベクトルの外積を計算します。
+
+    Parameters:
+        vec1: 最初の2次元ベクトル。
+        vec2: 2番目の2次元ベクトル。
+
+    Return:
+        vec1とvec2の外積。
+    """
+    return vec1[0] * vec2[1] - vec1[1] * vec2[0]
+
+
+def check_opposite_sides(
+    segment_vec: np.ndarray, point_vec1: np.ndarray, point_vec2: np.ndarray
+) -> bool:
+    """
+    2つの点がある線分の両側に存在するかどうかを判定する関数
+
+    Parameters:
+        segment_vec: 線分を表す2次元ベクトル。
+        point_vec1: 点を表す2次元ベクトル。
+        point_vec2: 点を表す2次元ベクトル。
+
+    Return:
+        両側に存在すればTrueを返す。
+    """
+    return (
+        cross2d(segment_vec, point_vec1) * cross2d(segment_vec, point_vec2)
+    ) < 0
+
+
+def is_internally_devided(
+    v1: np.ndarray, v2: np.ndarray, p: np.ndarray
+) -> bool:
+    """
+    点pが線分v1-v2を内分した点であるかどうかを判定する関数
+
+    Parameters:
+        v1: 線分の始点 (x, y)
+        v2: 線分の終点 (x, y)
+        p: 判定する点 (x, y)
+
+    Return:
+        点pが線分v1-v2上にある場合True、それ以外はFalse
+    """
+    # ベクトルv1 -> p と v2 -> p を計算
+    v1_p = p - v1
+    v1_v2 = v2 - v1
+    # 線分v1 -> v2 上で内分点・外分点を判定
+    cross_product = cross2d(v1_p, v1_v2)  # 外積 (z成分のみ)
+
+    # 外積が0なら2つの線分は並行にあることがわかる
+    if not cross_product == 0:
+        return False
+
+    # 点pが線分v1-v2上にあるかを確認するために以下を調べる
+    # 0 <= v1_pとv1_v2の内積 <= v1_v2の2乗
+    dot_product1 = np.dot(v1_p, v1_v2)
+    dot_product2 = np.dot(v1_v2, v1_v2)
+    if (0 <= dot_product1) and (dot_product1 <= dot_product2):
+        return True
+
+    return False
+
+
+def is_on_the_line(v1: np.ndarray, v2: np.ndarray, p: np.ndarray) -> bool:
+    """
+    点pが無限に伸びる直線v1-v2上にあるかどうかを判定する関数
+
+    Parameters:
+        v1: 直線の始点 (x, y)
+        v2: 直線の終点 (x, y)
+        p: 判定する点 (x, y)
+
+    Return:
+        点pが直線v1-v2上にある場合True、それ以外はFalse
+    """
+    # ベクトルv1 -> p と v2 -> p を計算
+    v1_p = p - v1
+    v1_v2 = v2 - v1
+    # 線分v1 -> v2 上で内分点・外分点を判定
+    cross_product = cross2d(v1_p, v1_v2)  # 外積 (z成分のみ)
+
+    # 外積が0なら2つの線分は並行にあることがわかる
+    if not cross_product == 0:
+        return False
+
+    return True

--- a/backend/pong/match/match_handler.py
+++ b/backend/pong/match/match_handler.py
@@ -46,10 +46,10 @@ class MatchHandler:
         self.channel_layer: Any = channel_layer
         self.channel_name: str = channel_name
         self.stage: Stage = Stage.NONE
-        self.player1: np.ndarray = np.array(2)
-        self.player2: np.ndarray = np.array(2)
-        self.ball: np.ndarray = np.array(2)
-        self.ball_speed: np.ndarray = np.array(2)
+        self.player1: np.ndarray = np.array([0, 0])
+        self.player2: np.ndarray = np.array([0, 0])
+        self.ball: np.ndarray = np.array([0, 0])
+        self.ball_speed: np.ndarray = np.array([0, 0])
         self.score1: int = 0
         self.score2: int = 0
         self.local_play: bool = False

--- a/backend/pong/match/tests.py
+++ b/backend/pong/match/tests.py
@@ -1,3 +1,0 @@
-# from django.test import TestCase
-
-# Create your tests here.

--- a/backend/pong/match/tests/test_geometry_utils.py
+++ b/backend/pong/match/tests/test_geometry_utils.py
@@ -1,0 +1,161 @@
+import unittest
+
+import numpy as np
+
+from ..geometry_utils import (
+    check_opposite_sides,
+    cross2d,
+    is_internally_devided,
+    is_on_the_line,
+)
+
+
+class TestGeometryUtils(unittest.TestCase):
+    """
+    geometry_utilsモジュールの関数をテストするクラス。
+
+    各テストケースは、2次元ベクトル計算における幾何学的な条件を確認するために設計されています。
+    """
+
+    def test_cross2d_positive(self) -> None:
+        """
+        正の外積を計算するテスト。
+        """
+        vec1 = np.array([1, 0])
+        vec2 = np.array([0, 1])
+        result = cross2d(vec1, vec2)
+        self.assertEqual(result, 1)
+
+    def test_cross2d_negative(self) -> None:
+        """
+        負の外積を計算するテスト。
+        """
+        vec1 = np.array([0, 1])
+        vec2 = np.array([1, 0])
+        result = cross2d(vec1, vec2)
+        self.assertEqual(result, -1)
+
+    def test_cross2d_zero(self) -> None:
+        """
+        外積が0になる場合のテスト。
+        """
+        vec1 = np.array([1, 1])
+        vec2 = np.array([2, 2])
+        result = cross2d(vec1, vec2)
+        self.assertEqual(result, 0)
+
+    def test_cross2d_same(self) -> None:
+        """
+        同じベクトルの場合のテスト。
+        """
+        vec1 = np.array([1, 1])
+        vec2 = np.array([1, 1])
+        self.assertEqual(cross2d(vec1, vec2), 0)  # 外積が0
+
+    def test_cross2d_zero_vetor(self) -> None:
+        """
+        片方がゼロベクトルの場合のテスト
+        外積が0になる場合のテスト。
+        """
+        vec1 = np.array([0, 0])
+        vec2 = np.array([1, 1])
+        self.assertEqual(cross2d(vec1, vec2), 0)  # 外積が0
+
+    def test_check_opposite_sides_true(self) -> None:
+        """
+        点が線分の両側に存在する場合のテスト。
+        両側に存在するため、結果がTrueであることを確認します。
+        """
+        segment_vec = np.array([1, 0])
+        point_vec1 = np.array([0, 1])
+        point_vec2 = np.array([0, -1])
+        result = check_opposite_sides(segment_vec, point_vec1, point_vec2)
+        self.assertTrue(result)
+
+    def test_check_opposite_sides_false(self) -> None:
+        """
+        点が線分の両側に存在しない場合のテスト。
+        両側に存在しないため、結果がFalseであることを確認します。
+        """
+        segment_vec = np.array([1, 0])
+        point_vec1 = np.array([0, 1])
+        point_vec2 = np.array([0, 1])
+        result = check_opposite_sides(segment_vec, point_vec1, point_vec2)
+        self.assertFalse(result)
+
+    def test_check_opposite_sides_point_on_segment(self) -> None:
+        """
+        片方の点が線分上にある場合のテスト。
+        点が線分上にあるため、結果がFalseであることを確認します。
+        """
+        segment_vec = np.array([1, 0])
+        point_vec1 = np.array([0, 0])
+        point_vec2 = np.array([0, -1])
+        result = check_opposite_sides(segment_vec, point_vec1, point_vec2)
+        self.assertFalse(result)
+
+    def test_check_opposite_sides_both_points_on_segment(self) -> None:
+        """
+        両方の点が線分上にある場合のテスト。
+        両方の点が線分上にあるため、結果がFalseであることを確認します。
+        """
+        segment_vec = np.array([1, 0])
+        point_vec1 = np.array([0, 0])
+        point_vec2 = np.array([1, 0])
+        result = check_opposite_sides(segment_vec, point_vec1, point_vec2)
+        self.assertFalse(result)
+
+    def test_is_internally_devided_true(self) -> None:
+        """
+        点が線分を内分する場合のテスト。
+        点pが線分v1-v2上にあるため、結果がTrueであることを確認します。
+        """
+        v1 = np.array([0, 0])
+        v2 = np.array([2, 2])
+        p = np.array([1, 1])
+        result = is_internally_devided(v1, v2, p)
+        self.assertTrue(result)
+
+    def test_is_internally_devided_false(self) -> None:
+        """
+        点が線分を内分しない場合のテスト。
+        点pが線分v1-v2上にないため、結果がFalseであることを確認します。
+        """
+        v1 = np.array([0, 0])
+        v2 = np.array([2, 2])
+        p = np.array([1, 3])
+        result = is_internally_devided(v1, v2, p)
+        self.assertFalse(result)
+
+    def test_is_internally_devided_collinear_but_not_on_segment(self) -> None:
+        """
+        点が同じ直線上にはあるが線分上にはない場合のテスト。
+        点pが直線上にあるが線分v1-v2上にないため、結果がFalseであることを確認します。
+        """
+        v1 = np.array([0, 0])
+        v2 = np.array([2, 2])
+        p = np.array([3, 3])
+        result = is_internally_devided(v1, v2, p)
+        self.assertFalse(result)
+
+    def test_is_on_the_line_true(self) -> None:
+        """
+        点が無限直線上にある場合のテスト。
+        点pが直線v1-v2上にあるため、結果がTrueであることを確認します。
+        """
+        v1 = np.array([0, 0])
+        v2 = np.array([2, 2])
+        p = np.array([4, 4])
+        result = is_on_the_line(v1, v2, p)
+        self.assertTrue(result)
+
+    def test_is_on_the_line_false(self) -> None:
+        """
+        点が無限直線上にない場合のテスト。
+        点pが直線v1-v2上にないため、結果がFalseであることを確認します。
+        """
+        v1 = np.array([0, 0])
+        v2 = np.array([2, 2])
+        p = np.array([1, 2])
+        result = is_on_the_line(v1, v2, p)
+        self.assertFalse(result)

--- a/backend/pong/match/tests/test_intersect.py
+++ b/backend/pong/match/tests/test_intersect.py
@@ -1,0 +1,291 @@
+import unittest
+
+import numpy as np
+
+from ..match_handler import MatchHandler
+
+
+class IntersectTest(unittest.TestCase):
+    """
+    Pongゲームでボールとパドルや壁の接触を判定する以下のMatchHandlerクラスのstatic関数のテスト
+    - MatchHandler.intersect_ball_and_paddle()
+    - MatchHandler.intersect_ball_and_wall()
+
+    Attributes:
+        ball_before: ボールの移動前の位置
+        ball_after: ボールの移動後の位置
+        paddle1: パドルの片端の位置
+        paddle2: パドルのもう片端の位置
+        wall1: 壁の片端の位置
+        wall2: 壁のもう片端の位置
+    """
+
+    def setUp(self) -> None:
+        """
+        クラス変数の初期化
+        """
+        self.paddle1 = np.array([2, 4])
+        self.paddle2 = np.array([2, 0])
+        self.wall1 = np.array([2, 2])
+        self.wall2 = np.array([4, 2])
+
+    def test_intersect_ball_and_paddle(self) -> None:
+        """
+        ボールの軌道とパドルが交差
+        = 線分が交差
+        """
+        ball_before: np.ndarray = np.array([0, 0])
+        ball_after: np.ndarray = np.array([4, 4])
+
+        self.assertTrue(
+            MatchHandler.intersect_ball_and_paddle(
+                ball_before, ball_after, self.paddle1, self.paddle2
+            )
+        )
+        self.assertTrue(
+            MatchHandler.intersect_ball_and_paddle(
+                ball_after, ball_before, self.paddle1, self.paddle2
+            )
+        )
+        self.assertTrue(
+            MatchHandler.intersect_ball_and_paddle(
+                ball_before, ball_after, self.paddle2, self.paddle1
+            )
+        )
+        self.assertTrue(
+            MatchHandler.intersect_ball_and_paddle(
+                ball_after, ball_before, self.paddle2, self.paddle1
+            )
+        )
+
+    def test_not_intersect_ball_and_paddle(self) -> None:
+        """
+        ボールの軌道とパドルが交差しない
+        = 線分が交差しない
+        """
+        ball_before: np.ndarray = np.array([3, 4])
+        ball_after: np.ndarray = np.array([6, 5])
+
+        self.assertFalse(
+            MatchHandler.intersect_ball_and_paddle(
+                ball_before, ball_after, self.paddle1, self.paddle2
+            )
+        )
+        self.assertFalse(
+            MatchHandler.intersect_ball_and_paddle(
+                ball_after, ball_before, self.paddle1, self.paddle2
+            )
+        )
+        self.assertFalse(
+            MatchHandler.intersect_ball_and_paddle(
+                ball_before, ball_after, self.paddle2, self.paddle1
+            )
+        )
+        self.assertFalse(
+            MatchHandler.intersect_ball_and_paddle(
+                ball_after, ball_before, self.paddle2, self.paddle1
+            )
+        )
+
+    def test_intersect_ball_and_paddle_at_the_both_endpoints(self) -> None:
+        """
+        ボールの端とパドルの端同士が接触するケース
+        = 線分同士の端点でちょうど接触するケース
+        * ボールの移動前の位置が接触している場合はFalseを返す
+        """
+        ball_before: np.ndarray = np.array([0, 2])
+        ball_after: np.ndarray = np.array([2, 4])
+
+        self.assertTrue(
+            MatchHandler.intersect_ball_and_paddle(
+                ball_before, ball_after, self.paddle1, self.paddle2
+            )
+        )
+        self.assertFalse(
+            MatchHandler.intersect_ball_and_paddle(
+                ball_after, ball_before, self.paddle1, self.paddle2
+            )
+        )
+        self.assertTrue(
+            MatchHandler.intersect_ball_and_paddle(
+                ball_before, ball_after, self.paddle2, self.paddle1
+            )
+        )
+        self.assertFalse(
+            MatchHandler.intersect_ball_and_paddle(
+                ball_after, ball_before, self.paddle2, self.paddle1
+            )
+        )
+
+    def test_intersect_paddle_edge_on_ball(self) -> None:
+        """
+        ボールの軌道がパドルの端に接触するケース
+        = 片方の線の端点がもう片方の線上に接触するケース
+        """
+        ball_before: np.ndarray = np.array([0, 2])
+        ball_after: np.ndarray = np.array([4, 6])
+
+        self.assertTrue(
+            MatchHandler.intersect_ball_and_paddle(
+                ball_before, ball_after, self.paddle1, self.paddle2
+            )
+        )
+        self.assertTrue(
+            MatchHandler.intersect_ball_and_paddle(
+                ball_after, ball_before, self.paddle1, self.paddle2
+            )
+        )
+        self.assertTrue(
+            MatchHandler.intersect_ball_and_paddle(
+                ball_before, ball_after, self.paddle2, self.paddle1
+            )
+        )
+        self.assertTrue(
+            MatchHandler.intersect_ball_and_paddle(
+                ball_after, ball_before, self.paddle2, self.paddle1
+            )
+        )
+
+    def test_intersect_ball_edge_on_paddle(self) -> None:
+        """
+        ボールの軌道の端点がパドルに接触するケース
+        = 片方の線上でちょうど接触するケース
+        * ボールの移動前の位置が接触している場合はFalseを返す
+        """
+        ball_before: np.ndarray = np.array([4, 0])
+        ball_after: np.ndarray = np.array([2, 3])
+
+        self.assertTrue(
+            MatchHandler.intersect_ball_and_paddle(
+                ball_before, ball_after, self.paddle1, self.paddle2
+            )
+        )
+        self.assertFalse(
+            MatchHandler.intersect_ball_and_paddle(
+                ball_after, ball_before, self.paddle1, self.paddle2
+            )
+        )
+        self.assertTrue(
+            MatchHandler.intersect_ball_and_paddle(
+                ball_before, ball_after, self.paddle2, self.paddle1
+            )
+        )
+        self.assertFalse(
+            MatchHandler.intersect_ball_and_paddle(
+                ball_after, ball_before, self.paddle2, self.paddle1
+            )
+        )
+
+    def test_intersect_ball_and_extended_wall(self) -> None:
+        """
+        直線v3-v4と線分v1-v2が交差するケース
+        実際のPongゲームでは上下の壁を無限に伸びた線分として扱える。
+        """
+        ball_before: np.ndarray = np.array([2, 0])
+        ball_after: np.ndarray = np.array([7, 5])
+
+        self.assertTrue(
+            MatchHandler.intersect_ball_and_wall(
+                ball_before, ball_after, self.wall1, self.wall2
+            )
+        )
+        self.assertTrue(
+            MatchHandler.intersect_ball_and_wall(
+                ball_after, ball_before, self.wall1, self.wall2
+            )
+        )
+        self.assertTrue(
+            MatchHandler.intersect_ball_and_wall(
+                ball_before, ball_after, self.wall2, self.wall1
+            )
+        )
+        self.assertTrue(
+            MatchHandler.intersect_ball_and_wall(
+                ball_after, ball_before, self.wall2, self.wall1
+            )
+        )
+
+    def test_not_intersect_ball_and_extended_wall(self) -> None:
+        """
+        直線v3-v4と線分v1-v2が交差しないケース
+        実際のPongゲームでは上下の壁を無限に伸びた線分として扱える。
+        """
+        ball_before: np.ndarray = np.array([1, 4])
+        ball_after: np.ndarray = np.array([3, 3])
+
+        self.assertFalse(
+            MatchHandler.intersect_ball_and_wall(
+                ball_before, ball_after, self.wall1, self.wall2
+            )
+        )
+        self.assertFalse(
+            MatchHandler.intersect_ball_and_wall(
+                ball_after, ball_before, self.wall1, self.wall2
+            )
+        )
+        self.assertFalse(
+            MatchHandler.intersect_ball_and_wall(
+                ball_before, ball_after, self.wall2, self.wall1
+            )
+        )
+        self.assertFalse(
+            MatchHandler.intersect_ball_and_wall(
+                ball_after, ball_before, self.wall2, self.wall1
+            )
+        )
+
+    def test_parallel_ball_and_paddle(self) -> None:
+        """
+        ボールとパドルが並行
+        """
+        ball_before: np.ndarray = np.array([1, 0])
+        ball_after: np.ndarray = np.array([1, 4])
+
+        self.assertFalse(
+            MatchHandler.intersect_ball_and_paddle(
+                ball_before, ball_after, self.paddle1, self.paddle2
+            )
+        )
+        self.assertFalse(
+            MatchHandler.intersect_ball_and_paddle(
+                ball_after, ball_before, self.paddle1, self.paddle2
+            )
+        )
+        self.assertFalse(
+            MatchHandler.intersect_ball_and_paddle(
+                ball_before, ball_after, self.paddle2, self.paddle1
+            )
+        )
+        self.assertFalse(
+            MatchHandler.intersect_ball_and_paddle(
+                ball_after, ball_before, self.paddle2, self.paddle1
+            )
+        )
+
+    def test_parallel_ball_and_wall(self) -> None:
+        """
+        ボールと壁が並行
+        """
+        ball_before: np.ndarray = np.array([2, 4])
+        ball_after: np.ndarray = np.array([4, 4])
+
+        self.assertFalse(
+            MatchHandler.intersect_ball_and_wall(
+                ball_before, ball_after, self.wall1, self.wall2
+            )
+        )
+        self.assertFalse(
+            MatchHandler.intersect_ball_and_wall(
+                ball_after, ball_before, self.wall1, self.wall2
+            )
+        )
+        self.assertFalse(
+            MatchHandler.intersect_ball_and_wall(
+                ball_before, ball_after, self.wall2, self.wall1
+            )
+        )
+        self.assertFalse(
+            MatchHandler.intersect_ball_and_wall(
+                ball_after, ball_before, self.wall2, self.wall1
+            )
+        )

--- a/backend/tools/requirements.in
+++ b/backend/tools/requirements.in
@@ -11,3 +11,4 @@ psycopg2-binary
 djangorestframework-simplejwt[crypto]
 daphne
 channels
+numpy

--- a/backend/tools/requirements.txt
+++ b/backend/tools/requirements.txt
@@ -10,7 +10,7 @@ asgiref==3.8.1
     #   daphne
     #   django
     #   django-stubs
-attrs==24.2.0
+attrs==24.3.0
     # via
     #   jsonschema
     #   referencing
@@ -20,14 +20,13 @@ autobahn==24.4.2
     # via daphne
 automat==24.8.1
     # via twisted
-certifi==2024.8.30
+certifi==2024.12.14
     # via requests
 cffi==1.17.1
     # via cryptography
 channels==4.2.0
-    # via
-    #   -r requirements.in
-charset-normalizer==3.4.0
+    # via -r requirements.in
+charset-normalizer==3.4.1
     # via requests
 constantly==23.10.4
     # via twisted
@@ -64,7 +63,7 @@ djangorestframework==3.15.2
     #   drf-spectacular
 djangorestframework-simplejwt==5.3.1
     # via -r requirements.in
-djangorestframework-stubs==3.15.1
+djangorestframework-stubs==3.15.2
     # via -r requirements.in
 drf-spectacular==0.28.0
     # via -r requirements.in
@@ -91,6 +90,8 @@ mypy==1.13.0
     # via -r requirements.in
 mypy-extensions==1.0.0
     # via mypy
+numpy==2.2.1
+    # via -r requirements.in
 psycopg2-binary==2.9.10
     # via -r requirements.in
 pyasn1==0.6.1
@@ -127,7 +128,7 @@ twisted==24.11.0
     # via daphne
 txaio==23.1.1
     # via autobahn
-types-pyyaml==6.0.12.20240917
+types-pyyaml==6.0.12.20241221
     # via
     #   django-stubs
     #   djangorestframework-stubs
@@ -142,7 +143,7 @@ typing-extensions==4.12.2
     #   twisted
 uritemplate==4.1.1
     # via drf-spectacular
-urllib3==2.2.3
+urllib3==2.3.0
     # via
     #   requests
     #   types-requests


### PR DESCRIPTION
## タスクやディスカッションのリンク
- #150 

## やったこと
- ボールやパドルの位置・速度ベクトルの持ち方を自作の構造体から、numpyの配列に変更
- 以前作成したMatchHandlerクラス内のボールとパドルや壁の衝突判定をする関数が、ボールのスピードを上げたときにすり抜けを起こしてしまうものになっていたので、新しく線分交差アルゴリズムなどを使用して衝突を判定する関数を作成。
- その関数のテストを作成

## やらないこと
- 作成した関数のゲームへの適用はまた別のPRで行います。
- ボールの1フレーム後の位置を導出する関数の作成は次のPRで行います。

## 動作確認
- 作成したテストを実行

## 特にレビューをお願いしたい箇所
- テストのバリエーションが十分か
  - `test_geometry_utils.py`の方はさらっと確認程度で大丈夫ですので、どちらかというと`test_intersect.py`の方のボールとペダルや壁の衝突のケースがほかに考えられたら教えてほしいです。（ある程度のバリエーションはそろってるはずですが見落としがあるかもなので）
- 新規作成した関数の置き場所（ほかのモジュールかクラスの静的メソッドか）が適切か
- 関数自体はテストケースが十分かつそれが通っていれば大丈夫なので、さらっと確認程度でいいと思います。関数のコードがわかりづらいところとかあれば言及していただければと思います。

## その他
- 特になし

## 参考リンク
- [ベクトルの外積を利用した線分交差判定](https://zenn.dev/megeton/articles/d771b7cd774122)
- [pythonでの内積外積計算](https://ictsr4.com/py/l0120.html)
- https://zenn.dev/ryutorion/articles/game-math-vector

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- ジオメトリ計算のためのユーティリティ関数を追加
	- ボールとパドル、壁の衝突検出ロジックを改善

- **依存関係の更新**
	- NumPyパッケージを追加
	- 複数のパッケージのバージョンを更新

- **テスト**
	- 衝突検出のための新しいテストスイートを追加

- **リファクタリング**
	- データ構造をNumPy配列に変更
	- ステージ列挙型を更新

<!-- end of auto-generated comment: release notes by coderabbit.ai -->