### PR TITLE
⚡ ♻️ Websocket/Matchのルール変更に即して変更・リファクタリング

### DIFF
--- a/backend/pong/match/consumers.py
+++ b/backend/pong/match/consumers.py
@@ -15,7 +15,7 @@ class MultiEventConsumer(AsyncJsonWebsocketConsumer):
         await self.accept()
 
     async def disconnect(self, close_code: int) -> None:
-        pass
+        await self.match_handler.remove_from_group()
 
     async def receive_json(self, message: dict) -> None:
         category: str = message.get(ws_constants.Category.key(), "")

--- a/backend/pong/match/consumers.py
+++ b/backend/pong/match/consumers.py
@@ -2,7 +2,7 @@ from channels.generic.websocket import (  # type: ignore
     AsyncJsonWebsocketConsumer,
 )
 
-from . import match_handler
+from . import match_handler, ws_constants
 
 
 class MultiEventConsumer(AsyncJsonWebsocketConsumer):
@@ -18,11 +18,11 @@ class MultiEventConsumer(AsyncJsonWebsocketConsumer):
         pass
 
     async def receive_json(self, message: dict) -> None:
-        category: str = message.get("category", "")
-        payload: dict = message.get("payload", {})
+        category: str = message.get(ws_constants.Category.key(), "")
+        payload: dict = message.get(ws_constants.PAYLOAD_KEY, {})
 
         match category:
-            case "MATCH":
+            case ws_constants.Category.MATCH.value:
                 await self.match_handler.handle(payload)
             case _:
                 pass

--- a/backend/pong/match/consumers.py
+++ b/backend/pong/match/consumers.py
@@ -15,7 +15,7 @@ class MultiEventConsumer(AsyncJsonWebsocketConsumer):
         await self.accept()
 
     async def disconnect(self, close_code: int) -> None:
-        await self.match_handler.remove_from_group()
+        await self.match_handler.cleanup()
 
     async def receive_json(self, message: dict) -> None:
         category: str = message.get(ws_constants.Category.key(), "")

--- a/backend/pong/match/match_enums.py
+++ b/backend/pong/match/match_enums.py
@@ -1,0 +1,42 @@
+from enum import Enum
+from typing import Final
+
+
+class Stage(Enum):
+    INIT: Final[str] = "INIT"
+    READY: Final[str] = "READY"
+    PLAY: Final[str] = "PLAY"
+    END: Final[str] = "END"
+    NONE: Final[str] = "NONE"
+
+    @classmethod
+    def key(cls) -> str:
+        return "stage"
+
+
+class Mode(Enum):
+    LOCAL: Final[str] = "local"
+    REMOTE: Final[str] = "remote"
+
+    @classmethod
+    def key(cls) -> str:
+        return "mode"
+
+
+class Team(Enum):
+    One: Final[str] = "1"
+    Two: Final[str] = "2"
+    Empty: Final[str] = ""
+
+    @classmethod
+    def key(cls) -> str:
+        return "team"
+
+
+class Move(Enum):
+    UP: Final[str] = "UP"
+    DOWN: Final[str] = "DOWN"
+
+    @classmethod
+    def key(cls) -> str:
+        return "move"

--- a/backend/pong/match/match_enums.py
+++ b/backend/pong/match/match_enums.py
@@ -16,8 +16,8 @@ class Stage(BaseEnum):
 
 
 class Mode(BaseEnum):
-    LOCAL: Final[str] = "local"
-    REMOTE: Final[str] = "remote"
+    LOCAL: Final[str] = "LOCAL"
+    REMOTE: Final[str] = "REMOTE"
 
 
 class Team(BaseEnum):

--- a/backend/pong/match/match_enums.py
+++ b/backend/pong/match/match_enums.py
@@ -13,7 +13,6 @@ class Stage(BaseEnum):
     READY: Final[str] = "READY"
     PLAY: Final[str] = "PLAY"
     END: Final[str] = "END"
