### PR TITLE
🌱 (FE) グローバル WebSocket を導入

### DIFF
--- a/frontend/pong/js/Endpoints.js
+++ b/frontend/pong/js/Endpoints.js
@@ -5,5 +5,5 @@ const WEBSOCKET_BASE_URL = new URL(`ws://${HOST}`);
 
 export const Endpoints = Object.freeze({
   HEALTH: new URL("/api/health/", BASE_URL),
-  WEBSOCKET: new URL("/ws/match/", WEBSOCKET_BASE_URL),
+  WEBSOCKET: new URL("/ws/", WEBSOCKET_BASE_URL),
 });

--- a/frontend/pong/js/components/views/HomeView.js
+++ b/frontend/pong/js/components/views/HomeView.js
@@ -1,9 +1,13 @@
 import { Endpoints } from "../../Endpoints";
 import { View } from "../../core/View";
+import { isOpenWebSocket } from "../../websocket";
 
 export class HomeView extends View {
   _onConnect() {
-    Object.assign(this._state, { healthStatus: "..." });
+    Object.assign(this._state, {
+      healthStatus: "...",
+      webSocketBaseStatus: "...",
+    });
 
     const getHealthStatus = async () => {
       let healthStatus;
@@ -18,8 +22,22 @@ export class HomeView extends View {
       return healthStatus;
     };
 
+    const getWebSocketBaseStatus = async () => {
+      let isOpen;
+      try {
+        isOpen = await isOpenWebSocket();
+      } catch (error) {
+        isOpen = false;
+      }
+      return isOpen ? "OK" : "KO";
+    };
+
     getHealthStatus().then((healthStatus) => {
       this._updateState({ healthStatus });
+    });
+
+    getWebSocketBaseStatus().then((webSocketBaseStatus) => {
+      this._updateState({ webSocketBaseStatus });
     });
   }
 
@@ -31,5 +49,9 @@ export class HomeView extends View {
     const status = document.createElement("h2");
     status.textContent = `${Endpoints.HEALTH.pathname}: ${this._getState().healthStatus}`;
     this.appendChild(status);
+
+    const wsStatus = document.createElement("h2");
+    wsStatus.textContent = `${Endpoints.WEBSOCKET_BASE_URL.pathname}: ${this._getState().webSocketBaseStatus}`;
+    this.appendChild(wsStatus);
   }
 }

--- a/frontend/pong/js/components/views/HomeView.js
+++ b/frontend/pong/js/components/views/HomeView.js
@@ -51,7 +51,7 @@ export class HomeView extends View {
     this.appendChild(status);
 
     const wsStatus = document.createElement("h2");
-    wsStatus.textContent = `${Endpoints.WEBSOCKET_BASE_URL.pathname}: ${this._getState().webSocketBaseStatus}`;
+    wsStatus.textContent = `${Endpoints.WEBSOCKET.pathname}: ${this._getState().webSocketBaseStatus}`;
     this.appendChild(wsStatus);
   }
 }

--- a/frontend/pong/js/main.js
+++ b/frontend/pong/js/main.js
@@ -1,5 +1,5 @@
 import "./components";
