### PR TITLE
⚡ ログインページを配置

### DIFF
--- a/frontend/pong/js/components/auth/LoginContainer.js
+++ b/frontend/pong/js/components/auth/LoginContainer.js
@@ -1,3 +1,5 @@
+import { Paths } from "../../constants/Paths";
+import { PongEvents } from "../../constants/PongEvents";
 import { Component } from "../../core/Component";
 
 //ユーザーが入力するID、PWを保持する箱を入れる
@@ -67,6 +69,12 @@ export class LoginContainer extends Component {
     this.#container = container;
     this.#title = title;
     this.#form = form;
+
+    // TODO: "submit" ハンドリングの更新
+    this._attachEventListener("submit", (event) => {
+      event.preventDefault();
+      this.dispatchEvent(PongEvents.UPDATE_ROUTER.create(Paths.HOME));
+    });
   }
 
   _render() {

--- a/frontend/pong/js/components/auth/LoginContainer.js
+++ b/frontend/pong/js/components/auth/LoginContainer.js
@@ -1,0 +1,135 @@
+import { Component } from "../../core/Component";
+
+//ユーザーが入力するID、PWを保持する箱を入れる
+//サイインボタンを押した後の処理
+//フロントエンドのIDとPWバリデーション
+//BEのエンドポイントにIDとPWを送った後のresponse処理
+
+export class LoginContainer extends Component {
+  #container;
+  #title;
+  #form;
+
+  _onConnect() {
+    //コンテナ要素を作成
+    const container = document.createElement("div");
+    container.className = "form-container";
+
+    //タイトル要素を作成
+    const title = document.createElement("h1");
+    title.textContent = "Pong";
+
+    //フォーム要素を作成
+    const form = document.createElement("form");
+    form.id = "login-form";
+
+    //メール入力フィールドを作成
+    const emailInput = document.createElement("input");
+    emailInput.type = "text";
+    emailInput.name = "email";
+    emailInput.placeholder = "E-mail";
+    emailInput.required = true;
+
+    // パスワード入力フィールドを作成
+    const passwordInput = document.createElement("input");
+    passwordInput.type = "password";
+    passwordInput.name = "password";
+    passwordInput.placeholder = "Password";
+    passwordInput.required = true;
+
+    // サインインボタンを作成
+    const submitButton = document.createElement("button");
+    submitButton.type = "submit";
+    submitButton.textContent = "サインイン";
+
+    // ゲストボタン作成
+    const guestButton = document.createElement("button");
+    guestButton.type = "button";
+    guestButton.textContent = "ゲストとして";
+
+    // 42 OAuth2.0ボタン作成
+    const oauth2Button = document.createElement("button");
+    oauth2Button.type = "button";
+    oauth2Button.textContent = "42 OAuth 2.0";
+
+    // サインアップボタン作成
+    const signupButton = document.createElement("button");
+    signupButton.type = "button";
+    signupButton.textContent = "サインアップ";
+
+    form.appendChild(emailInput);
+    form.appendChild(passwordInput);
+    form.appendChild(submitButton);
+    form.appendChild(guestButton);
+    form.appendChild(oauth2Button);
+    form.appendChild(signupButton);
+
+    this.#container = container;
+    this.#title = title;
+    this.#form = form;
+  }
+
+  _render() {
+    // コンテナにタイトルとフォームを追加
+    this.#container.appendChild(this.#title);
+    this.#container.appendChild(this.#form);
+
+    // コンテナをカスタム要素に追加
+    this.appendChild(this.#container);
+
+    // TODO 各ボタンの条件分岐でAPIエンドポイントにフェッチ(以下からのコードはBEのエントポイントと連携するため、レビューしない)
+    // "api/signin/"　へfetchする
+    // this.#form.addEventListener("submit", async (event) => {
+    //   event.preventDefault();
+    //   const email = this.#form.elements.email.value;
+    //   const password = this.#form.elements.password.value;
+    //   console.log("Email", email);
+    //   console.log("Password", password);
+
+    //   try {
+    //     const response = await fetch(
+    //       "http://localhost:8000/api/signin/",
+    //       {
+    //         method: "POST",
+    //         headers: {
+    //           "Content-Type": "application/json",
+    //         },
+    //         body: JSON.stringify({ email, password }),
+    //       },
+    //     );
+
+    //     if (!response.ok) {
+    //       throw new Error("Network response was not ok");
+    //     }
+
+    //     const data = await response.json();
+    //     console.log("Success:", data);
+    //     // ここで成功時の処理を追加できます
+    //   } catch (error) {
+    //     console.error("Error:", error);
+    //     // ここでエラーハンドリングを追加できます
+    //   }
+    // });
+
+    // "api/oauth2/authorize/”　へfetchする
+    // this.#form.addEventListener("42oauth", async (event) => {
+    //   event.preventDefault();
+    //   try {
+    //     const response = await fetch(
+    //       "http://localhost:8000/api/oauth2/authorize/",
+    //       {
+    //         method: "GET",
+    //       },
+    //     );
+    //     if (!response.ok) {
+    //       throw new Error("Oauth2 response was not ok");
+    //     }
+
+    //     const data = await response.json();
+    //     console.log("Success", data);
+    //   } catch (error) {
+    //     console.error("Error:", error);
+    //   }
+    // });
+  }
+}

--- a/frontend/pong/js/components/index.js
+++ b/frontend/pong/js/components/index.js
@@ -1,9 +1,11 @@
+import { LoginContainer } from "./auth/LoginContainer";
 import { MainNav } from "./navs/MainNav";
 import { ChatView } from "./views/ChatView";
 import { HomeView } from "./views/HomeView";
 import { LoginView } from "./views/LoginView";
 import { MainView } from "./views/MainView";
 
+customElements.define("login-container", LoginContainer, {});
 customElements.define("main-nav", MainNav, {});
 customElements.define("chat-view", ChatView, {});
 customElements.define("home-view", HomeView, {});

--- a/frontend/pong/js/components/views/LoginView.js
+++ b/frontend/pong/js/components/views/LoginView.js
@@ -1,135 +1,14 @@
 import { View } from "../../core/View";
-
-//ユーザーが入力するID、PWを保持する箱を入れる
-//サイインボタンを押した後の処理
-//フロントエンドのIDとPWバリデーション
-//BEのエンドポイントにIDとPWを送った後のresponse処理
+import { LoginContainer } from "../auth/LoginContainer";
 
 export class LoginView extends View {
-  #container;
-  #title;
-  #form;
+  #main;
 
   _onConnect() {
-    //コンテナ要素を作成
-    const container = document.createElement("div");
-    container.className = "form-container";
-
-    //タイトル要素を作成
-    const title = document.createElement("h1");
-    title.textContent = "Pong";
-
-    //フォーム要素を作成
-    const form = document.createElement("form");
-    form.id = "login-form";
-
-    //メール入力フィールドを作成
-    const emailInput = document.createElement("input");
-    emailInput.type = "text";
-    emailInput.name = "email";
-    emailInput.placeholder = "E-mail";
-    emailInput.required = true;
-
-    // パスワード入力フィールドを作成
-    const passwordInput = document.createElement("input");
-    passwordInput.type = "password";
-    passwordInput.name = "password";
-    passwordInput.placeholder = "Password";
-    passwordInput.required = true;
-
-    // サインインボタンを作成
-    const submitButton = document.createElement("button");
-    submitButton.type = "submit";
-    submitButton.textContent = "サインイン";
-
-    // ゲストボタン作成
-    const guestButton = document.createElement("button");
-    guestButton.type = "button";
-    guestButton.textContent = "ゲストとして";
-
-    // 42 OAuth2.0ボタン作成
-    const oauth2Button = document.createElement("button");
-    oauth2Button.type = "button";
-    oauth2Button.textContent = "42 OAuth 2.0";
-
-    // サインアップボタン作成
-    const signupButton = document.createElement("button");
-    signupButton.type = "button";
-    signupButton.textContent = "サインアップ";
-
-    form.appendChild(emailInput);
-    form.appendChild(passwordInput);
-    form.appendChild(submitButton);
-    form.appendChild(guestButton);
-    form.appendChild(oauth2Button);
-    form.appendChild(signupButton);
-
-    this.#container = container;
-    this.#title = title;
-    this.#form = form;
+    this.#main = new LoginContainer();
   }
 
   _render() {
-    // コンテナにタイトルとフォームを追加
-    this.#container.appendChild(this.#title);
-    this.#container.appendChild(this.#form);
-
-    // コンテナをカスタム要素に追加
-    this.appendChild(this.#container);
-
-    // TODO 各ボタンの条件分岐でAPIエンドポイントにフェッチ(以下からのコードはBEのエントポイントと連携するため、レビューしない)
-    // "api/signin/"　へfetchする
-    // this.#form.addEventListener("submit", async (event) => {
-    //   event.preventDefault();
-    //   const email = this.#form.elements.email.value;
-    //   const password = this.#form.elements.password.value;
-    //   console.log("Email", email);
-    //   console.log("Password", password);
-
-    //   try {
-    //     const response = await fetch(
-    //       "http://localhost:8000/api/signin/",
-    //       {
-    //         method: "POST",
-    //         headers: {
-    //           "Content-Type": "application/json",
-    //         },
-    //         body: JSON.stringify({ email, password }),
-    //       },
-    //     );
-
-    //     if (!response.ok) {
-    //       throw new Error("Network response was not ok");
-    //     }
-
-    //     const data = await response.json();
-    //     console.log("Success:", data);
-    //     // ここで成功時の処理を追加できます
-    //   } catch (error) {
-    //     console.error("Error:", error);
-    //     // ここでエラーハンドリングを追加できます
-    //   }
-    // });
-
-    // "api/oauth2/authorize/”　へfetchする
-    // this.#form.addEventListener("42oauth", async (event) => {
-    //   event.preventDefault();
-    //   try {
-    //     const response = await fetch(
-    //       "http://localhost:8000/api/oauth2/authorize/",
-    //       {
-    //         method: "GET",
-    //       },
-    //     );
-    //     if (!response.ok) {
-    //       throw new Error("Oauth2 response was not ok");
-    //     }
-
-    //     const data = await response.json();
-    //     console.log("Success", data);
-    //   } catch (error) {
-    //     console.error("Error:", error);
-    //   }
-    // });
+    this.appendChild(this.#main);
   }
 }

--- a/frontend/pong/js/constants/Paths.js
+++ b/frontend/pong/js/constants/Paths.js
@@ -1,4 +1,5 @@
 export const Paths = Object.freeze({
+  LOGIN: "/login",
   HOME: "/",
   CHAT: "/chat",
 });

--- a/frontend/pong/js/routers/appRouter.js
+++ b/frontend/pong/js/routers/appRouter.js
@@ -1,3 +1,4 @@
+import { LoginView } from "../components/views/LoginView";
 import { MainView } from "../components/views/MainView";
 import { Paths } from "../constants/Paths";
 import { Route } from "../core/Route";
@@ -5,6 +6,7 @@ import { Router } from "../core/Router";
 
 export const appRouter = (target) => {
   const routes = {
+    [Paths.LOGIN]: Route.defaultRoute(LoginView),
     [Paths.HOME]: Route.createRoute(MainView, MainView.Paths.HOME),
     [Paths.CHAT]: Route.createRoute(MainView, MainView.Paths.CHAT),
   };


### PR DESCRIPTION
## タスクやディスカッションのリンク
特になし

## やったこと
`/login` にログインページを配置

## やらないこと
`LoginView` から `LoginContainer` に中身が移動しただけで、中身の変更は行っていません。

## 動作確認
- `cd frontend/pong && npm install && npm run dev`
- `http://localhost:5173/login` より、ログインページが表示されることを確認

## 特にレビューをお願いしたい箇所
一旦 `LoginContainer` という命名で中身を切り出して、`LoginView` の中に `LoginContainer` を追加しています。

## その他
特になし

## 参考リンク
特になし


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- ログインコンテナコンポーネントを追加
	- ログインページ用の新しいルートを導入

- **ルーティング**
	- `/login` パスを追加
	- ログインビューのルーティングを実装

- **コンポーネント**
	- ログインフォームを専用のコンテナコンポーネントに移行
	- ログイン画面のUIを再構築

<!-- end of auto-generated comment: release notes by coderabbit.ai -->