### PR TITLE
⚡ ホームビューを簡単な形で構成

### DIFF
--- a/frontend/pong/js/bootstrap/components/buttonGroup.js
+++ b/frontend/pong/js/bootstrap/components/buttonGroup.js
@@ -1,0 +1,9 @@
+import { setClassNames } from "../../utils/elements/setClassNames";
+
+const setVertical = (element) => {
+  return setClassNames(element, "btn-group-vertical");
+};
+
+export const BootstrapButtonGroup = {
+  setVertical,
+};

--- a/frontend/pong/js/bootstrap/components/buttons.js
+++ b/frontend/pong/js/bootstrap/components/buttons.js
@@ -1,0 +1,9 @@
+import { setClassNames } from "../../utils/elements/setClassNames";
+
+const setButtonPrimary = (element) => {
+  return setClassNames(element, "btn", "btn-primary");
+};
+
+export const BootstrapButtons = {
+  setButtonPrimary,
+};

--- a/frontend/pong/js/bootstrap/utilities/display.js
+++ b/frontend/pong/js/bootstrap/utilities/display.js
@@ -1,0 +1,14 @@
+import { setClassNames } from "../../utils/elements/setClassNames";
+
+const setFlex = (element) => {
+  return setClassNames(element, "d-flex");
+};
+
+const setGrid = (element) => {
+  return setClassNames(element, "d-grid");
+};
+
+export const BootstrapDisplay = {
+  setFlex,
+  setGrid,
+};

--- a/frontend/pong/js/bootstrap/utilities/flex.js
+++ b/frontend/pong/js/bootstrap/utilities/flex.js
@@ -1,0 +1,24 @@
+import { setClassNames } from "../../utils/elements/setClassNames";
+
+const setFlexColumn = (element) => {
+  return setClassNames(element, "flex-column");
+};
+
+const setFlexGrow1 = (element) => {
+  return setClassNames(element, "flex-grow-1");
+};
+
+const setJustifyContentCenter = (element) => {
+  return setClassNames(element, "justify-content-center");
+};
+
+const setAlignItemsCenter = (element) => {
+  return setClassNames(element, "align-items-center");
+};
+
+export const BootstrapFlex = {
+  setFlexColumn,
+  setFlexGrow1,
+  setJustifyContentCenter,
+  setAlignItemsCenter,
+};

--- a/frontend/pong/js/bootstrap/utilities/sizing.js
+++ b/frontend/pong/js/bootstrap/utilities/sizing.js
@@ -1,0 +1,29 @@
+import { setClassNames } from "../../utils/elements/setClassNames";
+
+const setWidth50 = (element) => {
+  return setClassNames(element, "w-50");
+};
+
+const setWidth100 = (element) => {
+  return setClassNames(element, "w-100");
+};
+
+const setHeight50 = (element) => {
+  return setClassNames(element, "h-50");
+};
+
+const setHeight100 = (element) => {
+  return setClassNames(element, "h-100");
+};
+
+const setViewportHeight100 = (element) => {
+  return setClassNames(element, "vh-100");
+};
+
+export const BootstrapSizing = {
+  setWidth50,
+  setWidth100,
+  setHeight50,
+  setHeight100,
+  setViewportHeight100,
+};

--- a/frontend/pong/js/bootstrap/utilities/spacing.js
+++ b/frontend/pong/js/bootstrap/utilities/spacing.js
@@ -1,0 +1,14 @@
+import { setClassNames } from "../../utils/elements/setClassNames";
+
+const setPadding = (element) => {
+  return setClassNames(element, "p-2");
+};
+
+const setGap = (element) => {
+  return setClassNames(element, "gap-3");
+};
+
+export const BootstrapSpacing = {
+  setPadding,
+  setGap,
+};

--- a/frontend/pong/js/components/game/GameStartPanel.js
+++ b/frontend/pong/js/components/game/GameStartPanel.js
@@ -2,6 +2,8 @@ import { BootstrapDisplay } from "../../bootstrap/utilities/display";
 import { BootstrapFlex } from "../../bootstrap/utilities/flex";
 import { BootstrapSizing } from "../../bootstrap/utilities/sizing";
 import { BootstrapSpacing } from "../../bootstrap/utilities/spacing";
