### PR TITLE
🌱 Bootstrap を導入し、ナビゲーションバーに適用

### DIFF
--- a/frontend/pong/index.html
+++ b/frontend/pong/index.html
@@ -5,9 +5,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>42-pong</title>
     <link rel="stylesheet" href="css/style.css">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-9ndCyUaIbzAi2FUVXJi0CjmCapSmO7SnpJef0486qhLnuZ2cdeRhO02iuK6FUUVM" crossorigin="anonymous">
   </head>
   <body>
     <div id="app"></div>
     <script type="module" src="js/main.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js" integrity="sha384-geWF76RCwLtnZ8qwWowPQNguL3RmwHVBC9FhGdlKrxdiJJigb/j/68SIy3Te4Bkz" crossorigin="anonymous"></script>
   </body>
 </html>

--- a/frontend/pong/js/bootstrap/components/navbar.js
+++ b/frontend/pong/js/bootstrap/components/navbar.js
@@ -1,13 +1,15 @@
+import { setClassNames } from "../../utils/elements/setClassNames";
+
 const setNavbarExpand = (element) => {
-  element.classList.add("navbar", "navbar-expand");
+  return setClassNames(element, "navbar", "navbar-expand");
 };
 
 const setNavbarBrand = (element) => {
-  element.classList.add("navbar-brand");
+  return setClassNames(element, "navbar-brand");
 };
 
 const setNavbarNav = (element) => {
-  element.classList.add("navbar-nav");
+  return setClassNames(element, "navbar-nav");
 };
 
 export const BootstrapNavbar = {

--- a/frontend/pong/js/bootstrap/components/navbar.js
+++ b/frontend/pong/js/bootstrap/components/navbar.js
@@ -1,0 +1,17 @@
+const setNavbarExpand = (element) => {
+  element.classList.add("navbar", "navbar-expand");
+};
+
+const setNavbarBrand = (element) => {
+  element.classList.add("navbar-brand");
+};
+
+const setNavbarNav = (element) => {
+  element.classList.add("navbar-nav");
+};
+
+export const BootstrapNavbar = {
+  setNavbarExpand,
+  setNavbarBrand,
+  setNavbarNav,
+};

--- a/frontend/pong/js/bootstrap/components/navsTabs.js
+++ b/frontend/pong/js/bootstrap/components/navsTabs.js
@@ -1,0 +1,17 @@
+const setNav = (element) => {
+  element.classList.add("nav");
+};
+
+const setNavItem = (element) => {
+  element.classList.add("nav-item");
+};
+
+const setNavLink = (element) => {
+  element.classList.add("nav-link");
+};
+
+export const BootstrapNavsTabs = {
+  setNav,
+  setNavItem,
+  setNavLink,
+};

--- a/frontend/pong/js/bootstrap/components/navsTabs.js
+++ b/frontend/pong/js/bootstrap/components/navsTabs.js
@@ -1,13 +1,15 @@
+import { setClassNames } from "../../utils/elements/setClassNames";
+
 const setNav = (element) => {
-  element.classList.add("nav");
+  return setClassNames(element, "nav");
 };
 
 const setNavItem = (element) => {
-  element.classList.add("nav-item");
+  return setClassNames(element, "nav-item");
 };
 
 const setNavLink = (element) => {
-  element.classList.add("nav-link");
+  return setClassNames(element, "nav-link");
 };
 
 export const BootstrapNavsTabs = {

--- a/frontend/pong/js/bootstrap/layout/containers.js
+++ b/frontend/pong/js/bootstrap/layout/containers.js
@@ -1,0 +1,7 @@
+const setFluid = (containerElement) => {
+  containerElement.classList.add("container-fluid");
+};
+
+export const BootstrapContainers = {
+  setFluid,
+};

--- a/frontend/pong/js/bootstrap/layout/containers.js
+++ b/frontend/pong/js/bootstrap/layout/containers.js
@@ -1,5 +1,7 @@
+import { setClassNames } from "../../utils/elements/setClassNames";
+
 const setFluid = (containerElement) => {
-  containerElement.classList.add("container-fluid");
+  return setClassNames(containerElement, "container-fluid");
 };
 
 export const BootstrapContainers = {

--- a/frontend/pong/js/components/index.js
+++ b/frontend/pong/js/components/index.js
@@ -1,5 +1,5 @@
 import { LoginContainer } from "./auth/LoginContainer";
-import { MainNav } from "./navs/MainNav";
+import { MainNavbar } from "./navigation/MainNavbar";
 import { ChatView } from "./views/ChatView";
 import { FriendsView } from "./views/FriendsView";
 import { HomeView } from "./views/HomeView";
@@ -11,7 +11,7 @@ import { TournamentsView } from "./views/TournamentsView";
 import { UsersView } from "./views/UsersView";
 
 customElements.define("login-container", LoginContainer, {});
-customElements.define("main-nav", MainNav, {});
+customElements.define("main-navbar", MainNavbar, {});
 customElements.define("chat-view", ChatView, {});
 customElements.define("friends-view", FriendsView, {});
 customElements.define("home-view", HomeView, {});

--- a/frontend/pong/js/components/navigation/MainNavbar.js
+++ b/frontend/pong/js/components/navigation/MainNavbar.js
@@ -3,8 +3,8 @@ import { PongEvents } from "../../constants/PongEvents";
 import { Component } from "../../core/Component";
 import { createDefaultNavbar } from "../../utils/elements/nav/createDefaultNavbar";
 
-export class MainNav extends Component {
-  #nav;
+export class MainNavbar extends Component {
+  #navbar;
 
   static links = Object.freeze([
     { name: "ホーム", path: Paths.HOME },
@@ -15,7 +15,7 @@ export class MainNav extends Component {
   ]);
 
   _onConnect() {
-    this.#nav = createDefaultNavbar(MainNav.links);
+    this.#navbar = createDefaultNavbar(MainNavbar.links);
 
     this._attachEventListener("click", (event) => {
       event.preventDefault();
@@ -29,6 +29,6 @@ export class MainNav extends Component {
   }
 
   _render() {
-    this.appendChild(this.#nav);
+    this.appendChild(this.#navbar);
   }
 }

--- a/frontend/pong/js/components/navs/MainNav.js
+++ b/frontend/pong/js/components/navs/MainNav.js
@@ -1,6 +1,7 @@
 import { Paths } from "../../constants/Paths";
 import { PongEvents } from "../../constants/PongEvents";
 import { Component } from "../../core/Component";
+import { createElement } from "../../utils/elements/createElement";
 
 export class MainNav extends Component {
   #nav;
@@ -14,19 +15,9 @@ export class MainNav extends Component {
   ]);
 
   _onConnect() {
-    const ul = document.createElement("ul");
-    for (const link of MainNav.links) {
-      const anchor = document.createElement("a");
-      anchor.textContent = link.name;
-      anchor.href = link.path;
+    const ul = getNavItemsList(MainNav.links);
 
-      const li = document.createElement("li");
-      li.appendChild(anchor);
-
-      ul.appendChild(li);
-    }
-
-    this.#nav = document.createElement("nav");
+    this.#nav = createElement("nav");
     // TODO: [DELETE] 一時的なスタイル指定
     this.#nav.innerHTML += `
     <style>
@@ -61,3 +52,25 @@ export class MainNav extends Component {
     this.appendChild(this.#nav);
   }
 }
+
+const getNavItemsList = (links) => {
+  const ul = createElement("ul");
+
+  for (const link of MainNav.links) {
+    const anchor = createElement(
+      "a",
+      {
+        textContent: link.name,
+      },
+      {
+        href: link.path,
+      },
+    );
+
+    const li = createElement("li");
+    li.appendChild(anchor);
+
+    ul.appendChild(li);
+  }
+  return ul;
+};

--- a/frontend/pong/js/components/navs/MainNav.js
+++ b/frontend/pong/js/components/navs/MainNav.js
@@ -1,7 +1,7 @@
 import { Paths } from "../../constants/Paths";
 import { PongEvents } from "../../constants/PongEvents";
 import { Component } from "../../core/Component";
-import { createElement } from "../../utils/elements/createElement";
+import { createDefaultNavbar } from "../../utils/elements/nav/createDefaultNavbar";
 
 export class MainNav extends Component {
   #nav;
@@ -15,27 +15,7 @@ export class MainNav extends Component {
   ]);
 
   _onConnect() {
-    const ul = getNavItemsList(MainNav.links);
-
-    this.#nav = createElement("nav");
-    // TODO: [DELETE] 一時的なスタイル指定
-    this.#nav.innerHTML += `
-    <style>
-      nav {
-        border-top: 1px solid black;
-        border-bottom: 1px solid black;
-      }
-      nav ul{
-        display: flex;
-        justify-content: flex-start;
-        align-items: center;
-      }
-      nav ul li{
-        list-style: none;
-        margin: 5px;
-      }
-    </style>`;
-    this.#nav.appendChild(ul);
+    this.#nav = createDefaultNavbar(MainNav.links);
 
     this._attachEventListener("click", (event) => {
       event.preventDefault();
@@ -52,25 +32,3 @@ export class MainNav extends Component {
     this.appendChild(this.#nav);
   }
 }
-
-const getNavItemsList = (links) => {
-  const ul = createElement("ul");
-
-  for (const link of MainNav.links) {
-    const anchor = createElement(
-      "a",
-      {
-        textContent: link.name,
-      },
-      {
-        href: link.path,
-      },
-    );
-
-    const li = createElement("li");
-    li.appendChild(anchor);
-
-    ul.appendChild(li);
-  }
-  return ul;
-};

--- a/frontend/pong/js/components/views/MainView.js
+++ b/frontend/pong/js/components/views/MainView.js
@@ -1,11 +1,12 @@
 import { View } from "../../core/View";
 import { mainRouter } from "../../routers/mainRouter";
+import { createElement } from "../../utils/elements/createElement";
 import { MainNav } from "../navs/MainNav";
 
 export class MainView extends View {
-  #router;
   #nav;
   #main;
+  #mainRouter;
 
   // MainView の対応中のパスを列挙
   static Paths = Object.freeze({
@@ -21,19 +22,21 @@ export class MainView extends View {
   _onConnect() {
     this.#nav = new MainNav();
     this.#main = createElement("div");
-    this.#router = mainRouter(this.#main);
+    this.#mainRouter = mainRouter(this.#main);
+  }
+
+  #updateMain() {
+    const path = this._getPath();
+    this.#mainRouter.update(path);
   }
 
   _render() {
-    const path = this._getPath();
-    this.#router.update(path);
-
+    this.#updateMain();
     this.appendChild(this.#nav);
     this.appendChild(this.#main);
   }
 
   _update() {
-    const path = this._getPath();
-    this.#router.update(path);
+    this.#updateMain();
   }
 }

--- a/frontend/pong/js/components/views/MainView.js
+++ b/frontend/pong/js/components/views/MainView.js
@@ -25,10 +25,6 @@ export class MainView extends View {
   }
 
   _render() {
-    const title = document.createElement("h1");
-    title.textContent = "🚧 Pong";
-    this.appendChild(title);
-
     const path = this._getPath();
     this.#router.update(path);
 

--- a/frontend/pong/js/components/views/MainView.js
+++ b/frontend/pong/js/components/views/MainView.js
@@ -20,7 +20,7 @@ export class MainView extends View {
 
   _onConnect() {
     this.#nav = new MainNav();
-    this.#main = document.createElement("div");
+    this.#main = createElement("div");
     this.#router = mainRouter(this.#main);
   }
 

--- a/frontend/pong/js/components/views/MainView.js
+++ b/frontend/pong/js/components/views/MainView.js
@@ -1,10 +1,10 @@
 import { View } from "../../core/View";
 import { mainRouter } from "../../routers/mainRouter";
 import { createElement } from "../../utils/elements/createElement";
-import { MainNav } from "../navs/MainNav";
+import { MainNavbar } from "../navigation/MainNavbar";
 
 export class MainView extends View {
-  #nav;
+  #navbar;
   #main;
   #mainRouter;
 
@@ -20,7 +20,7 @@ export class MainView extends View {
   });
 
   _onConnect() {
-    this.#nav = new MainNav();
+    this.#navbar = new MainNavbar();
     this.#main = createElement("div");
     this.#mainRouter = mainRouter(this.#main);
   }
@@ -32,7 +32,7 @@ export class MainView extends View {
 
   _render() {
     this.#updateMain();
-    this.appendChild(this.#nav);
+    this.appendChild(this.#navbar);
     this.appendChild(this.#main);
   }
 

--- a/frontend/pong/js/utils/elements/anchor/createBrandAnchor.js
+++ b/frontend/pong/js/utils/elements/anchor/createBrandAnchor.js
@@ -1,0 +1,11 @@
+import { Paths } from "../../../constants/Paths";
+import { createElement } from "../createElement";
+
+export const createBrandAnchor = () => {
+  const brandAnchor = createElement(
+    "a",
+    { textContent: "Pong" },
+    { href: Paths.HOME },
+  );
+  return brandAnchor;
+};

--- a/frontend/pong/js/utils/elements/createElement.js
+++ b/frontend/pong/js/utils/elements/createElement.js
@@ -1,0 +1,12 @@
+export const createElement = (
+  tagname,
+  properties = {},
+  attributes = {},
+) => {
+  const newElement = document.createElement(tagname);
+  Object.assign(newElement, properties);
+  for (const [key, value] of Object.entries(attributes)) {
+    newElement.setAttribute(key, value);
+  }
+  return newElement;
+};

--- a/frontend/pong/js/utils/elements/nav/createDefaultNavbar.js
+++ b/frontend/pong/js/utils/elements/nav/createDefaultNavbar.js
@@ -1,0 +1,26 @@
+import { BootstrapNavbar } from "../../../bootstrap/components/navbar";
+import { BootstrapContainers } from "../../../bootstrap/layout/containers";
+import { createBrandAnchor } from "../anchor/createBrandAnchor";
+import { createElement } from "../createElement";
+import { createNavbarNavList } from "./createNavbarNavList";
+
+export const createDefaultNavbar = (links) => {
+  const navList = createNavbarNavList(links);
+  BootstrapNavbar.setNavbarNav(navList);
+
+  const brand = createBrandAnchor();
+  BootstrapNavbar.setNavbarBrand(brand);
+
+  const navListWrapper = createElement("div");
+  navListWrapper.appendChild(navList);
+
+  const containerFluid = createElement("div");
+  BootstrapContainers.setFluid(containerFluid);
+  containerFluid.appendChild(brand);
+  containerFluid.appendChild(navListWrapper);
+
+  const navbar = createElement("nav");
+  BootstrapNavbar.setNavbarExpand(navbar);
+  navbar.appendChild(containerFluid);
+  return navbar;
+};

--- a/frontend/pong/js/utils/elements/nav/createNavbarNavList.js
+++ b/frontend/pong/js/utils/elements/nav/createNavbarNavList.js
@@ -12,6 +12,13 @@ export const createNavbarNavList = (links) => {
   return navList;
 };
 
+// 引数 link は、次のような形を前提にしています。
+// {
+//   name: <表示名>,
+//   path: <移動先のパス>,
+//   ...
+// }
+// ex) { name: "ホーム", path: "/", ...}
 const createNavbarNavListItem = (link) => {
   const linkAnchor = createElement(
     "a",

--- a/frontend/pong/js/utils/elements/nav/createNavbarNavList.js
+++ b/frontend/pong/js/utils/elements/nav/createNavbarNavList.js
@@ -1,0 +1,31 @@
+import { BootstrapNavsTabs } from "../../../bootstrap/components/navsTabs";
+import { createElement } from "../createElement";
+
+export const createNavbarNavList = (links) => {
+  const navList = createElement("ul");
+  BootstrapNavsTabs.setNav(navList);
+
+  for (const link of links) {
+    const navListItem = createNavbarNavListItem(link);
+    navList.appendChild(navListItem);
+  }
+  return navList;
+};
+
+const createNavbarNavListItem = (link) => {
+  const linkAnchor = createElement(
+    "a",
+    {
+      textContent: link.name,
+    },
+    {
+      href: link.path,
+    },
+  );
+  BootstrapNavsTabs.setNavLink(linkAnchor);
+
+  const navListItem = createElement("li");
+  BootstrapNavsTabs.setNavItem(navListItem);
+  navListItem.appendChild(linkAnchor);
+  return navListItem;
+};

--- a/frontend/pong/js/utils/elements/setClassNames.js
+++ b/frontend/pong/js/utils/elements/setClassNames.js
@@ -1,0 +1,4 @@
+export const setClassNames = (element, ...classNames) => {
+  if (element) element.classList.add(...classNames);
+  return element;
+};


### PR DESCRIPTION
## タスクやディスカッションのリンク
- #194 

## やったこと
- utils に createElement という関数を作成、タグごとの関数を準備
- Bootstrap ドキュメント作成
https://www.notion.so/Bootstrap-22cdd73ee8e442f0b2d5482d8d2d2bd6?pvs=4
- 作成したドキュメントどおり Bootstrap を導入し、ナビゲーションバーに適用
- 合わせて MainView と MainNav(MainNavbar に名前変更) を改善

## やらないこと
なし

## 動作確認
- `cd frontend/pong && npm install && npm run dev`
- ナビゲーションバーの表示を確認

## 特にレビューをお願いしたい箇所
- 作成した Bootstrap のドキュメント
- 公式ドキュメントや作成したドキュメントに沿っているか

## その他
- 一旦 Bootstrap の使い方に慣れる目的もあり、ほぼ下記の公式ドキュメントどおりであまり工夫のないミニマルなものしています。
https://getbootstrap.jp/docs/5.3/components/navbar/
- 具体的なスタイリングは今後他の部分と合わせて、仕上げても良いかと思っています。

## 参考リンク
- https://www.notion.so/Bootstrap-22cdd73ee8e442f0b2d5482d8d2d2bd6?pvs=4
- https://getbootstrap.jp/docs/5.3/components/navbar/
- https://getbootstrap.jp/docs/5.3/components/navs-tabs/
- https://getbootstrap.jp/docs/5.3/layout/containers/#%E4%BB%95%E7%B5%84%E3%81%BF


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新機能**
	- Bootstrap 5.3.0を導入し、ナビゲーションバーとレイアウトを改善
	- 動的なナビゲーションコンポーネントを追加
	- 新しいユーティリティ関数で要素作成を簡素化
	- ブランドアンカーを作成する新しい関数を追加

- **リファクタリング**
	- ナビゲーションコンポーネントを`MainNav`から`MainNavbar`に更新
	- コンポーネント構造を最適化

- **スタイル**
	- Bootstrapのスタイルシートとコンポーネントを統合

<!-- end of auto-generated comment: release notes by coderabbit.ai -->