### PR TITLE
Django の CORS の設定追加

### DIFF
--- a/backend/pong/pong/settings.py
+++ b/backend/pong/pong/settings.py
@@ -27,6 +27,8 @@ env = environ.Env(
     PONG_ORIGIN=(str, "api"),
     OAUTH2_AUTHORIZATION_ENDPOINT=(str, "authorization_endpoint"),
     OAUTH2_TOKEN_ENDPOINT=(str, "token_endpoint"),
+    # todo: デフォルトは設定せず、空文字はエラーにする
+    FRONT_SERVER_PORT=(str, "8080"),
 )
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
@@ -60,6 +62,7 @@ INSTALLED_APPS = [
     "drf_spectacular",  # for Swagger UI
     "drf_spectacular_sidecar",  # for Swagger UI
     "channels",
+    "corsheaders",  # for CORS
     # apps
     "jwt_token",
     "oauth2",
@@ -68,6 +71,8 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
+    # corsheaders: なるべく上に配置する。特にCommonMiddlewareなどのresponseを生成するミドルウェアの前に配置する必要がある
+    "corsheaders.middleware.CorsMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
@@ -195,3 +200,13 @@ OAUTH2_CLIENT_SECRET_KEY = env("OAUTH2_CLIENT_SECRET_KEY")
 PONG_ORIGIN = env("PONG_ORIGIN")
 OAUTH2_AUTHORIZATION_ENDPOINT = env("OAUTH2_AUTHORIZATION_ENDPOINT")
 OAUTH2_TOKEN_ENDPOINT = env("OAUTH2_TOKEN_ENDPOINT")
+
+
+# Django CORS headers
+# https://github.com/adamchainz/django-cors-headers
+
+# リストに追加することでオリジンを許可する
+CORS_ALLOWED_ORIGINS = [
+    f"http://localhost:{env("FRONT_SERVER_PORT")}",  # frontendコンテナ
+]
+# todo: CORS_ALLOW_CREDENTIALS, CSRFについての設定は必要になり次第追加

--- a/backend/pong/pong/settings.py
+++ b/backend/pong/pong/settings.py
@@ -186,6 +186,10 @@ SPECTACULAR_SETTINGS = {
     ],
 }
 
+
+# Django Channels
+# https://channels.readthedocs.io/en/latest/#
+
 CHANNEL_LAYERS = {
     # TODO: 必要になったらchannel_redisを利用する
     "default": {
@@ -194,6 +198,9 @@ CHANNEL_LAYERS = {
 }
 
 ASGI_APPLICATION = "pong.asgi.application"
+
+
+# OAuth2.0
 
 OAUTH2_CLIENT_ID = env("OAUTH2_CLIENT_ID")
 OAUTH2_CLIENT_SECRET_KEY = env("OAUTH2_CLIENT_SECRET_KEY")

--- a/backend/tools/requirements.in
+++ b/backend/tools/requirements.in
@@ -11,3 +11,4 @@ psycopg2-binary
 djangorestframework-simplejwt[crypto]
 daphne
 channels
+django-cors-headers

--- a/backend/tools/requirements.txt
+++ b/backend/tools/requirements.txt
@@ -9,8 +9,9 @@ asgiref==3.8.1
     #   channels
     #   daphne
     #   django
+    #   django-cors-headers
     #   django-stubs
-attrs==24.2.0
+attrs==24.3.0
     # via
     #   jsonschema
     #   referencing
@@ -20,14 +21,13 @@ autobahn==24.4.2
     # via daphne
 automat==24.8.1
     # via twisted
-certifi==2024.8.30
+certifi==2024.12.14
     # via requests
 cffi==1.17.1
     # via cryptography
 channels==4.2.0
-    # via
-    #   -r requirements.in
-charset-normalizer==3.4.0
+    # via -r requirements.in
+charset-normalizer==3.4.1
     # via requests
 constantly==23.10.4
     # via twisted
@@ -43,12 +43,15 @@ django==5.1.4
     # via
     #   -r requirements.in
     #   channels
+    #   django-cors-headers
     #   django-stubs
     #   django-stubs-ext
     #   djangorestframework
     #   djangorestframework-simplejwt
     #   drf-spectacular
     #   drf-spectacular-sidecar
+django-cors-headers==4.6.0
+    # via -r requirements.in
 django-environ==0.11.2
     # via -r requirements.in
 django-stubs==5.1.1
@@ -64,7 +67,7 @@ djangorestframework==3.15.2
     #   drf-spectacular
 djangorestframework-simplejwt==5.3.1
     # via -r requirements.in
-djangorestframework-stubs==3.15.1
+djangorestframework-stubs==3.15.2
     # via -r requirements.in
 drf-spectacular==0.28.0
     # via -r requirements.in
@@ -127,7 +130,7 @@ twisted==24.11.0
     # via daphne
 txaio==23.1.1
     # via autobahn
-types-pyyaml==6.0.12.20240917
+types-pyyaml==6.0.12.20241230
     # via
     #   django-stubs
     #   djangorestframework-stubs
@@ -142,7 +145,7 @@ typing-extensions==4.12.2
     #   twisted
 uritemplate==4.1.1
     # via drf-spectacular
-urllib3==2.2.3
+urllib3==2.3.0
     # via
     #   requests
     #   types-requests


### PR DESCRIPTION
## タスクやディスカッションのリンク
- #158 

## やったこと
django に CORS に関するパッケージを install し、設定を追加しました
これにより、FE コンテナからの request が許可され、BE の WEB API から正常な response を受け取れるようになりました
動作確認に詳細を書いています

## やらないこと
- `localhost:8080` 以外の許可 -> 必要になったら適宜追加
- `CSRF` の設定 -> CSRF について調べて何か追加する際にまとめて追加

## 動作確認
1. `make build-up`
2. `localhost:8080` にアクセス

今まで `localhost:8080` にアクセスすると `/api/health/ : KO` とブラウザに表示されていたのが、この PR の設定追加により `/api/health/ : OK` になることを確認

具体的には、今まで以下のように CORS のエラーだと表示されていたが、
![スクリーンショット 2025-01-02 224125](https://github.com/user-attachments/assets/a8768a6c-0e5c-45ab-80c4-66fee7dbb204)

以下のようにエラーがなくなり、response に `Access-Control-Allow-Origin` header が追加され、指定のオリジンからの request が許可されるようになりました
![スクリーンショット 2025-01-02 224416](https://github.com/user-attachments/assets/a62c055c-e94d-41c4-ab7b-6d1f013b8df5)

## 特にレビューをお願いしたい箇所
- ブラウザで `localhost:8080` にアクセスし、表示されている index.html の内容が `/api/health/ : OK` になっているか
- 他に同時に指定しておきたいオプション設定があれば教えていただきたいです

## その他
- 特になし

## 参考リンク
- [django-cors-headers](https://pypi.org/project/django-cors-headers/)
- [Access-Control-Allow-Origin](https://developer.mozilla.org/ja/docs/Web/HTTP/Headers/Access-Control-Allow-Origin)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新機能**
	- フロントエンドサーバーのポートを設定するための新しい環境変数を追加
	- CORSの処理をサポートするための設定を導入

- **依存関係の更新**
	- `django-cors-headers` パッケージを追加
	- 複数のパッケージのバージョンを更新（`attrs`、`certifi`、`charset-normalizer`など）

<!-- end of auto-generated comment: release notes by coderabbit.ai -->