### PR TITLE
[accounts] usernameをランダム文字列で自動生成する関数のラッパー作成

### DIFF
--- a/backend/pong/accounts/create_account.py
+++ b/backend/pong/accounts/create_account.py
@@ -1,15 +1,37 @@
+from typing import Final
+
 from django.contrib.auth.models import User
+from django.utils.crypto import get_random_string
 from rest_framework import serializers as def_serializers
 
 import utils.result
 
 from . import constants, serializers
 
+# 定数
+USERNAME_LENGTH: Final[int] = 7
+
 # 関数の結果用のResult型の型エイリアス
 CreatePlayerSerializerResult = utils.result.Result[
     serializers.PlayerSerializer, dict
 ]
 CreateAccountResult = utils.result.Result[User, dict]
+
+
+def get_unique_random_username() -> str:
+    """
+    ユニークかつランダムな文字列のusernameを生成する
+    UserModelのusernameとして使用する
+    ランダム文字列は英子文字・英大文字・数字の計62文字の組み合わせ
+
+    Returns:
+        str: ランダム文字列かつ、DBに存在しないusername
+    """
+    while True:
+        random_str: str = get_random_string(length=USERNAME_LENGTH)
+        if not User.objects.filter(username=random_str).exists():
+            break
+    return random_str
 
 
 def _create_user_related_player_serializer(

--- a/backend/pong/accounts/tests/create_account/test_create_account.py
+++ b/backend/pong/accounts/tests/create_account/test_create_account.py
@@ -33,6 +33,9 @@ class CreateAccountTests(TestCase):
             # この関数ではerrorにならない想定
             raise AssertionError(self.mock_user_serializer.errors)
 
+    # -------------------------------------------------------------------------
+    # 正常ケース
+    # -------------------------------------------------------------------------
     def test_create_account_with_valid_user_serializer(self) -> None:
         """
         Userをmodelに設定した有効なUserSerializerを使ってアカウント作成できるかを確認する
@@ -47,3 +50,25 @@ class CreateAccountTests(TestCase):
 
         user: User = create_account_result.unwrap()
         self.assertEqual(user.username, "testuser")
+
+    def test_get_unique_random_username_string(self) -> None:
+        """
+        get_unique_random_username()のユニットテスト
+        文字数と、英数字からなるusernameが生成されていることを確認
+        """
+        random_username: str = create_account.get_unique_random_username()
+
+        self.assertEqual(len(random_username), create_account.USERNAME_LENGTH)
+        self.assertTrue(all(char.isalnum() for char in random_username))
+
+    def test_get_unique_random_username_unique(self) -> None:
+        """
+        get_unique_random_username()のユニットテスト
+        生成されたusernameがユニークであることを軽く確認
+        """
+        for _ in range(5):
+            random_username: str = create_account.get_unique_random_username()
+
+            self.assertFalse(
+                User.objects.filter(username=random_username).exists()
+            )


### PR DESCRIPTION
## タスクやディスカッションのリンク
- #168 

## やったこと
- `User` model 作成時に使う、`username` 生成関数を作成しました
具体的には以下を満たす文字列です
  - 英数字の計 62 種からなる
  - ランダム文字列
  - `username` は重複を許さないため、DB に同じ `username` が存在しないこと
- この関数は `accounts` と `oauth2` の 2 つのアプリから呼ばれる想定です
  この関数により同じルールで作成された `username` を使い、各アプリで各 `UserSerializer` を作成します

## やらないこと
- 実際に各アプリでこの関数を使用すること -> 2 つのアプリから使われる想定の関数なので先にこの関数だけの PR にしています
- [coderabbitの細かめな指摘](https://github.com/42-pong/42-pong/pull/178#pullrequestreview-2534293579) ですが、トランザクション処理はこの関数内でだけ書いても意味がなく、`username` は User Model の方でのユニーク制約もあるため、しないことにしました

## 動作確認
気持ち程度のユニットテストを追加したので、軽く確認で大丈夫だと思います
```sh
make build-up
make exec-be
make unit-test
```

## 特にレビューをお願いしたい箇所
- 関数の実装の確認
- 文字長を 7 文字にしてみましたが、良さそうかどうか (62 ^ 7 = 3,521,614,606,208)

## その他
- while 文で DB に既に存在するかチェックしていますが、滅多にこのランダム文字列は重複しないと思われるので、実際には DB が叩かれる回数は 1 回、たまに 2 回がありえるのか…？くらいだと思います

## 参考リンク
- [get_random_string()](https://github.com/django/django/blob/main/django/utils/crypto.py#L51)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **テスト**
	- ユーザー名生成機能の新しいテストケースを追加
	- テストスイートの構造を改善し、セクションヘッダーを追加
	- ユーザー名の長さと英数字文字の検証を強化

<!-- end of auto-generated comment: release notes by coderabbit.ai -->