### PR TITLE
♻️ [accounts, jwt, swagger, healthcheck] BE で決めた import のルールを適応

### DIFF
--- a/backend/pong/accounts/admin.py
+++ b/backend/pong/accounts/admin.py
@@ -1,13 +1,14 @@
 from django.contrib import admin
-from django.contrib.auth import admin as auth_admin
-from django.contrib.auth import models as auth_models
+from django.contrib.admin import ModelAdmin
+from django.contrib.auth.admin import UserAdmin
+from django.contrib.auth.models import User
 
 from . import models
 from .constants import PlayerFields, UserFields
 
 
 # todo: Userモデルに関するカスタマイズは専用のファイルに移動した方が良いのかも
-class CustomUserAdmin(auth_admin.UserAdmin):
+class CustomUserAdmin(UserAdmin):
     """
     adminサイトのUsersに表示されるカラムをカスタマイズ
     """
@@ -24,12 +25,12 @@ class CustomUserAdmin(auth_admin.UserAdmin):
 
 # デフォルトのUserModelの登録を解除して、カスタマイズしたUserAdminクラスで再登録
 # adminサイトにカスタマイズされたlist_displayが表示されるようになる
-admin.site.unregister(auth_models.User)
-admin.site.register(auth_models.User, CustomUserAdmin)
+admin.site.unregister(User)
+admin.site.register(User, CustomUserAdmin)
 
 
 @admin.register(models.Player)
-class AccountAdmin(admin.ModelAdmin):
+class AccountAdmin(ModelAdmin):
     """
     adminサイトでPlayersに表示されるカラムをカスタマイズ
     """

--- a/backend/pong/accounts/admin.py
+++ b/backend/pong/accounts/admin.py
@@ -3,8 +3,7 @@ from django.contrib.admin import ModelAdmin
 from django.contrib.auth.admin import UserAdmin
 from django.contrib.auth.models import User
 
-from . import models
-from .constants import PlayerFields, UserFields
+from . import constants, models
 
 
 # todo: Userモデルに関するカスタマイズは専用のファイルに移動した方が良いのかも
@@ -14,9 +13,9 @@ class CustomUserAdmin(UserAdmin):
     """
 
     list_display: tuple = (
-        UserFields.ID,
-        UserFields.USERNAME,
-        UserFields.EMAIL,
+        constants.UserFields.ID,
+        constants.UserFields.USERNAME,
+        constants.UserFields.EMAIL,
         "is_superuser",
         "is_staff",
         "is_active",
@@ -41,11 +40,13 @@ class AccountAdmin(ModelAdmin):
     list_display: tuple = (
         "user_id",
         "username",
-        PlayerFields.CREATED_AT,
-        PlayerFields.UPDATED_AT,
+        constants.PlayerFields.CREATED_AT,
+        constants.PlayerFields.UPDATED_AT,
     )
-    list_filter: tuple = (PlayerFields.UPDATED_AT,)
-    search_fields: tuple = (f"{PlayerFields.USER}__{UserFields.USERNAME}",)
+    list_filter: tuple = (constants.PlayerFields.UPDATED_AT,)
+    search_fields: tuple = (
+        f"{constants.PlayerFields.USER}__{constants.UserFields.USERNAME}",
+    )
 
     def user_id(self, obj: models.Player) -> int:
         """

--- a/backend/pong/accounts/constants.py
+++ b/backend/pong/accounts/constants.py
@@ -1,7 +1,7 @@
-from dataclasses import dataclass
+import dataclasses
 
 
-@dataclass(frozen=True)
+@dataclasses.dataclass(frozen=True)
 class UserFields:
     ID: str = "id"
     USERNAME: str = "username"
@@ -9,7 +9,7 @@ class UserFields:
     PASSWORD: str = "password"
 
 
-@dataclass(frozen=True)
+@dataclasses.dataclass(frozen=True)
 class PlayerFields:
     USER: str = "user"
     CREATED_AT: str = "created_at"

--- a/backend/pong/accounts/models.py
+++ b/backend/pong/accounts/models.py
@@ -1,19 +1,17 @@
 from django.contrib.auth.models import User
-from django.db import models
+from django.db.models import CASCADE, DateTimeField, Model, OneToOneField
 
 
 # todo: 表示名・アバター画像PATHなどがfieldに追加される予定
