### PR TITLE
⚡ マッチしないパスのハンドリング

### DIFF
--- a/frontend/pong/js/components/index.js
+++ b/frontend/pong/js/components/index.js
@@ -3,9 +3,11 @@ import { ChatView } from "./views/ChatView";
 import { HomeView } from "./views/HomeView";
 import { LoginView } from "./views/LoginView";
 import { MainView } from "./views/MainView";
+import { NotFoundView } from "./views/NotFoundView";
 
 customElements.define("main-nav", MainNav, {});
 customElements.define("chat-view", ChatView, {});
 customElements.define("home-view", HomeView, {});
 customElements.define("login-view", LoginView, {});
 customElements.define("main-view", MainView, {});
+customElements.define("not-found-view", NotFoundView, {});

--- a/frontend/pong/js/components/views/MainView.js
+++ b/frontend/pong/js/components/views/MainView.js
@@ -11,6 +11,7 @@ export class MainView extends View {
   static Paths = Object.freeze({
     HOME: "/",
     CHAT: "/chat",
+    NOT_FOUND: "/not-found",
   });
 
   _onConnect() {

--- a/frontend/pong/js/components/views/NotFoundView.js
+++ b/frontend/pong/js/components/views/NotFoundView.js
@@ -1,0 +1,9 @@
+import { View } from "../../core/View";
+
+export class NotFoundView extends View {
+  _render() {
+    const title = document.createElement("h2");
+    title.textContent = "Not Found View";
+    this.appendChild(title);
+  }
+}

--- a/frontend/pong/js/core/Route.js
+++ b/frontend/pong/js/core/Route.js
@@ -22,8 +22,4 @@ export class Route {
   static defaultRoute(View) {
     return Route.createRoute(View, View._defaultPath);
   }
-
-  static defaultRoutes(View) {
-    return { [View._defaultPath]: Route.defaultRoute(View) };
-  }
 }

--- a/frontend/pong/js/core/Router.js
+++ b/frontend/pong/js/core/Router.js
@@ -4,20 +4,19 @@ export class Router {
   #target;
   #view;
   #routes;
-  #DefaultView;
+  #defaultRoute;
 
-  constructor(target, DefaultView, routes = {}) {
+  constructor(target, defaultRoute, routes = {}) {
     this.#target = target;
 
     this.#view = null;
 
-    this.#routes = Route.defaultRoutes(DefaultView);
-    Object.assign(this.#routes, routes);
+    this.#routes = routes;
 
-    this.#DefaultView = DefaultView;
+    this.#defaultRoute = defaultRoute;
   }
 
-  update(path = this.#DefaultView._defaultPath) {
+  update(path) {
     const route = this.#findRoute(path);
     const isUpdated = this.#render(route);
     return isUpdated;
@@ -25,7 +24,7 @@ export class Router {
 
   #findRoute(path) {
     if (path && this.#routes[path]) return this.#routes[path];
-    return Route.defaultRoute(this.#DefaultView);
+    return this.#defaultRoute;
   }
 
   #mountView() {

--- a/frontend/pong/js/core/Router.js
+++ b/frontend/pong/js/core/Router.js
@@ -25,7 +25,7 @@ export class Router {
 
   #findRoute(path) {
     if (path && this.#routes[path]) return this.#routes[path];
-    return Route.createRoute(this.#DefaultView, path);
+    return Route.defaultRoute(this.#DefaultView);
   }
 
   #mountView() {

--- a/frontend/pong/js/core/Router.js
+++ b/frontend/pong/js/core/Router.js
@@ -25,7 +25,7 @@ export class Router {
 
   #findRoute(path) {
     if (path && this.#routes[path]) return this.#routes[path];
-    return Route.defaultRoute(this.#DefaultView);
+    return Route.createRoute(this.#DefaultView, path);
   }
 
   #mountView() {

--- a/frontend/pong/js/routers/appRouter.js
+++ b/frontend/pong/js/routers/appRouter.js
@@ -10,7 +10,7 @@ export const appRouter = (target) => {
   };
   const defaultRoute = Route.createRoute(
     MainView,
-    MainView.Paths.HOME,
+    MainView.Paths.NOT_FOUND,
   );
   return new Router(target, defaultRoute, routes);
 };

--- a/frontend/pong/js/routers/appRouter.js
+++ b/frontend/pong/js/routers/appRouter.js
@@ -8,5 +8,9 @@ export const appRouter = (target) => {
     [Paths.HOME]: Route.createRoute(MainView, MainView.Paths.HOME),
     [Paths.CHAT]: Route.createRoute(MainView, MainView.Paths.CHAT),
   };
-  return new Router(target, MainView, routes);
+  const defaultRoute = Route.createRoute(
+    MainView,
+    MainView.Paths.HOME,
+  );
+  return new Router(target, defaultRoute, routes);
 };

--- a/frontend/pong/js/routers/mainRouter.js
+++ b/frontend/pong/js/routers/mainRouter.js
@@ -1,6 +1,7 @@
 import { ChatView } from "../components/views/ChatView";
 import { HomeView } from "../components/views/HomeView";
 import { MainView } from "../components/views/MainView";
+import { NotFoundView } from "../components/views/NotFoundView";
 import { Route } from "../core/Route";
 import { Router } from "../core/Router";
 
@@ -9,5 +10,5 @@ export const mainRouter = (target) => {
     [MainView.Paths.HOME]: Route.defaultRoute(HomeView),
     [MainView.Paths.CHAT]: Route.defaultRoute(ChatView),
   };
-  return new Router(target, HomeView, routes);
+  return new Router(target, NotFoundView, routes);
 };

--- a/frontend/pong/js/routers/mainRouter.js
+++ b/frontend/pong/js/routers/mainRouter.js
@@ -9,6 +9,7 @@ export const mainRouter = (target) => {
   const routes = {
     [MainView.Paths.HOME]: Route.defaultRoute(HomeView),
     [MainView.Paths.CHAT]: Route.defaultRoute(ChatView),
+    [MainView.Paths.NOT_FOUND]: Route.defaultRoute(NotFoundView),
   };
   const defaultRoute = Route.defaultRoute(NotFoundView);
   return new Router(target, defaultRoute, routes);

--- a/frontend/pong/js/routers/mainRouter.js
+++ b/frontend/pong/js/routers/mainRouter.js
@@ -10,5 +10,6 @@ export const mainRouter = (target) => {
     [MainView.Paths.HOME]: Route.defaultRoute(HomeView),
     [MainView.Paths.CHAT]: Route.defaultRoute(ChatView),
   };
-  return new Router(target, NotFoundView, routes);
+  const defaultRoute = Route.defaultRoute(NotFoundView);
+  return new Router(target, defaultRoute, routes);
 };


### PR DESCRIPTION
## タスクやディスカッションのリンク
#195 

## やったこと
ルーティングを行う際、用意していないパスへのリクエストを `NotFoundView` に流れるように対応

## やらないこと
実際の画面の構成は行っていなく、`NotFoundView` というタイトルを載せただけです。

## 動作確認
- `cd frontend/pong && npm install && npm run dev`
- URL を `http://localhost:5173/no-exist-path` などにして、`Not Found View` が表示されることを確認

## 特にレビューをお願いしたい箇所
特になし

## その他
特になし

## 参考リンク
一個目のコミットは https://github.com/42-pong/42-pong/pull/193#discussion_r1924719836 よりこの PR に含めました。
→ 良くない修正コミットだったため、取り消しコミットをかけています。(https://github.com/42-pong/42-pong/pull/208#discussion_r1928284601)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **新機能**
	- 404ページ（見つからないページ）のサポートを追加
	- ルーティング時に存在しないページにアクセスした際の表示を実装

- **改善**
	- アプリケーションの404エラーハンドリングを強化
	- デフォルトのルーティング動作を更新
	- ルーティングに関するロジックの調整
<!-- end of auto-generated comment: release notes by coderabbit.ai -->