### PR TITLE
⚡ ♻️  [accounts] accounts app内のusernameをランダム生成関数に置き換え & リファクタ

### DIFF
--- a/backend/pong/accounts/serializers.py
+++ b/backend/pong/accounts/serializers.py
@@ -59,13 +59,15 @@ class UserSerializer(serializers.ModelSerializer):
     def create(self, validated_data: dict) -> User:
         """
         新規Userを作成する
+        create_user(): emailのnormalize、passwordのhash化などを自動で行う
+
+        Args:
+            validated_data: バリデーション後の全てのuser fieldが含まれるdict
+
+        Returns:
+            User: 新規作成しDBに追加されたUser
         """
-        # todo: usernameはBEが自動生成する
-        user: User = User.objects.create_user(
-            username=validated_data[constants.UserFields.USERNAME],
-            email=validated_data[constants.UserFields.EMAIL],
-            password=validated_data[constants.UserFields.PASSWORD],
-        )
+        user: User = User.objects.create_user(**validated_data)
         return user
 
 

--- a/backend/pong/accounts/serializers.py
+++ b/backend/pong/accounts/serializers.py
@@ -20,39 +20,19 @@ class UserSerializer(serializers.ModelSerializer):
             constants.UserFields.PASSWORD,
         )
         extra_kwargs = {
+            constants.UserFields.EMAIL: {
+                "allow_blank": False,
+                "required": True,
+            },
             constants.UserFields.PASSWORD: {"write_only": True},
         }
-
-    # todo:
-    #  - serializer.errorsに複数のエラーメッセージをセットできそう
-    #  - より詳細なvalidationの実装
-    def _validate_required_fields(
-        self, data: dict, required_fields: list[str]
-    ) -> None:
-        for field in required_fields:
-            # 実装上のミスでdataに存在しないfieldが渡された場合
-            if field not in data:
-                raise AssertionError(
-                    f"{field} is required but not provided in data."
-                )
-            # dataの中のfieldが空の場合
-            if not data.get(field):
-                raise serializers.ValidationError(
-                    {field: "This field is required."}
-                )
 
     # PlayerSerializerのuser_serializer.is_valid()の内部で呼ばれる
     def validate(self, data: dict) -> dict:
         """
-        バリデーションを行う
-        - 必須fieldが空の場合はエラーを発生させる
+        バリデーションを行うvalidate()のオーバーライド
         """
-        required_fields: list[str] = [
-            constants.UserFields.USERNAME,
-            constants.UserFields.EMAIL,
-            constants.UserFields.PASSWORD,
-        ]
-        self._validate_required_fields(data, required_fields)
+        # todo: emailの重複を許可しないバリデーションを追加
         return data
 
     # PlayerSerializerのuser_serializer.save()の内部で呼ばれる

--- a/backend/pong/accounts/tests/integration/test_accounts.py
+++ b/backend/pong/accounts/tests/integration/test_accounts.py
@@ -46,14 +46,18 @@ class AccountsTests(test.APITestCase):
         # passwordは返されない
         self.assertNotIn(PASSWORD, response_user)
 
-        # DBの状態を確認
+        # DBにUser,Playerが1つずつ作成されていることを確認
+        self.assertEqual(models.User.objects.count(), 1)
         self.assertEqual(models.Player.objects.count(), 1)
 
         # emailからplayerを取得できる/例外がraiseされないことを確認
         player: models.Player = models.Player.objects.get(
             user__email="testuser@example.com"
         )
-        self.assertEqual(player.user.email, "testuser@example.com")
+        # playerから取得したランダム文字列usernameのUserが実際にDBに存在するか確認
+        self.assertTrue(
+            models.User.objects.filter(username=player.user.username).exists()
+        )
 
     # -------------------------------------------------------------------------
     # エラーケース