+import { Paths } from "../../constants/Paths";
+import { PongEvents } from "../../constants/PongEvents";
 import { Component } from "../../core/Component";
 import { createPrimaryButton } from "../../utils/elements/button/createPrimaryButton";
 import { createElement } from "../../utils/elements/createElement";
@@ -29,6 +31,11 @@ export class GameStartPanel extends Component {
     this.#menu = menu;
 
     this.#setStyle();
+
+    this._attachEventListener(
+      "click",
+      PongEvents.UPDATE_ROUTER.trigger,
+    );
   }
 
   _render() {
@@ -48,7 +55,7 @@ const getLocalMatchStartButton = () => {
 
 const getTournamentStartButton = () => {
   const tournamentStartButton = createPrimaryButton(
-    { textContent: "トーナメント開始" },
+    { textContent: "トーナメント開始", pathname: Paths.TOURNAMENTS },
     { type: "button" },
   );
   return tournamentStartButton;

--- a/frontend/pong/js/components/game/GameStartPanel.js
+++ b/frontend/pong/js/components/game/GameStartPanel.js
@@ -1,0 +1,55 @@
+import { BootstrapDisplay } from "../../bootstrap/utilities/display";
+import { BootstrapFlex } from "../../bootstrap/utilities/flex";
+import { BootstrapSizing } from "../../bootstrap/utilities/sizing";
+import { BootstrapSpacing } from "../../bootstrap/utilities/spacing";
+import { Component } from "../../core/Component";
+import { createPrimaryButton } from "../../utils/elements/button/createPrimaryButton";
+import { createElement } from "../../utils/elements/createElement";
+
+export class GameStartPanel extends Component {
+  #menu;
+
+  #setStyle() {
+    BootstrapDisplay.setGrid(this.#menu);
+    BootstrapSizing.setWidth50(this.#menu);
+    BootstrapSpacing.setGap(this.#menu);
+
+    BootstrapDisplay.setFlex(this);
+    BootstrapFlex.setFlexColumn(this);
+    BootstrapFlex.setJustifyContentCenter(this);
+    BootstrapFlex.setAlignItemsCenter(this);
+    BootstrapSizing.setWidth50(this);
+    BootstrapSizing.setHeight50(this);
+  }
+
+  _onConnect() {
+    const menu = createElement("div");
+    menu.appendChild(getLocalMatchStartButton());
+    menu.appendChild(getTournamentStartButton());
+    this.#menu = menu;
+
+    this.#setStyle();
+  }
+
+  _render() {
+    this.appendChild(this.#menu);
+  }
+}
+
+const getLocalMatchStartButton = () => {
+  const localMatchStartButton = createPrimaryButton(
+    { textContent: "ローカル対戦" },
+    { type: "button" },
+  );
+  // TODO: [DELETE] ローカルマッチの準備とともに削除
+  localMatchStartButton.setAttribute("disabled", "");
+  return localMatchStartButton;
+};
+
+const getTournamentStartButton = () => {
+  const tournamentStartButton = createPrimaryButton(
+    { textContent: "トーナメント開始" },
+    { type: "button" },
+  );
+  return tournamentStartButton;
+};

--- a/frontend/pong/js/components/index.js
+++ b/frontend/pong/js/components/index.js
@@ -1,4 +1,5 @@
 import { LoginContainer } from "./auth/LoginContainer";
+import { GameStartPanel } from "./game/GameStartPanel";
 import { MainNavbar } from "./navigation/MainNavbar";
 import { ChatView } from "./views/ChatView";
 import { FriendsView } from "./views/FriendsView";
@@ -11,6 +12,7 @@ import { TournamentsView } from "./views/TournamentsView";
 import { UsersView } from "./views/UsersView";
 
 customElements.define("login-container", LoginContainer, {});
+customElements.define("game-start-panel", GameStartPanel, {});
 customElements.define("main-navbar", MainNavbar, {});
 customElements.define("chat-view", ChatView, {});
 customElements.define("friends-view", FriendsView, {});

--- a/frontend/pong/js/components/navigation/MainNavbar.js
+++ b/frontend/pong/js/components/navigation/MainNavbar.js
@@ -17,15 +17,10 @@ export class MainNavbar extends Component {
   _onConnect() {
     this.#navbar = createDefaultNavbar(MainNavbar.links);
 
-    this._attachEventListener("click", (event) => {
-      event.preventDefault();
-      const link = event.target;
-      if (link?.pathname === undefined) return;
-
-      link.dispatchEvent(
-        PongEvents.UPDATE_ROUTER.create(link.pathname),
-      );
-    });
+    this._attachEventListener(
+      "click",
+      PongEvents.UPDATE_ROUTER.trigger,
+    );
   }
 
   _render() {

--- a/frontend/pong/js/components/views/HomeView.js
+++ b/frontend/pong/js/components/views/HomeView.js
@@ -1,12 +1,12 @@
 import { BootstrapDisplay } from "../../bootstrap/utilities/display";
 import { BootstrapFlex } from "../../bootstrap/utilities/flex";
 import { BootstrapSizing } from "../../bootstrap/utilities/sizing";
-import { Endpoints } from "../../constants/Endpoints";
 import { View } from "../../core/View";
-import { isOpenWebSocket } from "../../websocket";
+import { GameStartPanel } from "../game/GameStartPanel";
 
 export class HomeView extends View {
-  
+  #gameStartPanel;
+
   #setStyle() {
     BootstrapDisplay.setFlex(this);
     BootstrapFlex.setFlexColumn(this);
@@ -17,55 +17,11 @@ export class HomeView extends View {
   }
 
   _onConnect() {
+    this.#gameStartPanel = new GameStartPanel();
     this.#setStyle();
-    Object.assign(this._state, {
-      healthStatus: "...",
-      webSocketBaseStatus: "...",
-    });
-
-    const getHealthStatus = async () => {
-      let healthStatus;
-      try {
-        const res = await fetch(Endpoints.HEALTH.href);
-        const json = await res.json();
-        healthStatus = json.status;
-      } catch (error) {
-        console.error(error);
-        healthStatus = "KO";
-      }
-      return healthStatus;
-    };
-
-    const getWebSocketBaseStatus = async () => {
-      let isOpen;
-      try {
-        isOpen = await isOpenWebSocket();
-      } catch (error) {
-        isOpen = false;
-      }
-      return isOpen ? "OK" : "KO";
-    };
-
-    getHealthStatus().then((healthStatus) => {
-      this._updateState({ healthStatus });
-    });
-
-    getWebSocketBaseStatus().then((webSocketBaseStatus) => {
-      this._updateState({ webSocketBaseStatus });
-    });
   }
 
   _render() {
-    const title = document.createElement("h2");
-    title.textContent = "Hello World";
-    this.appendChild(title);
-
-    const status = document.createElement("h3");
-    status.textContent = `${Endpoints.HEALTH.pathname}: ${this._getState().healthStatus}`;
-    this.appendChild(status);
-
-    const wsStatus = document.createElement("h3");
-    wsStatus.textContent = `${Endpoints.WEBSOCKET.pathname}: ${this._getState().webSocketBaseStatus}`;
-    this.appendChild(wsStatus);
+    this.appendChild(this.#gameStartPanel);
   }
 }

--- a/frontend/pong/js/components/views/HomeView.js
+++ b/frontend/pong/js/components/views/HomeView.js
@@ -1,9 +1,23 @@
+import { BootstrapDisplay } from "../../bootstrap/utilities/display";
+import { BootstrapFlex } from "../../bootstrap/utilities/flex";
+import { BootstrapSizing } from "../../bootstrap/utilities/sizing";
 import { Endpoints } from "../../constants/Endpoints";
 import { View } from "../../core/View";
 import { isOpenWebSocket } from "../../websocket";
 
 export class HomeView extends View {
+  
+  #setStyle() {
+    BootstrapDisplay.setFlex(this);
+    BootstrapFlex.setFlexColumn(this);
+    BootstrapFlex.setJustifyContentCenter(this);
+    BootstrapFlex.setAlignItemsCenter(this);
+    BootstrapSizing.setWidth100(this);
+    BootstrapSizing.setHeight100(this);
+  }
+
   _onConnect() {
+    this.#setStyle();
     Object.assign(this._state, {
       healthStatus: "...",
       webSocketBaseStatus: "...",

--- a/frontend/pong/js/components/views/MainView.js
+++ b/frontend/pong/js/components/views/MainView.js
@@ -1,3 +1,7 @@
+import { BootstrapDisplay } from "../../bootstrap/utilities/display";
+import { BootstrapFlex } from "../../bootstrap/utilities/flex";
+import { BootstrapSizing } from "../../bootstrap/utilities/sizing";
+import { BootstrapSpacing } from "../../bootstrap/utilities/spacing";
 import { View } from "../../core/View";
 import { mainRouter } from "../../routers/mainRouter";
 import { createElement } from "../../utils/elements/createElement";
@@ -19,10 +23,20 @@ export class MainView extends View {
     NOT_FOUND: "/not-found",
   });
 
+  #setStyle() {
+    BootstrapDisplay.setFlex(this);
+    BootstrapFlex.setFlexColumn(this);
+    BootstrapSizing.setViewportHeight100(this);
+    BootstrapSpacing.setPadding(this);
+
+    BootstrapFlex.setFlexGrow1(this.#main);
+  }
+
   _onConnect() {
     this.#navbar = new MainNavbar();
     this.#main = createElement("div");
     this.#mainRouter = mainRouter(this.#main);
+    this.#setStyle();
   }
 
   #updateMain() {

--- a/frontend/pong/js/constants/PongEvents.js
+++ b/frontend/pong/js/constants/PongEvents.js
@@ -5,6 +5,12 @@ const createPongEvent = (type, detail = {}) => {
 const UPDATE_ROUTER = {
   type: "update-router",
   create: (path) => createPongEvent(UPDATE_ROUTER.type, { path }),
+  trigger: (event) => {
+    event.preventDefault();
+    const { target } = event;
+    if (!target?.pathname) return;
+    target.dispatchEvent(UPDATE_ROUTER.create(target.pathname));
+  },
 };
 
 export const PongEvents = {

--- a/frontend/pong/js/utils/elements/button/createPrimaryButton.js
+++ b/frontend/pong/js/utils/elements/button/createPrimaryButton.js
@@ -1,0 +1,11 @@
+import { BootstrapButtons } from "../../../bootstrap/components/buttons";
+import { createElement } from "../createElement";
+
+export const createPrimaryButton = (
+  properties = {},
+  attributes = {},
+) => {
+  const button = createElement("button", properties, attributes);
+  BootstrapButtons.setButtonPrimary(button);
+  return button;
+};


### PR DESCRIPTION
## タスクやディスカッションのリンク
#237
https://www.notion.so/004-158f1b77f6c280318cffec9b1554010c?pvs=4

## やったこと
- ホームにローカルマッチとトーナメント開始ボタンを配置
- スタイリングのための、Bootstrap 関連の関数も追加

## やらないこと
- パネルにあるものはボタン二つだけで、さらにローカルマッチは TODO を残して一旦無効化しています。

## 動作確認
- `cd frontend/pong && npm install && npm run dev` よりホーム画面を確認
- `トーナメント開始`のクリックよりトーナメントビューが表示されることを確認

## 特にレビューをお願いしたい箇所
なし

## その他
ボタンやそのグループのデザインと構成は Bootstrap のデフォルトのものをそのまま使用しています。
https://getbootstrap.jp/docs/5.3/components/buttons/#%e3%83%96%e3%83%ad%e3%83%83%e3%82%af%e3%83%9c%e3%82%bf%e3%83%b3

## 参考リンク
https://getbootstrap.jp/docs/5.3/utilities/flex/
https://getbootstrap.jp/docs/5.3/components/buttons/
https://developer.mozilla.org/en-US/docs/Web/CSS/display
https://getbootstrap.jp/docs/5.3/utilities/spacing/#%E3%82%AE%E3%83%A3%E3%83%83%E3%83%97
https://getbootstrap.jp/docs/5.3/utilities/sizing/
<!-- - 実装に際し参考にした、記事やサイトのリンクを記載する -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- ゲーム開始パネルを追加
	- ボタングループの垂直配置をサポート
	- プライマリボタンのスタイル設定機能を追加
	- Bootstrapのディスプレイ、フレックス、サイズ、間隔のユーティリティ関数を導入

- **スタイル**
	- ナビゲーションとビューのスタイリングを改善
	- Bootstrapのユーティリティクラスを使用したレイアウト調整

- **リファクタリング**
	- ホームビューとメインビューのコンポーネント構造を更新

<!-- end of auto-generated comment: release notes by coderabbit.ai -->