-class Player(models.Model):
+class Player(Model):
     """
     Playerモデル
     Userモデルと1対1の関係を持つ
     """
 
-    user = models.OneToOneField(
-        User, on_delete=models.CASCADE, related_name="player"
-    )
-    created_at = models.DateTimeField(auto_now_add=True)
-    updated_at = models.DateTimeField(auto_now=True)
+    user = OneToOneField(User, on_delete=CASCADE, related_name="player")
+    created_at = DateTimeField(auto_now_add=True)
+    updated_at = DateTimeField(auto_now=True)
 
     # ユーザーが認証に使用するfield
     # todo: ログイン/認証機能実装時に確認して変更

--- a/backend/pong/accounts/serializers.py
+++ b/backend/pong/accounts/serializers.py
@@ -1,8 +1,7 @@
 from django.contrib.auth.models import User
 from rest_framework import serializers
 
-from . import models
-from .constants import PlayerFields, UserFields
+from . import constants, models
 
 
 class UserSerializer(serializers.ModelSerializer):
@@ -15,13 +14,13 @@ class UserSerializer(serializers.ModelSerializer):
     class Meta:
         model = User
         fields = (
-            UserFields.ID,
-            UserFields.USERNAME,
-            UserFields.EMAIL,
-            UserFields.PASSWORD,
+            constants.UserFields.ID,
+            constants.UserFields.USERNAME,
+            constants.UserFields.EMAIL,
+            constants.UserFields.PASSWORD,
         )
         extra_kwargs = {
-            UserFields.PASSWORD: {"write_only": True},
+            constants.UserFields.PASSWORD: {"write_only": True},
         }
 
     # todo:
@@ -49,9 +48,9 @@ class UserSerializer(serializers.ModelSerializer):
         - 必須fieldが空の場合はエラーを発生させる
         """
         required_fields: list[str] = [
-            UserFields.USERNAME,
-            UserFields.EMAIL,
-            UserFields.PASSWORD,
+            constants.UserFields.USERNAME,
+            constants.UserFields.EMAIL,
+            constants.UserFields.PASSWORD,
         ]
         self._validate_required_fields(data, required_fields)
         return data
@@ -63,9 +62,9 @@ class UserSerializer(serializers.ModelSerializer):
         """
         # todo: usernameはBEが自動生成する
         user: User = User.objects.create_user(
-            username=validated_data[UserFields.USERNAME],
-            email=validated_data[UserFields.EMAIL],
-            password=validated_data[UserFields.PASSWORD],
+            username=validated_data[constants.UserFields.USERNAME],
+            email=validated_data[constants.UserFields.EMAIL],
+            password=validated_data[constants.UserFields.PASSWORD],
         )
         return user
 
@@ -82,13 +81,13 @@ class PlayerSerializer(serializers.ModelSerializer):
     class Meta:
         model = models.Player
         fields = (
-            PlayerFields.USER,
-            PlayerFields.CREATED_AT,
-            PlayerFields.UPDATED_AT,
+            constants.PlayerFields.USER,
+            constants.PlayerFields.CREATED_AT,
+            constants.PlayerFields.UPDATED_AT,
         )
         extra_kwargs = {
-            PlayerFields.CREATED_AT: {"read_only": True},
-            PlayerFields.UPDATED_AT: {"read_only": True},
+            constants.PlayerFields.CREATED_AT: {"read_only": True},
+            constants.PlayerFields.UPDATED_AT: {"read_only": True},
         }
 
     # todo: Playerモデルにfieldが追加されたらvalidate()を作成する
@@ -101,7 +100,7 @@ class PlayerSerializer(serializers.ModelSerializer):
         UserSerializerを使用してUserを作成し、そのUserと関連付けたPlayerを作成する
         """
         # requestの中にuserがあるので、それだけpopしてUserSerializerに渡す
-        user_data: dict = validated_data.pop(PlayerFields.USER)
+        user_data: dict = validated_data.pop(constants.PlayerFields.USER)
         user_serializer: UserSerializer = UserSerializer(data=user_data)
 
         # UserSerializerのvalidate()が成功したらUserを作成する

--- a/backend/pong/accounts/tests/integration/test_accounts.py
+++ b/backend/pong/accounts/tests/integration/test_accounts.py
@@ -1,8 +1,15 @@
+from typing import Final
+
 from django.urls import reverse
 from rest_framework import response as drf_response
 from rest_framework import status, test
 
 from ... import constants, models
+
+USERNAME: Final[str] = constants.UserFields.USERNAME
+EMAIL: Final[str] = constants.UserFields.EMAIL
+PASSWORD: Final[str] = constants.UserFields.PASSWORD
+USER: Final[str] = constants.PlayerFields.USER
 
 
 # todo: 認証付きのテスト追加？
@@ -24,26 +31,22 @@ class AccountsTests(test.APITestCase):
         """
         account_data: dict = {
             "user": {
-                constants.UserFields.USERNAME: "testuser",
-                constants.UserFields.EMAIL: "testuser@example.com",
-                constants.UserFields.PASSWORD: "testpassword12345",
+                USERNAME: "testuser",
+                EMAIL: "testuser@example.com",
+                PASSWORD: "testpassword12345",
             }
         }
         response: drf_response.Response = self.client.post(
             self.url, account_data, format="json"
         )