-    NONE: Final[str] = "NONE"
 
 
 class Mode(BaseEnum):
@@ -22,9 +21,9 @@ class Mode(BaseEnum):
 
 
 class Team(BaseEnum):
-    One: Final[str] = "1"
-    Two: Final[str] = "2"
-    Empty: Final[str] = ""
+    ONE: Final[str] = "1"
+    TWO: Final[str] = "2"
+    EMPTY: Final[str] = ""
 
 
 class Move(BaseEnum):

--- a/backend/pong/match/match_enums.py
+++ b/backend/pong/match/match_enums.py
@@ -2,41 +2,31 @@ from enum import Enum
 from typing import Final
 
 
-class Stage(Enum):
+class BaseEnum(Enum):
+    @classmethod
+    def key(cls) -> str:
+        return cls.__name__.lower()
+
+
+class Stage(BaseEnum):
     INIT: Final[str] = "INIT"
     READY: Final[str] = "READY"
     PLAY: Final[str] = "PLAY"
     END: Final[str] = "END"
     NONE: Final[str] = "NONE"
 
-    @classmethod
-    def key(cls) -> str:
-        return "stage"
 
-
-class Mode(Enum):
+class Mode(BaseEnum):
     LOCAL: Final[str] = "local"
     REMOTE: Final[str] = "remote"
 
-    @classmethod
-    def key(cls) -> str:
-        return "mode"
 
-
-class Team(Enum):
+class Team(BaseEnum):
     One: Final[str] = "1"
     Two: Final[str] = "2"
     Empty: Final[str] = ""
 
-    @classmethod
-    def key(cls) -> str:
-        return "team"
 
-
-class Move(Enum):
+class Move(BaseEnum):
     UP: Final[str] = "UP"
     DOWN: Final[str] = "DOWN"
-
-    @classmethod
-    def key(cls) -> str:
-        return "move"

--- a/backend/pong/match/match_handler.py
+++ b/backend/pong/match/match_handler.py
@@ -27,6 +27,7 @@ class MatchHandler:
     BALL_SIZE: Final[int] = 10
     BALL_SPEED: Final[int] = 2
     FPS: Final[float] = 1 / 60
+    WINNING_SCORE: Final[int] = 5
 
     # クラス属性
     stage: Optional[match_enums.Stage]
@@ -247,7 +248,10 @@ class MatchHandler:
             self._reset_ball()
 
         # 勝利判定
-        if self.score1 >= 5 or self.score2 >= 5:
+        if (
+            self.score1 >= self.WINNING_SCORE
+            or self.score2 >= self.WINNING_SCORE
+        ):
             self.stage = match_enums.Stage.END
 
     def _process_ball_paddle_collision(

--- a/backend/pong/match/match_handler.py
+++ b/backend/pong/match/match_handler.py
@@ -163,8 +163,7 @@ class MatchHandler:
         ENDステージのメッセージが送られてきたときの処理
         プレーヤーがmatchを退出したときの処理を行う。
         """
-        await self.remove_from_group()
-        self._reset_state()  # 初期化
+        await self.cleanup()
 
     async def _end_process(self) -> None:
         """
@@ -181,10 +180,7 @@ class MatchHandler:
             {"win": win_team, "score1": self.score1, "score2": self.score2},
         )
         await self._send_to_group(message)
-        # matchが終わったのでグループから削除
-        await self.remove_from_group()
-        # 初期化
-        self._reset_state()
+        await self.cleanup()
 
     # ==============================
     # ゲームロジック関係のメソッド
@@ -337,7 +333,7 @@ class MatchHandler:
         """
         await self.channel_layer.group_add(self.group_name, self.channel_name)
 
-    async def remove_from_group(self) -> None:
+    async def _remove_from_group(self) -> None:
         """
         Consuerをグループから削除。
 
