### PR TITLE
⚡ [account] create_account() が serializer.data を返すように変更

### DIFF
--- a/backend/pong/accounts/create_account.py
+++ b/backend/pong/accounts/create_account.py
@@ -14,7 +14,7 @@ USERNAME_LENGTH: Final[int] = 7
 # 関数の結果用のResult型の型エイリアス
 SaveUserResult = utils.result.Result[User, dict]
 SavePlayerResult = utils.result.Result[models.Player, dict]
-CreateAccountResult = utils.result.Result[User, dict]
+CreateAccountResult = utils.result.Result[dict, dict]
 
 
 def get_unique_random_username() -> str:
@@ -138,4 +138,4 @@ def create_account(
         return CreateAccountResult.error(save_player_result.unwrap_error())
     # save_player_result.unwrap()でPlayerを取得できるが、使わないため呼ばない
 
-    return CreateAccountResult.ok(user)
+    return CreateAccountResult.ok(user_serializer.data)

--- a/backend/pong/accounts/tests/create_account/test_create_account.py
+++ b/backend/pong/accounts/tests/create_account/test_create_account.py
@@ -48,8 +48,8 @@ class CreateAccountTests(TestCase):
         )
         self.assertEqual(create_account_result.is_ok, True)
 
-        user: User = create_account_result.unwrap()
-        self.assertEqual(user.username, "testuser")
+        user_serializer_data: dict = create_account_result.unwrap()
+        self.assertEqual(user_serializer_data["username"], "testuser")
 
     def test_get_unique_random_username_string(self) -> None:
         """

--- a/backend/pong/accounts/views.py
+++ b/backend/pong/accounts/views.py
@@ -1,4 +1,3 @@
-from django.contrib.auth.models import User
 from drf_spectacular import utils
 
 # todo: IsAuthenticatedが追加されたらAllowAnyは不要かも
@@ -119,17 +118,11 @@ class AccountCreateView(views.APIView):
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
-        user: User = create_account_result.unwrap()
+        user_serializer_data: dict = create_account_result.unwrap()
         return response.Response(
             {
                 "status": "ok",
-                "data": {
-                    constants.PlayerFields.USER: {
-                        constants.UserFields.ID: user.id,
-                        constants.UserFields.USERNAME: user.username,
-                        constants.UserFields.EMAIL: user.email,
-                    }
-                },
+                "data": {constants.PlayerFields.USER: user_serializer_data},
             },
             status=status.HTTP_201_CREATED,
         )


### PR DESCRIPTION
## タスクやディスカッションのリンク
<!-- - URLをここに貼る -->
- #199 

## やったこと
<!-- - このタスクでやったことはなにか？ -->
`create_account()` から `serializer.data` を返すように変更し、その `serializer.data` を `Response` にそのまま使うようにしました
`serializer.data` の本来の使い方ができていなかったのを修正できたかと思います

## やらないこと
<!-- - このタスクでやらないことはなにか？（やらない場合いつやるのか？無ければ「なし」を記述） -->
上記以外

## 動作確認
<!-- - どのような動作確認を行い、結果はどうだったのか？(適宜スクショ等添付) -->
挙動に変更なしです
```sh
make build-up
make exec-be
make unit-test
```

## 特にレビューをお願いしたい箇所
<!-- - 特にチェックをお願いしたいポイントを簡潔に記述する -->
実装内容・動作確認

## その他
<!-- - 実装上の懸念点、注意点等あれば記載する -->
- `oauth2` app の方も `Response` には `serializer.data` を使うように変更していただければと思います
- コミットメッセージにも書いたのですが、今は `create_account()` が  `user` の方の `serializer.data` のみ返していますが、本当は作成されたものは全部返した方が良いのかもしれないです (`player` の `serializer.data` も)

## 参考リンク
<!-- - 実装に際し参考にした、記事やサイトのリンクを記載する -->
特になし

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- アカウント作成プロセスのデータ構造を更新
	- シリアライズされたユーザーデータを返すように変更

- **バグ修正**
	- アカウント作成時のレスポンスデータの処理を最適化

- **リファクタリング**
	- ユーザーデータの取得と返却方法を改善
	- レスポンス構築のロジックを簡素化

<!-- end of auto-generated comment: release notes by coderabbit.ai -->