-        response_user: dict = response.data[constants.PlayerFields.USER]
+        response_user: dict = response.data[USER]
 
         # responseの内容を確認
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        self.assertEqual(
-            response_user[constants.UserFields.USERNAME], "testuser"
-        )
-        self.assertEqual(
-            response_user[constants.UserFields.EMAIL], "testuser@example.com"
-        )
+        self.assertEqual(response_user[USERNAME], "testuser")
+        self.assertEqual(response_user[EMAIL], "testuser@example.com")
         # passwordは返されない
-        self.assertNotIn(constants.UserFields.PASSWORD, response_user)
+        self.assertNotIn(PASSWORD, response_user)
 
         # DBの状態を確認
         self.assertEqual(models.Player.objects.count(), 1)
@@ -63,15 +66,15 @@ class AccountsTests(test.APITestCase):
         """
         account_data: dict = {
             "user": {
-                constants.UserFields.USERNAME: "",  # 空のusername
-                constants.UserFields.EMAIL: "invalid-email@none",  # 不正なemail
-                constants.UserFields.PASSWORD: "testpassword12345",
+                USERNAME: "",  # 空のusername
+                EMAIL: "invalid-email@none",  # 不正なemail
+                PASSWORD: "testpassword12345",
             }
         }
         response: drf_response.Response = self.client.post(
             self.url, account_data, format="json"
         )
-        response_user: dict = response.data[constants.PlayerFields.USER]
+        response_user: dict = response.data[USER]
 
         # responseの内容を確認
         # response.data = {
@@ -85,8 +88,8 @@ class AccountsTests(test.APITestCase):
         #     }
         # }
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertIn(constants.UserFields.USERNAME, response_user)
-        self.assertIn(constants.UserFields.EMAIL, response_user)
+        self.assertIn(USERNAME, response_user)
+        self.assertIn(EMAIL, response_user)
 
         # DBの状態を確認
         self.assertEqual(models.Player.objects.count(), 0)

--- a/backend/pong/accounts/tests/integration/test_accounts.py
+++ b/backend/pong/accounts/tests/integration/test_accounts.py
@@ -1,14 +1,13 @@
 from django.urls import reverse
-from rest_framework import status
-from rest_framework.response import Response
-from rest_framework.test import APITestCase
+from rest_framework import response as drf_response
+from rest_framework import status, test
 
 from ... import models
 from ...constants import PlayerFields, UserFields
 
 
 # todo: 認証付きのテスト追加？
-class AccountsTests(APITestCase):
+class AccountsTests(test.APITestCase):
     def setUp(self) -> None:
         """
         APITestCaseのsetUpメソッドのオーバーライド
@@ -31,7 +30,7 @@ class AccountsTests(APITestCase):
                 UserFields.PASSWORD: "testpassword12345",
             }
         }
-        response: Response = self.client.post(
+        response: drf_response.Response = self.client.post(
             self.url, account_data, format="json"
         )
         response_user: dict = response.data[PlayerFields.USER]
@@ -68,7 +67,7 @@ class AccountsTests(APITestCase):
                 UserFields.PASSWORD: "testpassword12345",
             }
         }