@@ -395,6 +391,15 @@ class MatchHandler:
         self.ball_speed: PosStruct = PosStruct(
             x=self.BALL_SPEED, y=self.BALL_SPEED
         )
+
+    async def cleanup(self) -> None:
+        """
+        ゲーム終了後のクリーンナップ処理
+        グループから削除し、状態を初期化する
+        """
+        if self.group_name != "":
+            await self._remove_from_group()
+        self._reset_state()
 
     def _build_message(self, data: dict) -> dict:
         """

--- a/backend/pong/match/match_handler.py
+++ b/backend/pong/match/match_handler.py
@@ -403,7 +403,7 @@ class MatchHandler:
         ゲーム終了後のクリーンナップ処理
         グループから削除し、状態を初期化する
         """
-        if self.group_name != "":
+        if self.group_name:
             await self._remove_from_group()
         self._reset_state()
 

--- a/backend/pong/match/match_handler.py
+++ b/backend/pong/match/match_handler.py
@@ -2,7 +2,7 @@ import asyncio
 from dataclasses import dataclass
 from typing import Any, Final
 
-from . import match_enums
+from . import match_enums, ws_constants
 
 
 @dataclass
@@ -90,8 +90,8 @@ class MatchHandler:
 
         :param payload: プレイヤーからのデータを含むペイロード
         """
-        data: dict = payload.get("data", {})
-        stage: str = payload.get("stage", "")
+        data: dict = payload.get(ws_constants.DATA_KEY, {})
+        stage: str = payload.get(match_enums.Stage.key(), "")
         handler = self.stage_handlers.get(stage)
 
         # TODO: ステージごとのバリデーションも実装する必要あり
@@ -384,9 +384,9 @@ class MatchHandler:
         :return: 作成したメッセージ
         """
         return {
-            "category": "MATCH",
-            "payload": {
+            ws_constants.Category.key(): ws_constants.Category.MATCH.value,
+            ws_constants.PAYLOAD_KEY: {
                 match_enums.Stage.key(): stage.value,
-                "data": data,
+                ws_constants.DATA_KEY: data,
             },
         }

--- a/backend/pong/match/match_handler.py
+++ b/backend/pong/match/match_handler.py
@@ -23,7 +23,7 @@ class MatchHandler:
     PADDLE_HEIGHT: Final[int] = 60
     PADDLE_WIDTH: Final[int] = 10
     PADDLE_SPEED: Final[int] = 5
-    BALL_RADIUS: Final[int] = 10
+    BALL_SIZE: Final[int] = 10
     BALL_SPEED: Final[int] = 2
 
     # クラス属性
@@ -217,9 +217,9 @@ class MatchHandler:
         self.ball.y += self.ball_speed.y
 
         # 上下の壁との衝突判定
-        if self.ball.y - self.BALL_RADIUS <= 0:
+        if self.ball.y - self.BALL_SIZE <= 0:
             self.ball_speed.y = abs(self.ball_speed.y)
-        elif self.ball.y + self.BALL_RADIUS >= self.HEIGHT:
+        elif self.ball.y + self.BALL_SIZE >= self.HEIGHT:
             self.ball_speed.y = -abs(self.ball_speed.y)
 
         # パドルとの衝突判定
@@ -227,10 +227,10 @@ class MatchHandler:
         self._process_ball_paddle_collision(self.paddle2, False)
 
         # 得点判定
-        if self.ball.x + self.BALL_RADIUS <= 0:
+        if self.ball.x + self.BALL_SIZE <= 0:
             self.score2 += 1
             self._reset_ball()
-        elif self.ball.x - self.BALL_RADIUS >= self.WIDTH:
+        elif self.ball.x - self.BALL_SIZE >= self.WIDTH:
             self.score1 += 1
             self._reset_ball()
 
@@ -250,11 +250,11 @@ class MatchHandler:
         """
         # 衝突判定
         if (
-            self.ball.x - self.BALL_RADIUS <= paddle_pos.x + self.PADDLE_WIDTH
-            and self.ball.x + self.BALL_RADIUS >= paddle_pos.x
-            and self.ball.y - self.BALL_RADIUS
+            self.ball.x - self.BALL_SIZE <= paddle_pos.x + self.PADDLE_WIDTH
+            and self.ball.x + self.BALL_SIZE >= paddle_pos.x
+            and self.ball.y - self.BALL_SIZE
             <= paddle_pos.y + self.PADDLE_HEIGHT
-            and self.ball.y + self.BALL_RADIUS >= paddle_pos.y
+            and self.ball.y + self.BALL_SIZE >= paddle_pos.y
         ):
             # ボールのx座標がパドルの側面に当たった場合
             # ボールの中心がパドルの端よりも自陣側に過ぎていたらx軸方向に跳ね返さない
@@ -369,7 +369,8 @@ class MatchHandler:
         ボールを中央に配置し、速度を設定する。
         """
         self.ball: PosStruct = PosStruct(
-            x=int(self.WIDTH / 2), y=int(self.HEIGHT / 2)
+            x=int(self.WIDTH / 2 - self.BALL_SIZE / 2),
+            y=int(self.HEIGHT / 2 - self.BALL_SIZE / 2),
         )
         self.ball_speed: PosStruct = PosStruct(
             x=self.BALL_SPEED, y=self.BALL_SPEED

--- a/backend/pong/match/match_handler.py
+++ b/backend/pong/match/match_handler.py
@@ -1,6 +1,6 @@
 import asyncio
 from dataclasses import dataclass
-from typing import Any, Final
+from typing import Any, Final, Optional
 
 from . import match_enums, ws_constants
 
@@ -27,7 +27,7 @@ class MatchHandler:
     BALL_SPEED: Final[int] = 2
 
     # クラス属性
-    stage: match_enums.Stage
+    stage: Optional[match_enums.Stage]
     paddle1: PosStruct
     paddle2: PosStruct
     ball: PosStruct
@@ -118,7 +118,7 @@ class MatchHandler:
         message = self._build_message(
             match_enums.Stage.INIT,
             {
-                match_enums.Team.key(): match_enums.Team.Empty.value,
+                match_enums.Team.key(): match_enums.Team.EMPTY.value,
                 "display_name1": "",
                 "display_name2": "",
                 "paddle1": {"x": self.paddle1.x, "y": self.paddle1.y},
@@ -165,9 +165,9 @@ class MatchHandler:
         勝者を決定し、グループから退出し、ゲーム状態を初期化。
         """
         win_team: str = (
-            match_enums.Team.One.value
+            match_enums.Team.ONE.value
             if self.score1 > self.score2
-            else match_enums.Team.Two.value
+            else match_enums.Team.TWO.value
         )
         message = self._build_message(
             match_enums.Stage.END,
@@ -190,13 +190,13 @@ class MatchHandler:
             case match_enums.Move.UP.value:
                 if (
                     paddle_move.get(match_enums.Team.key())
-                    == match_enums.Team.One.value
+                    == match_enums.Team.ONE.value
                     and self.paddle1.y > 0
                 ):
                     self.paddle1.y -= self.PADDLE_SPEED
                 elif (
                     paddle_move.get(match_enums.Team.key())
-                    == match_enums.Team.Two.value
+                    == match_enums.Team.TWO.value
                     and self.paddle2.y > 0
                 ):
                     self.paddle2.y -= self.PADDLE_SPEED
@@ -204,13 +204,13 @@ class MatchHandler:
             case match_enums.Move.DOWN.value:
                 if (
                     paddle_move.get(match_enums.Team.key())
-                    == match_enums.Team.One.value
+                    == match_enums.Team.ONE.value
                     and self.paddle1.y + self.PADDLE_HEIGHT < self.HEIGHT
                 ):
                     self.paddle1.y += self.PADDLE_SPEED
                 elif (
                     paddle_move.get(match_enums.Team.key())
-                    == match_enums.Team.Two.value
+                    == match_enums.Team.TWO.value
                     and self.paddle2.y + self.PADDLE_HEIGHT < self.HEIGHT
                 ):
                     self.paddle2.y += self.PADDLE_SPEED
@@ -354,7 +354,7 @@ class MatchHandler:
 
         ゲームのステージ、スコア、プレイヤーの位置、ボールの位置を初期状態に戻す。
         """
-        self.stage = match_enums.Stage.NONE
+        self.stage = None
         # paddleの位置は左上とする
         self.paddle1 = PosStruct(
             x=10, y=int(self.HEIGHT / 2 - self.PADDLE_HEIGHT / 2)

--- a/backend/pong/match/match_handler.py
+++ b/backend/pong/match/match_handler.py
@@ -305,6 +305,8 @@ class MatchHandler:
             delta = current_time - last_update
             if delta >= self.FPS:
                 self._update_match_state()
+                if self.stage == match_enums.Stage.END:
+                    break
                 game_state = self._build_message(
                     {
                         "paddle1": {"x": self.paddle1.x, "y": self.paddle1.y},

--- a/backend/pong/match/match_handler.py
+++ b/backend/pong/match/match_handler.py
@@ -155,7 +155,7 @@ class MatchHandler:
         """
         プレーヤーがmatchを退出したときの処理を行う。
         """
-        await self._remove_from_group()
+        await self.remove_from_group()
         self._reset_state()  # 初期化
 
     async def _end_process(self) -> None:
@@ -175,7 +175,7 @@ class MatchHandler:
         )
         await self._send_to_group(message)
         # matchが終わったのでグループから削除
-        await self._remove_from_group()
+        await self.remove_from_group()
         # 初期化
         self._reset_state()
 
@@ -327,7 +327,7 @@ class MatchHandler:
         """
         await self.channel_layer.group_add(self.group_name, self.channel_name)
 
-    async def _remove_from_group(self) -> None:
+    async def remove_from_group(self) -> None:
         """
         マッチをグループから削除。
 

--- a/backend/pong/match/match_handler.py
+++ b/backend/pong/match/match_handler.py
@@ -106,6 +106,7 @@ class MatchHandler:
 
     async def _handle_init(self, data: dict) -> None:
         """
+        INITステージのメッセージが送られてきたときの処理
         ゲームの初期化処理。
         初期配置情報などを送信する。
 
@@ -135,6 +136,7 @@ class MatchHandler:
 
     async def _handle_ready(self, data: dict) -> None:
         """
+        READYステージのメッセージが送られてきたときの処理
         プレイヤーの準備が整ったことがdataによってわかるので、ゲームを開始する。
 
         :param data: 準備状態に必要なデータ
@@ -149,6 +151,7 @@ class MatchHandler:
 
     async def _handle_play(self, data: dict) -> None:
         """
+        PLAYステージのメッセージが送られてきたときの処理
         プレーヤーのパドルの動きに基づいてゲーム状態を更新。
 
         :param data: パドルの移動情報
@@ -157,6 +160,7 @@ class MatchHandler:
 
     async def _handle_end(self) -> None:
         """
+        ENDステージのメッセージが送られてきたときの処理
         プレーヤーがmatchを退出したときの処理を行う。
         """
         await self.remove_from_group()
@@ -166,7 +170,7 @@ class MatchHandler:
         """
         ゲーム終了時の処理。
 
-        試合の結果を送信し、グループからの退出、ゲーム状態の初期化を行う。
+        ENDステージのメッセージを送信し、クリーンナップ処理を行う。
         """
         win_team: str = (
             match_enums.Team.ONE.value

--- a/backend/pong/match/match_handler.py
+++ b/backend/pong/match/match_handler.py
@@ -153,6 +153,13 @@ class MatchHandler:
 
     async def _handle_end(self) -> None:
         """
+        プレーヤーがmatchを退出したときの処理を行う。
+        """
+        await self._remove_from_group()
+        self._reset_state()  # 初期化
+
+    async def _end_process(self) -> None:
+        """
         ゲーム終了時の処理。
 
         勝者を決定し、グループから退出し、ゲーム状態を初期化。
@@ -309,7 +316,7 @@ class MatchHandler:
                 await asyncio.sleep(1 / 60 - delta)
 
         # ENDステージの処理
-        await self._handle_end()
+        await self._end_process()
 
     # グループ関係のメソッド
     async def _add_to_group(self) -> None:

--- a/backend/pong/match/ws_constants.py
+++ b/backend/pong/match/ws_constants.py
@@ -1,0 +1,15 @@
+from enum import Enum
+from typing import Final
+
+
+class Category(Enum):
+    MATCH: Final[str] = "MATCH"
+    # TODO: 他のカテゴリーは順次追加する
+
+    @classmethod
+    def key(cls) -> str:
+        return "category"
+
+
+PAYLOAD_KEY: Final[str] = "payload"
+DATA_KEY: Final[str] = "data"


### PR DESCRIPTION
## タスクやディスカッションのリンク
- #151 

## やったこと
マッチのメッセージ形式の変更に伴い細かい修正をいくつかまとめて行いました。  

- [ルール変更](https://www.notion.so/Websocket-match-8d2e636ba72d48dd8cce3c68c11be982)に従っての修正事項
  - ボールを四角として扱うよう変更
  - クライアントがマッチを抜けたときはENDステージでメッセージが送ってくるようになったので、それに合わせてハンドラを修正（これに関してはクライアント側のコードを修正していないので試せません。）
  - メッセージの文字列の値を大文字に統一

- その他のリファクタリング
  - スキーマの定数を別ファイルに定義して使うよう変更
  - 切断された時にチャネルグループから外すように修正

- 追加修正
  - https://github.com/42-pong/42-pong/pull/176#issuecomment-2581633407

## やらないこと
- ボールの初期位置など四角であることを想定して変更しましたが、実際のロジックはまた別のPRで行います。
- クライアントからの不正なメッセージの対応もこのPRで行おうと思いましたが、テストも必要になったりしそうなので別PRにします。
- ディレクトリ構成もほかのChatやトーナメントなどのイベントが追加されるタイミングで変えようと思っています。

## 動作確認
- 今回は例外の部分以外はほとんどリファクタリングに近いので、前回と同じようにテストコンテナのコードが動くかどうかで確認しています。（[こちら](https://github.com/42-pong/demo-repository/tree/test-container-branch)から`test`ディレクトリをルートにコピペして、compose.yamlのfrontendコンテナの名前をtestにしてポートを7000に変更すれば動きます。）

## 特にレビューをお願いしたい箇所
- リファクタリングの部分は定数を別で定義するようにしただけなので確認程度でいいと思います。

## その他
- スキーマで使う定数でよく使うものに関しては別ファイルに定数として定義していますが、いくつかのキーだけべた書きしてしまっています。いろいろ悩んだのですが、いい方法が浮かばずこのようになっています。単にそれらも定数のように定義してもいいんじゃないかなどあればコメントいただきたいです。

## 参考リンク


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **新機能**
	- マッチングプロセスの列挙型と定数を追加
	- WebSocketメッセージングのカテゴリと定数を導入

- **バグ修正**
	- メッセージ処理のロジックを改善
	- 例外処理を追加

- **リファクタリング**
	- プレイヤーパドルの用語と参照を標準化
	- ゲームステージの管理方法を更新

これらの変更により、ゲームのWebSocketハンドリングとマッチングプロセスの堅牢性と一貫性が向上しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->