@@ -86,5 +90,6 @@ class AccountsTests(test.APITestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIn(EMAIL, response_error)
 
-        # DBの状態を確認
+        # DBにUser,Playerが作成されていないことを確認
+        self.assertEqual(models.User.objects.count(), 0)
         self.assertEqual(models.Player.objects.count(), 0)

--- a/backend/pong/accounts/tests/integration/test_accounts.py
+++ b/backend/pong/accounts/tests/integration/test_accounts.py
@@ -38,7 +38,13 @@ class AccountsTests(test.APITestCase):
         response: drf_response.Response = self.client.post(
             self.url, account_data, format="json"
         )
-        response_user: dict = response.data[USER]
+        # response.data == {
+        #     "status": "ok",
+        #     "data": {
+        #         "user": {...}
+        #     },
+        # }
+        response_user: dict = response.data["data"][USER]
 
         # responseの内容を確認
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
@@ -77,11 +83,12 @@ class AccountsTests(test.APITestCase):
         response: drf_response.Response = self.client.post(
             self.url, account_data, format="json"
         )
-        response_error: dict = response.data["error"]
+        response_error: dict = response.data["errors"]
 
         # responseの内容を確認
-        # response.data = {
-        #     "error": {
+        # response.data == {
+        #     "status": "error",
+        #     "errors": {
         #         "email": [
         #             ErrorDetail(string="Enter a valid email address.", code="invalid")
         #         ],

--- a/backend/pong/accounts/tests/integration/test_accounts.py
+++ b/backend/pong/accounts/tests/integration/test_accounts.py
@@ -31,7 +31,6 @@ class AccountsTests(test.APITestCase):
         """
         account_data: dict = {
             "user": {
-                USERNAME: "testuser",
                 EMAIL: "testuser@example.com",
                 PASSWORD: "testpassword12345",
             }
@@ -43,31 +42,31 @@ class AccountsTests(test.APITestCase):
 
         # responseの内容を確認
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        self.assertEqual(response_user[USERNAME], "testuser")
         self.assertEqual(response_user[EMAIL], "testuser@example.com")
         # passwordは返されない
         self.assertNotIn(PASSWORD, response_user)
 
         # DBの状態を確認
         self.assertEqual(models.Player.objects.count(), 1)
+
+        # emailからplayerを取得できる/例外がraiseされないことを確認
         player: models.Player = models.Player.objects.get(
-            user__username="testuser"
+            user__email="testuser@example.com"
         )
         self.assertEqual(player.user.email, "testuser@example.com")
 
     # -------------------------------------------------------------------------
     # エラーケース
     # -------------------------------------------------------------------------
-    def test_create_account_with_invalid_data(self) -> None:
+    def test_create_account_with_invalid_email(self) -> None:
         """
-        無効なデータでアカウントを作成するテスト
+        不正なemailの形式でアカウントを作成するテスト
         status 400 が返されることを確認
-        ErrorDetail に username, email が含まれることを確認
+        ErrorDetail に email が含まれることを確認
         """
         account_data: dict = {
             "user": {
-                USERNAME: "",  # 空のusername
-                EMAIL: "invalid-email@none",  # 不正なemail
+                EMAIL: "invalid-email@none",  # 不正なemail形式
                 PASSWORD: "testpassword12345",
             }
         }
@@ -79,16 +78,12 @@ class AccountsTests(test.APITestCase):
         # responseの内容を確認
         # response.data = {
         #     "error": {
-        #         "username": [
-        #             ErrorDetail(string="This field may not be blank.", code="blank")
-        #         ],
         #         "email": [
         #             ErrorDetail(string="Enter a valid email address.", code="invalid")
         #         ],
         #     }
         # }
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertIn(USERNAME, response_error)
         self.assertIn(EMAIL, response_error)
 
         # DBの状態を確認

--- a/backend/pong/accounts/tests/serializers/test_user_serializer.py
+++ b/backend/pong/accounts/tests/serializers/test_user_serializer.py
@@ -147,16 +147,24 @@ class UserSerializerTests(TestCase):
     def test_user_serializer_duplicate_username(self) -> None:
         """
         既に登録されているusernameが渡された場合にエラーになることを確認する
-        実装はしていない。UserModel関連のどこかで自動チェックしてくれている
+        実装はしていない。UserModelのUniqueValidatorで自動チェックしてくれている
         """
-        User.objects.create_user(
-            username=self.user_data[USERNAME],
-            email="non-exist-email@example.com",
-            password="testpassword",
-        )
-        serializer: serializers.UserSerializer = serializers.UserSerializer(
+        # 1人目のUserをDBに保存
+        serializer_1: serializers.UserSerializer = serializers.UserSerializer(
             data=self.user_data
         )
+        serializer_1.is_valid(raise_exception=True)
+        serializer_1.save()
 
-        self.assertFalse(serializer.is_valid())
-        self.assertIn(USERNAME, serializer.errors)
+        # 2人目のUserSerializerを作成
+        user_data_2: dict = {
+            USERNAME: self.user_data[USERNAME],  # 既に登録されているusername
+            EMAIL: "non-exist-email@example.com",
+            PASSWORD: "testpassword",
+        }
+        serializer_2: serializers.UserSerializer = serializers.UserSerializer(
+            data=user_data_2
+        )
+
+        self.assertFalse(serializer_2.is_valid())
+        self.assertIn(USERNAME, serializer_2.errors)

--- a/backend/pong/accounts/tests/serializers/test_user_serializer.py
+++ b/backend/pong/accounts/tests/serializers/test_user_serializer.py
@@ -59,6 +59,42 @@ class UserSerializerTests(TestCase):
     # -------------------------------------------------------------------------
     # エラーケース
     # -------------------------------------------------------------------------
+    def test_user_serializer_none_field_username(self) -> None:
+        """
+        必須フィールド"username"が存在しない場合にエラーになることを確認する
+        """
+        self.user_data.pop(USERNAME)
+        serializer: serializers.UserSerializer = serializers.UserSerializer(
+            data=self.user_data
+        )
+
+        self.assertFalse(serializer.is_valid())
+        self.assertIn(USERNAME, serializer.errors)
+
+    def test_user_serializer_none_field_email(self) -> None:
+        """
+        必須フィールド"email"が存在しない場合にエラーになることを確認する
+        """
+        self.user_data.pop(EMAIL)
+        serializer: serializers.UserSerializer = serializers.UserSerializer(
+            data=self.user_data
+        )
+
+        self.assertFalse(serializer.is_valid())
+        self.assertIn(EMAIL, serializer.errors)
+
+    def test_user_serializer_none_field_password(self) -> None:
+        """
+        必須フィールド"password"が存在しない場合にエラーになることを確認する
+        """
+        self.user_data.pop(PASSWORD)
+        serializer: serializers.UserSerializer = serializers.UserSerializer(
+            data=self.user_data
+        )
+
+        self.assertFalse(serializer.is_valid())
+        self.assertIn(PASSWORD, serializer.errors)
+
     def test_user_serializer_empty_username(self) -> None:
         """
         必須フィールド"username"が空の場合にエラーになることを確認する

--- a/backend/pong/accounts/views.py
+++ b/backend/pong/accounts/views.py
@@ -26,7 +26,6 @@ class AccountCreateView(views.APIView):
                     "Example request",
                     value={
                         constants.PlayerFields.USER: {
-                            constants.UserFields.USERNAME: "username",
                             constants.UserFields.EMAIL: "user@example.com",
                             constants.UserFields.PASSWORD: "password",
                         }
@@ -79,6 +78,10 @@ class AccountCreateView(views.APIView):
 
         # サインアップ専用のUserSerializerを作成
         user_data: dict = request.data.pop(constants.PlayerFields.USER)
+        # usernameのみBEがランダムな文字列をセット
+        user_data[constants.UserFields.USERNAME] = (
+            create_account.get_unique_random_username()
+        )
         user_serializer: serializers.UserSerializer = (
             serializers.UserSerializer(data=user_data)
         )

--- a/backend/pong/accounts/views.py
+++ b/backend/pong/accounts/views.py
@@ -74,7 +74,6 @@ class AccountCreateView(views.APIView):
         requestをSerializerに渡してvalidationを行い、
         有効な場合はPlayerとUserを作成してDBに追加し、作成されたアカウント情報をresponseとして返す
         """
-        # todo: pop()する前にrequestのfieldのvalidationが必要かも
 
         def _create_user_serializer(
             user_data: dict,
@@ -87,7 +86,8 @@ class AccountCreateView(views.APIView):
 
         # サインアップ専用のUserSerializerを作成
         user_serializer: serializers.UserSerializer = _create_user_serializer(
-            request.data.pop(constants.PlayerFields.USER)
+            # popしたいfieldが存在しない場合は空dictを渡し、UserSerializerでエラーになる
+            request.data.pop(constants.PlayerFields.USER, {})
         )
         if not user_serializer.is_valid():
             return response.Response(

--- a/backend/pong/accounts/views.py
+++ b/backend/pong/accounts/views.py
@@ -76,14 +76,18 @@ class AccountCreateView(views.APIView):
         """
         # todo: pop()する前にrequestのfieldのvalidationが必要かも
 
+        def _create_user_serializer(
+            user_data: dict,
+        ) -> serializers.UserSerializer:
+            # usernameのみBEがランダムな文字列をセット
+            user_data[constants.UserFields.USERNAME] = (
+                create_account.get_unique_random_username()
+            )
+            return serializers.UserSerializer(data=user_data)
+
         # サインアップ専用のUserSerializerを作成
-        user_data: dict = request.data.pop(constants.PlayerFields.USER)
-        # usernameのみBEがランダムな文字列をセット
-        user_data[constants.UserFields.USERNAME] = (
-            create_account.get_unique_random_username()
-        )
-        user_serializer: serializers.UserSerializer = (
-            serializers.UserSerializer(data=user_data)
+        user_serializer: serializers.UserSerializer = _create_user_serializer(
+            request.data.pop(constants.PlayerFields.USER)
         )
         if not user_serializer.is_valid():
             return response.Response(


### PR DESCRIPTION
## タスクやディスカッションのリンク
<!-- - URLをここに貼る -->
- #179 
- accounts 全体の流れ : #110 

## やったこと
<!-- - このタスクでやったことはなにか？ -->
- `/api/accounts/, POST` が呼ばれた際に、#178 で作成した `get_unique_random_username()` 関数を使用して、BE がユニークでランダムな文字列を `username` に指定するようにしました
- 併せて、今まで仮に request から`username` も受け取っていましたが、request からは `username` を受け取らないようになりました
- ついでに以下もしてしまいました
  - 関連するテストの修正・リファクタ
  - serializer の実装が不要だった部分のリファクタ
  - `response` 形式を全体で決めたものにする

## やらないこと
<!-- - このタスクでやらないことはなにか？（やらない場合いつやるのか？無ければ「なし」を記述） -->
- テスト内容の分類 (Model に対するテストなのか、serializer に対するテストなのかを分けること)
-> 別のテストの追加・リファクタ PR でします

## 動作確認
<!-- - どのような動作確認を行い、結果はどうだったのか？(適宜スクショ等添付) -->
- テストが通ることを確認
```sh
make build-up
make exec-be
make unit-test
```
- `swagger-ui`(`http://localhost:8000/api/schema/swagger-ui/`) で以下を確認
  - `api/accounts/` の request 入力部分の `username` がなくなったこと
  - request を送ると、response にはランダム文字列の `username` が返ってくること
  - その `username` が DB の `Users` と `Players` に同じ `user_id` で保存されていること

## 特にレビューをお願いしたい箇所
<!-- - 特にチェックをお願いしたいポイントを簡潔に記述する -->
- `api/accounts/` で新規追加した時の挙動が、`username` がランダム文字列になったこと 以外は今まで通り問題なく動くかどうか

## その他
<!-- - 実装上の懸念点、注意点等あれば記載する -->
- 現状、各 app が `get_unique_random_username()` 関数を呼ばないと同じ制約の `usename` を作成できない (カプセル化できていない) 状態だと思っていて、この辺をクラス化して隠蔽できれば良いなと思っているのですが、アドバイスあれば欲しいです
- `response` 形式が全 app で統一になったので、`status`, `ok`, `data`, `error` などの文字列をどこかに定義して使いたいのですが良いディレクトリ / ファイル構成が分からなかったので保留にしています。相談したいです

## 参考リンク
<!-- - 実装に際し参考にした、記事やサイトのリンクを記載する -->
特になし

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
	- メールフィールドの必須性を強化し、空白を許可しないように設定

- **バグ修正**
	- メールフィールドの検証ロジックを改善
	- ユーザー作成プロセスを最適化

- **テスト**
	- ユーザーシリアライザのテストケースを追加
	- 必須フィールドの検証テストを強化
	- 重複ユーザー名のテストを更新

- **リファクタリング**
	- アカウント作成ビューの内部ロジックを改善
	- ユーザーシリアライザの検証メソッドを簡素化
<!-- end of auto-generated comment: release notes by coderabbit.ai -->