### PR TITLE
♻️ [BE, workflow] backend_code_check.yml が不要な時に、job 自体実行されないように統一する

### DIFF
--- a/.github/workflows/backend_code_check.yml
+++ b/.github/workflows/backend_code_check.yml
@@ -2,17 +2,14 @@ name: Backend Code Check
 
 on:
   pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
+    paths:
+      - 'backend/pong/**'
+      - '.github/workflows/backend_code_check.yml'
 
 jobs:
   backend-code-check:
     runs-on: ubuntu-latest  # GitHub Actionsで使用する環境
     timeout-minutes: 30
-    # PR元が 'feature/backend/*' のブランチからの場合にトリガー
-    if: startsWith(github.head_ref, 'feature-backend')
 
     # 環境変数にデフォルト値が入っていないとmypyでエラーになってしまうので、
     # pong/settings.pyで使用する環境変数は事前にここで設定する


### PR DESCRIPTION
## タスクやディスカッションのリンク
<!-- - URLをここに貼る -->
- #198 

## やったこと
<!-- - このタスクでやったことはなにか？ -->
`backend_unit_test.yml` と同じように `paths` で対象を指定しました
これにより、以下のように FE の変更しかないのに actions で skip だけする job が発生していた `Backend Code Check`、 がなくなりました
![image](https://github.com/user-attachments/assets/7f1996b6-20e8-4c13-8d50-3f525610a31c)


## やらないこと
<!-- - このタスクでやらないことはなにか？（やらない場合いつやるのか？無ければ「なし」を記述） -->
やったこと以外

## 動作確認
<!-- - どのような動作確認を行い、結果はどうだったのか？(適宜スクショ等添付) -->
- #201 で frontend だけに変更を加えて、この PR への PR を作成してみたところ、以下のように actions で `Backend Code Check` は動いてなかったです
close すると見れなくなるのでスクショですみません
demo-repository に再現するのは面倒でしてないです…
![image](https://github.com/user-attachments/assets/3573321e-03eb-4993-b47e-817720857313)


## 特にレビューをお願いしたい箇所
<!-- - 特にチェックをお願いしたいポイントを簡潔に記述する -->
`paths` の設定が大丈夫そうかどうか

## その他
<!-- - 実装上の懸念点、注意点等あれば記載する -->
特になし

## 参考リンク
<!-- - 実装に際し参考にした、記事やサイトのリンクを記載する -->
特になし

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- GitHub Actionsワークフローの設定を更新
	- バックエンドコードのチェックトリガー条件を調整
	- 特定のパスへの変更に基づくワークフロー実行の最適化

<!-- end of auto-generated comment: release notes by coderabbit.ai -->