### PR TITLE
⚡ BE の全 app 共通で使うレスポンス形式を定義する

### DIFF
--- a/backend/pong/accounts/tests/integration/test_accounts.py
+++ b/backend/pong/accounts/tests/integration/test_accounts.py
@@ -4,7 +4,7 @@ from django.urls import reverse
 from rest_framework import response as drf_response
 from rest_framework import status, test
 
-from pong.response import response as custom_response
+from pong.custom_response import custom_response
 
 from ... import constants, models
 

--- a/backend/pong/accounts/tests/integration/test_accounts.py
+++ b/backend/pong/accounts/tests/integration/test_accounts.py
@@ -4,12 +4,17 @@ from django.urls import reverse
 from rest_framework import response as drf_response
 from rest_framework import status, test
 
+from pong.response import response as custom_response
+
 from ... import constants, models
 
 USERNAME: Final[str] = constants.UserFields.USERNAME
 EMAIL: Final[str] = constants.UserFields.EMAIL
 PASSWORD: Final[str] = constants.UserFields.PASSWORD
 USER: Final[str] = constants.PlayerFields.USER
+
+DATA: Final[str] = custom_response.DATA
+ERRORS: Final[str] = custom_response.ERRORS
 
 
 # todo: 認証付きのテスト追加？
@@ -30,7 +35,7 @@ class AccountsTests(test.APITestCase):
         status 201, username, email が返されることを確認
         """
         account_data: dict = {
-            "user": {
+            USER: {
                 EMAIL: "testuser@example.com",
                 PASSWORD: "testpassword12345",
             }
@@ -44,7 +49,7 @@ class AccountsTests(test.APITestCase):
         #         "user": {...}
         #     },
         # }
-        response_user: dict = response.data["data"][USER]
+        response_user: dict = response.data[DATA][USER]
 
         # responseの内容を確認
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
@@ -72,10 +77,10 @@ class AccountsTests(test.APITestCase):
         """
         不正なemailの形式でアカウントを作成するテスト
         status 400 が返されることを確認
-        ErrorDetail に email が含まれることを確認
+        errorsにemailが含まれることを確認
         """
         account_data: dict = {
-            "user": {
+            USER: {
                 EMAIL: "invalid-email@none",  # 不正なemail形式
                 PASSWORD: "testpassword12345",
             }
@@ -83,7 +88,7 @@ class AccountsTests(test.APITestCase):
         response: drf_response.Response = self.client.post(
             self.url, account_data, format="json"
         )
-        response_error: dict = response.data["errors"]
+        response_error: dict = response.data[ERRORS]
 
         # responseの内容を確認
         # response.data == {

--- a/backend/pong/accounts/views.py
+++ b/backend/pong/accounts/views.py
@@ -4,10 +4,11 @@ from drf_spectacular import utils
 # todo: IsAuthenticatedが追加されたらAllowAnyは不要かも
 from rest_framework import permissions, request, response, status, views
 
+from pong.response import response as custom_response
+
 from . import constants, create_account, serializers
 
 
-# todo: response形式は全app共通の形式のため、どこかにkey-valueを定義してそれを使用する
 class AccountCreateView(views.APIView):
     """
     新規アカウントを作成するビュー
@@ -98,8 +99,8 @@ class AccountCreateView(views.APIView):
             request.data.pop(constants.PlayerFields.USER, {})
         )
         if not user_serializer.is_valid():
-            return response.Response(
-                {"status": "error", "errors": user_serializer.errors},
+            return custom_response.Response(
+                errors=user_serializer.errors,
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
@@ -111,25 +112,19 @@ class AccountCreateView(views.APIView):
             )
         )
         if create_account_result.is_error:
-            return response.Response(
-                {
-                    "status": "error",
-                    "errors": create_account_result.unwrap_error(),
-                },
+            return custom_response.Response(
+                errors=create_account_result.unwrap_error(),
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
         user: User = create_account_result.unwrap()
-        return response.Response(
-            {
-                "status": "ok",
-                "data": {
-                    constants.PlayerFields.USER: {
-                        constants.UserFields.ID: user.id,
-                        constants.UserFields.USERNAME: user.username,
-                        constants.UserFields.EMAIL: user.email,
-                    }
-                },
+        return custom_response.Response(
+            data={
+                constants.PlayerFields.USER: {
+                    constants.UserFields.ID: user.id,
+                    constants.UserFields.USERNAME: user.username,
+                    constants.UserFields.EMAIL: user.email,
+                }
             },
             status=status.HTTP_201_CREATED,
         )

--- a/backend/pong/accounts/views.py
+++ b/backend/pong/accounts/views.py
@@ -3,7 +3,7 @@ from drf_spectacular import utils
 # todo: IsAuthenticatedが追加されたらAllowAnyは不要かも
 from rest_framework import permissions, request, response, status, views
 
-from pong.response import response as custom_response
+from pong.custom_response import custom_response
 
 from . import constants, create_account, serializers
 
@@ -98,7 +98,7 @@ class AccountCreateView(views.APIView):
             request.data.pop(constants.PlayerFields.USER, {})
         )
         if not user_serializer.is_valid():
-            return custom_response.Response(
+            return custom_response.CustomResponse(
                 errors=user_serializer.errors,
                 status=status.HTTP_400_BAD_REQUEST,
             )
@@ -111,13 +111,13 @@ class AccountCreateView(views.APIView):
             )
         )
         if create_account_result.is_error:
-            return custom_response.Response(
+            return custom_response.CustomResponse(
                 errors=create_account_result.unwrap_error(),
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
         user_serializer_data: dict = create_account_result.unwrap()
-        return custom_response.Response(
+        return custom_response.CustomResponse(
             data={constants.PlayerFields.USER: user_serializer_data},
             status=status.HTTP_201_CREATED,
         )

--- a/backend/pong/pong/custom_response/custom_response.py
+++ b/backend/pong/pong/custom_response/custom_response.py
@@ -14,7 +14,7 @@ class Status:
     ERROR: str = "error"
 
 
-class Response(response.Response):
+class CustomResponse(response.Response):
     """
     全appでレスポンスの形式を統一するためのクラス
 

--- a/backend/pong/pong/custom_response/test_custom_response.py
+++ b/backend/pong/pong/custom_response/test_custom_response.py
@@ -3,7 +3,7 @@ from typing import Final
 from django import test
 from rest_framework import status
 
-from . import response as custom_response
+from . import custom_response
 
 STATUS: Final[str] = custom_response.STATUS
 DATA: Final[str] = custom_response.DATA
@@ -21,7 +21,9 @@ class ResponseTests(test.TestCase):
         """
         引数なしで呼ばれた際に、デフォルトのレスポンスが返されることを確認
         """
-        response: custom_response.Response = custom_response.Response()
+        response: custom_response.CustomResponse = (
+            custom_response.CustomResponse()
+        )
 
         self.assertEqual(response.status, status.HTTP_200_OK)
         self.assertEqual(response.data, {STATUS: STATUS_OK, DATA: {}})
@@ -30,8 +32,10 @@ class ResponseTests(test.TestCase):
         """
         201で呼ばれた際に、成功レスポンスが形式に沿って返されることを確認
         """
-        response: custom_response.Response = custom_response.Response(
-            data={"key": "value"}, status=status.HTTP_201_CREATED
+        response: custom_response.CustomResponse = (
+            custom_response.CustomResponse(
+                data={"key": "value"}, status=status.HTTP_201_CREATED
+            )
         )
 
         self.assertEqual(response.status, status.HTTP_201_CREATED)
@@ -43,9 +47,11 @@ class ResponseTests(test.TestCase):
         """
         400で呼ばれた際に、エラーレスポンスが形式に沿って返されることを確認
         """
-        response: custom_response.Response = custom_response.Response(
-            errors={"key": "value"},
-            status=status.HTTP_400_BAD_REQUEST,
+        response: custom_response.CustomResponse = (
+            custom_response.CustomResponse(
+                errors={"key": "value"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
         )
 
         self.assertEqual(response.status, status.HTTP_400_BAD_REQUEST)
@@ -62,7 +68,7 @@ class ResponseTests(test.TestCase):
         100-599以外のステータスコードが渡された場合に例外が発生することを確認
         """
         with self.assertRaises(ValueError):
-            custom_response.Response(status=99)
+            custom_response.CustomResponse(status=99)
 
         with self.assertRaises(ValueError):
-            custom_response.Response(status=600)
+            custom_response.CustomResponse(status=600)

--- a/backend/pong/pong/response/response.py
+++ b/backend/pong/pong/response/response.py
@@ -1,0 +1,58 @@
+import dataclasses
+from typing import Final
+
+from rest_framework import response
+
+STATUS: Final[str] = "status"
+DATA: Final[str] = "data"
+ERRORS: Final[str] = "errors"
+
+
+@dataclasses.dataclass(frozen=True)
+class Status:
+    OK: str = "ok"
+    ERROR: str = "error"
+
+
+class Response(response.Response):
+    """
+    全appでレスポンスの形式を統一するためのクラス
+
+    Args:
+        data  : 成功時のレスポンスデータ
+        errors: エラー時のエラーメッセージ
+        status: ステータスコード
+
+    レスポンスのJSON形式(self.data):
+        {
+            "status": "ok" | "error",
+            "data": {...},
+            "errors": {...}
+        }
+
+        - status: 必須。300番台までは"ok"、400番台以上は"error"を格納
+        - data  : 成功時のみ、返すデータのdictを格納
+        - errors: エラー時のみ、エラーメッセージのdictを格納
+    """
+
+    # statusのデフォルト値200は継承元を参考
+    # https://github.com/django/django/blob/main/django/http/response.py#L111
+    def __init__(
+        self,
+        data: dict | None = None,
+        errors: dict | None = None,
+        status: int = 200,
+    ):
+        # 内部で100-599番以外のステータスコードは例外を発生させる
+        super().__init__(None, status=status)
+        self.status = status
+        self.data = {}
+
+        if status < 400:
+            # 300番台までの成功レスポンス
+            self.data[STATUS] = Status.OK
+            self.data[DATA] = data if data else {}
+        else:
+            # 400番台以上のエラーレスポンス
+            self.data[STATUS] = Status.ERROR
+            self.data[ERRORS] = errors if errors else {}

--- a/backend/pong/pong/response/test_response.py
+++ b/backend/pong/pong/response/test_response.py
@@ -1,0 +1,68 @@
+from typing import Final
+
+from django import test
+from rest_framework import status
+
+from . import response as custom_response
+
+STATUS: Final[str] = custom_response.STATUS
+DATA: Final[str] = custom_response.DATA
+ERRORS: Final[str] = custom_response.ERRORS
+
+STATUS_OK: Final[str] = custom_response.Status.OK
+STATUS_ERROR: Final[str] = custom_response.Status.ERROR
+
+
+class ResponseTests(test.TestCase):
+    # -------------------------------------------------------------------------
+    # 正常ケース
+    # -------------------------------------------------------------------------
+    def test_200_no_args(self) -> None:
+        """
+        引数なしで呼ばれた際に、デフォルトのレスポンスが返されることを確認
+        """
+        response: custom_response.Response = custom_response.Response()
+
+        self.assertEqual(response.status, status.HTTP_200_OK)
+        self.assertEqual(response.data, {STATUS: STATUS_OK, DATA: {}})
+
+    def test_201_with_data(self) -> None:
+        """
+        201で呼ばれた際に、成功レスポンスが形式に沿って返されることを確認
+        """
+        response: custom_response.Response = custom_response.Response(
+            data={"key": "value"}, status=status.HTTP_201_CREATED
+        )
+
+        self.assertEqual(response.status, status.HTTP_201_CREATED)
+        self.assertEqual(
+            response.data, {STATUS: STATUS_OK, DATA: {"key": "value"}}
+        )
+
+    def test_400_with_errors(self) -> None:
+        """
+        400で呼ばれた際に、エラーレスポンスが形式に沿って返されることを確認
+        """
+        response: custom_response.Response = custom_response.Response(
+            errors={"key": "value"},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+
+        self.assertEqual(response.status, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(
+            response.data,
+            {STATUS: STATUS_ERROR, ERRORS: {"key": "value"}},
+        )
+
+    # -------------------------------------------------------------------------
+    # エラーケース
+    # -------------------------------------------------------------------------
+    def test_invalid_status(self) -> None:
+        """
+        100-599以外のステータスコードが渡された場合に例外が発生することを確認
+        """
+        with self.assertRaises(ValueError):
+            custom_response.Response(status=99)
+
+        with self.assertRaises(ValueError):
+            custom_response.Response(status=600)


### PR DESCRIPTION
## タスクやディスカッションのリンク
<!-- - URLをここに貼る -->
- #190 

## やったこと
<!-- - このタスクでやったことはなにか？ -->
- backend から返すレスポンス形式を共通化するため、専用の `Response` クラスを作成しました
- 簡単なユニットテスト追加
- (別 PR の方が良かったかもですが) `account` app の views のレスポンスを、作成した Response クラスで置き換えました

## やらないこと
<!-- - このタスクでやらないことはなにか？（やらない場合いつやるのか？無ければ「なし」を記述） -->
- `account` app 以外のレスポンスの置き換え

## 動作確認
<!-- - どのような動作確認を行い、結果はどうだったのか？(適宜スクショ等添付) -->
今までの挙動に変更はなしです
追加されたユニットテストが通ることを確認
```sh
make build-up
make exec-be
make unit-test
 または
make unit-test ARG=pong.response
```

## 特にレビューをお願いしたい箇所
<!-- - 特にチェックをお願いしたいポイントを簡潔に記述する -->
全体で使用するクラスのため、分かりづらい箇所や、より良くなる点などあれば教えてください！

## その他
<!-- - 実装上の懸念点、注意点等あれば記載する -->
クラス名について `Response` 以外にするか迷ったのですが、一旦しなかったです
- Django も DRF も `Response` という名前で作ってる
- ファイルが違えばクラス名の重複は気にしないで良いはず
- このクラスを使う際は、ルール的に必ずクラス名の前にファイル名をつける
- view の関数は必ず DRF の `response.Response` を返り値の型ヒントに書くので `response.py` というファイル名だと使う際に DRF と自作のどちらかは `as` で別名をつけることになる。ので分かりやすい名前空間名にできる

のような理由からですが、`Response` 以外のクラス名が良ければ全然変更しても大丈夫です
その場合はファイル名から変えたい気もします… `custom_response.py` の `CustomResponse` class など？

## 参考リンク
<!-- - 実装に際し参考にした、記事やサイトのリンクを記載する -->
- Response class の継承の仕方は DRF の Response の実装を参考にしました
https://github.com/encode/django-rest-framework/blob/master/rest_framework/response.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
	- カスタムレスポンスハンドリングシステムを導入
	- APIレスポンスの標準化と一貫性を強化

- **バグ修正**
	- レスポンス構造を改善し、エラーと成功時のデータ形式を統一

- **テスト**
	- カスタムレスポンスクラスの包括的なテストケースを追加
	- 様々なシナリオでのレスポンス動作を検証

- **リファクタリング**
	- レスポンス処理のコードを整理
	- 一貫性のあるAPIレスポンス形式を実装
<!-- end of auto-generated comment: release notes by coderabbit.ai -->