-        response: Response = self.client.post(
+        response: drf_response.Response = self.client.post(
             self.url, account_data, format="json"
         )
         response_user: dict = response.data[PlayerFields.USER]

--- a/backend/pong/accounts/tests/integration/test_accounts.py
+++ b/backend/pong/accounts/tests/integration/test_accounts.py
@@ -2,8 +2,7 @@ from django.urls import reverse
 from rest_framework import response as drf_response
 from rest_framework import status, test
 
-from ... import models
-from ...constants import PlayerFields, UserFields
+from ... import constants, models
 
 
 # todo: 認証付きのテスト追加？
@@ -25,24 +24,26 @@ class AccountsTests(test.APITestCase):
         """
         account_data: dict = {
             "user": {
-                UserFields.USERNAME: "testuser",
-                UserFields.EMAIL: "testuser@example.com",
-                UserFields.PASSWORD: "testpassword12345",
+                constants.UserFields.USERNAME: "testuser",
+                constants.UserFields.EMAIL: "testuser@example.com",
+                constants.UserFields.PASSWORD: "testpassword12345",
             }
         }
         response: drf_response.Response = self.client.post(
             self.url, account_data, format="json"
         )
-        response_user: dict = response.data[PlayerFields.USER]
+        response_user: dict = response.data[constants.PlayerFields.USER]
 
         # responseの内容を確認
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        self.assertEqual(response_user[UserFields.USERNAME], "testuser")
         self.assertEqual(
-            response_user[UserFields.EMAIL], "testuser@example.com"
+            response_user[constants.UserFields.USERNAME], "testuser"
+        )
+        self.assertEqual(
+            response_user[constants.UserFields.EMAIL], "testuser@example.com"
         )
         # passwordは返されない
-        self.assertNotIn(UserFields.PASSWORD, response_user)
+        self.assertNotIn(constants.UserFields.PASSWORD, response_user)
 
         # DBの状態を確認
         self.assertEqual(models.Player.objects.count(), 1)
@@ -62,15 +63,15 @@ class AccountsTests(test.APITestCase):
         """
         account_data: dict = {
             "user": {
-                UserFields.USERNAME: "",  # 空のusername
-                UserFields.EMAIL: "invalid-email@none",  # 不正なemail
-                UserFields.PASSWORD: "testpassword12345",
+                constants.UserFields.USERNAME: "",  # 空のusername
+                constants.UserFields.EMAIL: "invalid-email@none",  # 不正なemail
+                constants.UserFields.PASSWORD: "testpassword12345",
             }
         }
         response: drf_response.Response = self.client.post(
             self.url, account_data, format="json"
         )
-        response_user: dict = response.data[PlayerFields.USER]
+        response_user: dict = response.data[constants.PlayerFields.USER]
 
         # responseの内容を確認
         # response.data = {
@@ -84,8 +85,8 @@ class AccountsTests(test.APITestCase):
         #     }
         # }
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertIn(UserFields.USERNAME, response_user)
-        self.assertIn(UserFields.EMAIL, response_user)
+        self.assertIn(constants.UserFields.USERNAME, response_user)
+        self.assertIn(constants.UserFields.EMAIL, response_user)
 
         # DBの状態を確認
         self.assertEqual(models.Player.objects.count(), 0)

--- a/backend/pong/accounts/tests/serializers/test_player_serializer.py
+++ b/backend/pong/accounts/tests/serializers/test_player_serializer.py
@@ -1,6 +1,13 @@
+from typing import Final
+
 from django.test import TestCase
 
 from ... import constants, models, serializers
+
+USERNAME: Final[str] = constants.UserFields.USERNAME
+EMAIL: Final[str] = constants.UserFields.EMAIL
+PASSWORD: Final[str] = constants.UserFields.PASSWORD
+USER: Final[str] = constants.PlayerFields.USER
 
 
 class PlayerSerializerTests(TestCase):
@@ -10,13 +17,13 @@ class PlayerSerializerTests(TestCase):
         各テストメソッドの実行前に毎回自動実行される
         """
         self.user_data = {
-            constants.UserFields.USERNAME: "testuser_1",
-            constants.UserFields.EMAIL: "testuser_1@example.com",
-            constants.UserFields.PASSWORD: "testpassword",
+            USERNAME: "testuser_1",
+            EMAIL: "testuser_1@example.com",
+            PASSWORD: "testpassword",
         }
         # DB追加時に自動でセットされるID,CREATED_AT,UPDATED_ATは省略
         self.player_data = {
-            constants.PlayerFields.USER: self.user_data,
+            USER: self.user_data,
         }
 
     # -------------------------------------------------------------------------
@@ -46,12 +53,8 @@ class PlayerSerializerTests(TestCase):
 
         # todo: 現在Player独自のfieldがないため、紐づくUserのfieldのみ確認している
         #       今後Player独自のfieldが追加された時にテストも追加する
-        self.assertEqual(
-            player.user.username, self.user_data[constants.UserFields.USERNAME]
-        )
-        self.assertEqual(
-            player.user.email, self.user_data[constants.UserFields.EMAIL]
-        )
+        self.assertEqual(player.user.username, self.user_data[USERNAME])
+        self.assertEqual(player.user.email, self.user_data[EMAIL])
 
     def test_player_serializer_multi_create(self) -> None:
         """
@@ -59,12 +62,12 @@ class PlayerSerializerTests(TestCase):
         """
         # 2人目のアカウント情報
         user_data_2: dict = {
-            constants.UserFields.USERNAME: "testuser_2",
-            constants.UserFields.EMAIL: "testuser_2@example.com",
-            constants.UserFields.PASSWORD: "testpassword",
+            USERNAME: "testuser_2",
+            EMAIL: "testuser_2@example.com",
+            PASSWORD: "testpassword",
         }
         player_data_2: dict = {
-            constants.PlayerFields.USER: user_data_2,
+            USER: user_data_2,
         }
 
         # 2人共アカウントを作成し,正常に1対1で紐づいているか確認
@@ -80,15 +83,11 @@ class PlayerSerializerTests(TestCase):
             # todo: Player独自のfieldが追加された時にテストも追加する
             self.assertEqual(
                 player.user.username,
-                player_data[constants.PlayerFields.USER][
-                    constants.UserFields.USERNAME
-                ],
+                player_data[USER][USERNAME],
             )
             self.assertEqual(
                 player.user.email,
-                player_data[constants.PlayerFields.USER][
-                    constants.UserFields.EMAIL
-                ],
+                player_data[USER][EMAIL],
             )
 
     # -------------------------------------------------------------------------

--- a/backend/pong/accounts/tests/serializers/test_player_serializer.py
+++ b/backend/pong/accounts/tests/serializers/test_player_serializer.py
@@ -1,7 +1,6 @@
 from django.test import TestCase
 
-from ... import models, serializers
-from ...constants import PlayerFields, UserFields
+from ... import constants, models, serializers
 
 
 class PlayerSerializerTests(TestCase):
@@ -11,13 +10,13 @@ class PlayerSerializerTests(TestCase):
         各テストメソッドの実行前に毎回自動実行される
         """
         self.user_data = {
-            UserFields.USERNAME: "testuser_1",
-            UserFields.EMAIL: "testuser_1@example.com",
-            UserFields.PASSWORD: "testpassword",
+            constants.UserFields.USERNAME: "testuser_1",
+            constants.UserFields.EMAIL: "testuser_1@example.com",
+            constants.UserFields.PASSWORD: "testpassword",
         }
         # DB追加時に自動でセットされるID,CREATED_AT,UPDATED_ATは省略
         self.player_data = {
-            PlayerFields.USER: self.user_data,
+            constants.PlayerFields.USER: self.user_data,
         }
 
     # -------------------------------------------------------------------------
@@ -48,9 +47,11 @@ class PlayerSerializerTests(TestCase):
         # todo: 現在Player独自のfieldがないため、紐づくUserのfieldのみ確認している
         #       今後Player独自のfieldが追加された時にテストも追加する
         self.assertEqual(
-            player.user.username, self.user_data[UserFields.USERNAME]
+            player.user.username, self.user_data[constants.UserFields.USERNAME]
         )
-        self.assertEqual(player.user.email, self.user_data[UserFields.EMAIL])
+        self.assertEqual(
+            player.user.email, self.user_data[constants.UserFields.EMAIL]
+        )
 
     def test_player_serializer_multi_create(self) -> None:
         """
@@ -58,12 +59,12 @@ class PlayerSerializerTests(TestCase):
         """
         # 2人目のアカウント情報
         user_data_2: dict = {
-            UserFields.USERNAME: "testuser_2",
-            UserFields.EMAIL: "testuser_2@example.com",
-            UserFields.PASSWORD: "testpassword",
+            constants.UserFields.USERNAME: "testuser_2",
+            constants.UserFields.EMAIL: "testuser_2@example.com",
+            constants.UserFields.PASSWORD: "testpassword",
         }
         player_data_2: dict = {
-            PlayerFields.USER: user_data_2,
+            constants.PlayerFields.USER: user_data_2,
         }
 
         # 2人共アカウントを作成し,正常に1対1で紐づいているか確認
@@ -79,11 +80,15 @@ class PlayerSerializerTests(TestCase):
             # todo: Player独自のfieldが追加された時にテストも追加する
             self.assertEqual(
                 player.user.username,
-                player_data[PlayerFields.USER][UserFields.USERNAME],
+                player_data[constants.PlayerFields.USER][
+                    constants.UserFields.USERNAME
+                ],
             )
             self.assertEqual(
                 player.user.email,
-                player_data[PlayerFields.USER][UserFields.EMAIL],
+                player_data[constants.PlayerFields.USER][
+                    constants.UserFields.EMAIL
+                ],
             )
 
     # -------------------------------------------------------------------------

--- a/backend/pong/accounts/tests/serializers/test_user_serializer.py
+++ b/backend/pong/accounts/tests/serializers/test_user_serializer.py
@@ -3,13 +3,12 @@ from typing import Final
 from django.contrib.auth.models import User
 from django.test import TestCase
 
-from ... import serializers
-from ...constants import UserFields
+from ... import constants, serializers
 
-ID: Final[str] = UserFields.ID
-USERNAME: Final[str] = UserFields.USERNAME
-EMAIL: Final[str] = UserFields.EMAIL
-PASSWORD: Final[str] = UserFields.PASSWORD
+ID: Final[str] = constants.UserFields.ID
+USERNAME: Final[str] = constants.UserFields.USERNAME
+EMAIL: Final[str] = constants.UserFields.EMAIL
+PASSWORD: Final[str] = constants.UserFields.PASSWORD
 
 
 class UserSerializerTests(TestCase):

--- a/backend/pong/accounts/views.py
+++ b/backend/pong/accounts/views.py
@@ -3,8 +3,7 @@ from drf_spectacular import utils
 # todo: IsAuthenticatedが追加されたらAllowAnyは不要かも
 from rest_framework import permissions, request, response, status, views
 
-from . import models, serializers
-from .constants import PlayerFields, UserFields
+from . import constants, models, serializers
 
 
 class AccountCreateView(views.APIView):
@@ -25,10 +24,10 @@ class AccountCreateView(views.APIView):
                 utils.OpenApiExample(
                     "Example request",
                     value={
-                        PlayerFields.USER: {
-                            UserFields.USERNAME: "username",
-                            UserFields.EMAIL: "user@example.com",
-                            UserFields.PASSWORD: "password",
+                        constants.PlayerFields.USER: {
+                            constants.UserFields.USERNAME: "username",
+                            constants.UserFields.EMAIL: "user@example.com",
+                            constants.UserFields.PASSWORD: "password",
                         }
                     },
                 ),
@@ -41,10 +40,10 @@ class AccountCreateView(views.APIView):
                     utils.OpenApiExample(
                         "Example 201 response",
                         value={
-                            PlayerFields.USER: {
-                                UserFields.ID: 1,
-                                UserFields.USERNAME: "username",
-                                UserFields.EMAIL: "user@example.com",
+                            constants.PlayerFields.USER: {
+                                constants.UserFields.ID: 1,
+                                constants.UserFields.USERNAME: "username",
+                                constants.UserFields.EMAIL: "user@example.com",
                             }
                         },
                     ),
@@ -89,10 +88,10 @@ class AccountCreateView(views.APIView):
         player: models.Player = player_serializer.save()
         return response.Response(
             {
-                PlayerFields.USER: {
-                    UserFields.ID: player.user.id,
-                    UserFields.USERNAME: player.user.username,
-                    UserFields.EMAIL: player.user.email,
+                constants.PlayerFields.USER: {
+                    constants.UserFields.ID: player.user.id,
+                    constants.UserFields.USERNAME: player.user.username,
+                    constants.UserFields.EMAIL: player.user.email,
                 }
             },
             status=status.HTTP_201_CREATED,

--- a/backend/pong/accounts/views.py
+++ b/backend/pong/accounts/views.py
@@ -4,19 +4,15 @@ from drf_spectacular.utils import (
     OpenApiResponse,
     extend_schema,
 )
-from rest_framework import status
 
 # todo: IsAuthenticatedが追加されたらAllowAnyは不要かも
-from rest_framework.permissions import AllowAny
-from rest_framework.request import Request
-from rest_framework.response import Response
-from rest_framework.views import APIView
+from rest_framework import permissions, request, response, status, views
 
 from . import models, serializers
 from .constants import PlayerFields, UserFields
 
 
-class AccountCreateView(APIView):
+class AccountCreateView(views.APIView):
     """
     新規アカウントを作成するビュー
     """
@@ -25,7 +21,7 @@ class AccountCreateView(APIView):
         serializers.PlayerSerializer
     )
     # todo: 認証機能を実装したら多分IsAuthenticatedに変更
-    permission_classes = (AllowAny,)
+    permission_classes = (permissions.AllowAny,)
 
     @extend_schema(
         request=OpenApiRequest(
@@ -76,7 +72,9 @@ class AccountCreateView(APIView):
         },
     )
     # todo: try-exceptを書いて予期せぬエラー(実装上のミスを含む)の場合に500を返す
-    def post(self, request: Request, *args: tuple, **kwargs: dict) -> Response:
+    def post(
+        self, request: request.Request, *args: tuple, **kwargs: dict
+    ) -> response.Response:
         """
         新規アカウントを作成するPOSTメソッド
         requestをPlayerSerializerに渡してvalidationを行い、
@@ -87,14 +85,14 @@ class AccountCreateView(APIView):
             self.serializer_class(data=request.data)
         )
         if not player_serializer.is_valid():
-            return Response(
+            return response.Response(
                 player_serializer.errors,
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
         # Account(PlayerとUser)を新規作成してDBに追加し、作成された情報を返す
         player: models.Player = player_serializer.save()
-        return Response(
+        return response.Response(
             {
                 PlayerFields.USER: {
                     UserFields.ID: player.user.id,

--- a/backend/pong/accounts/views.py
+++ b/backend/pong/accounts/views.py
@@ -1,9 +1,4 @@
-from drf_spectacular.utils import (
-    OpenApiExample,
-    OpenApiRequest,
-    OpenApiResponse,
-    extend_schema,
-)
+from drf_spectacular import utils
 
 # todo: IsAuthenticatedが追加されたらAllowAnyは不要かも
 from rest_framework import permissions, request, response, status, views
@@ -23,11 +18,11 @@ class AccountCreateView(views.APIView):
     # todo: 認証機能を実装したら多分IsAuthenticatedに変更
     permission_classes = (permissions.AllowAny,)
 
-    @extend_schema(
-        request=OpenApiRequest(
+    @utils.extend_schema(
+        request=utils.OpenApiRequest(
             serializers.PlayerSerializer,
             examples=[
-                OpenApiExample(
+                utils.OpenApiExample(
                     "Example request",
                     value={
                         PlayerFields.USER: {
@@ -40,10 +35,10 @@ class AccountCreateView(views.APIView):
             ],
         ),
         responses={
-            201: OpenApiResponse(
+            201: utils.OpenApiResponse(
                 response=serializers.PlayerSerializer,
                 examples=[
-                    OpenApiExample(
+                    utils.OpenApiExample(
                         "Example 201 response",
                         value={
                             PlayerFields.USER: {
@@ -55,7 +50,7 @@ class AccountCreateView(views.APIView):
                     ),
                 ],
             ),
-            400: OpenApiResponse(
+            400: utils.OpenApiResponse(
                 response={
                     "type": "object",
                     "properties": {
@@ -63,7 +58,7 @@ class AccountCreateView(views.APIView):
                     },
                 },
                 examples=[
-                    OpenApiExample(
+                    utils.OpenApiExample(
                         "Example 400 response",
                         value={"field": "error messages"},
                     ),

--- a/backend/pong/jwt_token/urls.py
+++ b/backend/pong/jwt_token/urls.py
@@ -1,16 +1,12 @@
 from typing import Final
 
 from django.urls import path
-from rest_framework_simplejwt.views import (
-    TokenObtainPairView,
-    TokenRefreshView,
-    TokenVerifyView,
-)
+from rest_framework_simplejwt import views
 
 app_name: Final[str] = "jwt_token"
 urlpatterns = [
     # 'api/token/'
-    path("", TokenObtainPairView.as_view(), name="token_obtain_pair"),
-    path("refresh/", TokenRefreshView.as_view(), name="token_refresh"),
-    path("verify/", TokenVerifyView.as_view(), name="token_verify"),
+    path("", views.TokenObtainPairView.as_view(), name="token_obtain_pair"),
+    path("refresh/", views.TokenRefreshView.as_view(), name="token_refresh"),
+    path("verify/", views.TokenVerifyView.as_view(), name="token_verify"),
 ]

--- a/backend/pong/pong/health_check/tests.py
+++ b/backend/pong/pong/health_check/tests.py
@@ -1,10 +1,9 @@
 from django.test import TestCase
-from rest_framework import status
-from rest_framework.request import Request
-from rest_framework.response import Response
-from rest_framework.test import APIRequestFactory
+from rest_framework import request as drf_request
+from rest_framework import response as drf_response
+from rest_framework import status, test
 
-from .views import health_check
+from . import views
 
 
 class HealthCheckUnitTests(TestCase):
@@ -13,9 +12,9 @@ class HealthCheckUnitTests(TestCase):
         Unit tes for health_check view.
         GET /health/ returns 200 OK
         """
-        factory: APIRequestFactory = APIRequestFactory()
-        request: Request = factory.get("/health/")
-        response: Response = health_check(request)
+        factory: test.APIRequestFactory = test.APIRequestFactory()
+        request: drf_request.Request = factory.get("/health/")
+        response: drf_response.Response = views.health_check(request)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data, {"status": "OK"})

--- a/backend/pong/pong/health_check/views.py
+++ b/backend/pong/pong/health_check/views.py
@@ -1,8 +1,6 @@
-from rest_framework.decorators import api_view
-from rest_framework.request import Request
-from rest_framework.response import Response
+from rest_framework import decorators, request, response
 
 
-@api_view(["GET"])
-def health_check(request: Request) -> Response:
-    return Response({"status": "OK"})
+@decorators.api_view(["GET"])
+def health_check(request: request.Request) -> response.Response:
+    return response.Response({"status": "OK"})

--- a/backend/pong/swagger_ui/urls.py
+++ b/backend/pong/swagger_ui/urls.py
@@ -1,12 +1,12 @@
 from django.urls import path
-from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
+from drf_spectacular import views
 
 urlpatterns = [
     # 'api/schema/'
-    path("", SpectacularAPIView.as_view(), name="schema"),
+    path("", views.SpectacularAPIView.as_view(), name="schema"),
     path(
         "swagger-ui/",
-        SpectacularSwaggerView.as_view(url_name="schema"),
+        views.SpectacularSwaggerView.as_view(url_name="schema"),
         name="swagger-ui",
     ),
 ]


### PR DESCRIPTION
## タスクやディスカッションのリンク
- #159 
- Notion: [BE import のルール](https://www.notion.so/FT_PONG-145f1b77f6c280919971e02b33392fc2?p=4f0a4d178e52418f85d4ffc02c3d9236&pm=s)

## やったこと
- リファクタのみです
- Django 標準の import 以外は、基本的に 1 つ上の名前空間まで指定して使うことに決めたため、以下 app の import をまとめて修正しました
  - accounts
  - jwt_token
  - swagger-ui
  - pong/health_check
- ついでに少し関連したリファクタ
  - テストのみ、`constants` からグローバル変数に代入して使用

## やらないこと
- 特になし

## 動作確認
挙動自体は何も変えていないです
以下コマンドや、`django admin サイト`・`swagger-ui` などが今まで通り見れたり使えたりしていれば問題ないと思います
```sh
make exec-be
make unit-test
```

## 特にレビューをお願いしたい箇所
- 今まで通り動くか
- 他に変更漏れがあれば教えていただきたいです
- `response` など既に使用している変数名などと重複した場合に `as` を使用して別名をつけているのですが、これで良いかどうか。変数名の方を変えようかとも思ったが、レスポンスは `response` という変数名がシンプルでこのまま使用したいと思ったため、モジュール名の方を `as` で変更してみました
```py
from rest_framework import response as drf_response

response: drf_response.Response = views.health_check(request)
```

## その他
- 特になし

## 参考リンク
- 特になし


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **リファクタリング**
	- インポート文と定数の参照方法を改善
	- モデル、シリアライザ、管理画面、テストファイルの構造を最適化

- **スタイル**
	- コードの一貫性と可読性を向上
	- 型ヒントと定数の使用を強化

- **テスト**
	- テストケースの定数参照を更新
	- インポートパスを最適化

これらの変更は、バックエンドコードの全体的な品質と保守性を向上させることを目的としています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->