-import { homeRouter } from "./routers/homeRouter.js";
+import { homeRouter } from "./routers/homeRouter";
 
 function main() {
   const app = document.getElementById("app");

--- a/frontend/pong/js/main.js
+++ b/frontend/pong/js/main.js
@@ -1,10 +1,12 @@
 import "./components";
 import { homeRouter } from "./routers/homeRouter";
+import { initWebSocket } from "./websocket";
 
 function main() {
   const app = document.getElementById("app");
   const router = homeRouter(app);
 
+  initWebSocket();
   router.update(window.location.pathname);
 }
 

--- a/frontend/pong/js/websocket/WebSocketWrapper.js
+++ b/frontend/pong/js/websocket/WebSocketWrapper.js
@@ -1,0 +1,57 @@
+export class WebSocketWrapper {
+  #socket;
+  #handlers;
+
+  constructor(url) {
+    const socket = new WebSocket(url);
+    this.#socket = socket;
+
+    this.#handlers = {};
+
+    socket.addEventListener("open", this.onOpen.bind(this));
+    socket.addEventListener("close", this.onClose.bind(this));
+    socket.addEventListener("error", this.onError.bind(this));
+    socket.addEventListener("message", this.onMessage.bind(this));
+  }
+
+  get readyState() {
+    return this.#socket.readyState;
+  }
+
+  send(category, payload) {
+    if (this.#socket === null) return;
+    this.#socket.send(JSON.stringify({ category, payload }));
+  }
+
+  // TODO: クローズコードと理由を指定できる形にする
+  close() {
+    if (this.#socket === null) return;
+    this.#socket.close();
+    this.#socket = null;
+  }
+
+  onOpen(event) {}
+
+  onClose(event) {
+    this.#socket = null;
+  }
+
+  onError(event) {
+    this.#socket.close();
+  }
+
+  onMessage(event) {
+    const { category, payload } = JSON.parse(event.data);
+    const handler = this.#handlers[category];
+
+    if (handler) handler(payload);
+  }
+
+  attachHandler(category, handler) {
+    this.#handlers[category] = handler;
+  }
+
+  detachHandler(category) {
+    delete this.#handlers[category];
+  }
+}

--- a/frontend/pong/js/websocket/index.js
+++ b/frontend/pong/js/websocket/index.js
@@ -5,9 +5,7 @@ let globalWebSocket = null;
 
 const initWebSocket = () => {
   if (globalWebSocket !== null) return;
-  globalWebSocket = new WebSocketWrapper(
-    Endpoints.WEBSOCKET_BASE_URL,
-  );
+  globalWebSocket = new WebSocketWrapper(Endpoints.WEBSOCKET);
 };
 
 const getWebSocket = () => {

--- a/frontend/pong/js/websocket/index.js
+++ b/frontend/pong/js/websocket/index.js
@@ -1,0 +1,71 @@
+import { Endpoints } from "../Endpoints";
+import { WebSocketWrapper } from "./WebSocketWrapper";
+
+let globalWebSocket = null;
+
+const initWebSocket = () => {
+  if (globalWebSocket !== null) return;
+  globalWebSocket = new WebSocketWrapper(
+    Endpoints.WEBSOCKET_BASE_URL,
+  );
+};
+
+const getWebSocket = () => {
+  return globalWebSocket;
+};
+
+const clearWebSocket = () => {
+  globalWebSocket.close();
+  globalWebSocket = null;
+};
+
+// WebSocket の接続状態は、次の四つのいずれかの値を持つ
+// - CONNECTING
+// - OPEN
+// - CLOSING
+// - CLOSED
+//
+// 接続状態が OPEN であるかを、何回か繰り返して確認する関数
+// - 引数 checkLimit と関係なく、必ず一回はチェック
+// - 引数 checkLimit が 3 なら 3回チェック
+// - 繰り返すたびに、間の時間を 2倍で伸ばしていく
+//   ex) 100ms -> 200ms -> 400ms -> 800ms
+const isOpenWebSocket = async (checkLimit = 5) => {
+  const DELAY_INTERVAL_INIT = 100;
+  // TODO: utils に移動
+  const delay = (timeInMilliseconds) =>
+    new Promise((resolve) => setTimeout(resolve, timeInMilliseconds));
+
+  try {
+    let delayInterval = DELAY_INTERVAL_INIT;
+    let checkCount = 0;
+
+    while (true) {
+      switch (globalWebSocket.readyState) {
+        case WebSocket.CONNECTING:
+          break;
+        case WebSocket.OPEN:
+          return true;
+        // case WebSocket.CLOSING:
+        // case WebSocket.CLOSED:
+        default:
+          return false;
+      }
+
+      ++checkCount;
+      if (checkCount >= checkLimit) break;
+
+      await delay(delayInterval);
+      delayInterval *= 2;
+    }
+  } catch (error) {}
+
+  return false;
+};
+
+export {
+  initWebSocket,
+  getWebSocket,
+  clearWebSocket,
+  isOpenWebSocket,
+};


### PR DESCRIPTION
## タスクやディスカッションのリンク
- #171

## やったこと
- クラス WebSocketWrapper を用意
- グローバル WebSocket のインターフェース作成
- 実際、グローバル WebSocket を導入

## やらないこと
- 認証などを問わず、`main.js`より必ず WebSocket の接続をすることを前提にしていますので、
どのタイミング、どの条件で接続を行うか、などは悩んでいません。

## 動作確認
- `cd frontend/pong && npm install`
- `npm run dev` よりホーム画面を表示
- `/ws/: OK` が表示されることを確認

## 特にレビューをお願いしたい箇所
- クラス WebSocketWrapper の確認
- グローバル WebSocket のインターフェースの確認
  - `isOpenWebSocket`:
  WebSocket を確立する際、接続状態が CONNECTING を経由するため、OPEN 状態になっている保証がなく[^readyState]、この関数を呼べば OPEN 状態であるかがわかるように定めています。

## その他
- WebSocketWrapper では、受信するデータのハンドラーをカテゴリに応じて登録できるようにしています。
 `attachHandler`, `detachHandler` はその目的のメソッドです。

## 参考リンク
- https://developer.mozilla.org/ja/docs/Web/API/WebSocket/WebSocket
- https://developer.mozilla.org/ja/docs/Web/API/WebSocket/close

[^readyState]: https://developer.mozilla.org/ja/docs/Web/API/WebSocket/readyState

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- WebSocketの接続状態を追跡する機能を追加
	- ホーム画面にWebSocketステータスを表示

- **改善**
	- WebSocketの初期化プロセスを最適化
	- WebSocket接続の信頼性を向上

- **バグ修正**
	- WebSocket接続の安定性を改善
	- エラーハンドリングを強化

<!-- end of auto-generated comment: release notes by coderabbit.ai -->