### PR TITLE
⚡♻️ [users] 500 schema・logger 追加・リファクタリング

### DIFF
--- a/backend/pong/users/tests/integration/test_list.py
+++ b/backend/pong/users/tests/integration/test_list.py
@@ -71,7 +71,7 @@ class UsersListViewTests(test.APITestCase):
 
     def test_200_no_users_exist(self) -> None:
         """
-        ユーザーが存在しない場合、エラーにならず空のdataを返すことを確認
+        ユーザーが存在しない場合、エラーにならず空のプロフィール一覧を取得できることを確認
         """
         response: drf_response.Response = self.client.get(self.url)
 

--- a/backend/pong/users/tests/integration/test_me.py
+++ b/backend/pong/users/tests/integration/test_me.py
@@ -35,8 +35,8 @@ class UsersMeViewTests(test.APITestCase):
             DISPLAY_NAME: "display_name1",
         }
         # User,Playerを作成
-        user: User = User.objects.create_user(**self.user_data)
-        self.player_data[USER] = user
+        self.user: User = User.objects.create_user(**self.user_data)
+        self.player_data[USER] = self.user
         self.player: player_models.Player = (
             player_models.Player.objects.create(**self.player_data)
         )
@@ -57,6 +57,15 @@ class UsersMeViewTests(test.APITestCase):
         )
 
         self.url: str = reverse("users:me")
+
+    def test_setup_create_user(self) -> None:
+        """
+        念のため、setUp()でUser,Playerが作成できていることを確認
+        """
+        self.assertTrue(User.objects.filter(id=self.user.id).exists())
+        self.assertTrue(
+            player_models.Player.objects.filter(id=self.player.id).exists()
+        )
 
     def test_get_200_authenticated_user(self) -> None:
         """

--- a/backend/pong/users/tests/integration/test_retrieve.py
+++ b/backend/pong/users/tests/integration/test_retrieve.py
@@ -72,7 +72,7 @@ class UsersRetrieveViewTests(test.APITestCase):
         self.assertTrue(User.objects.filter(id=user1.id).exists())
         self.assertTrue(User.objects.filter(id=user2.id).exists())
 
-    def test_get_user_with_valid_user_id(self) -> None:
+    def test_get_200_user_with_valid_user_id(self) -> None:
         """
         存在するuser_idをurlに指定して特定のユーザープロフィールを取得できることを確認
         """
@@ -101,7 +101,7 @@ class UsersRetrieveViewTests(test.APITestCase):
             )
             self.assertNotIn(EMAIL, response_data)
 
-    def test_get_user_returns_404_with_nonexistent_user_id(self) -> None:
+    def test_get_404_user_returns_404_with_nonexistent_user_id(self) -> None:
         """
         存在しないuser_idを指定した場合に、エラーが返されることを確認
         """

--- a/backend/pong/users/views/list.py
+++ b/backend/pong/users/views/list.py
@@ -54,6 +54,8 @@ class UsersListView(views.APIView):
                     ),
                 ],
             ),
+            # todo: 詳細のschemaが必要であれば追加する
+            500: utils.OpenApiResponse(description="Internal server error"),
         },
     )
     # todo: try-exceptで全体を囲って500を返す？

--- a/backend/pong/users/views/list.py
+++ b/backend/pong/users/views/list.py
@@ -20,7 +20,7 @@ class UsersListView(views.APIView):
     ユーザープロフィールの一覧を取得するビュー
     """
 
-    # todo: IsAuthenticatedに変更する
+    # todo: IsAuthenticatedに変更する。extend_schemaにも401を追加する
     permission_classes = (permissions.AllowAny,)
 
     @utils.extend_schema(

--- a/backend/pong/users/views/list.py
+++ b/backend/pong/users/views/list.py
@@ -24,6 +24,7 @@ class UsersListView(views.APIView):
     permission_classes = (permissions.AllowAny,)
 
     @utils.extend_schema(
+        operation_id="get_users_list",
         request=None,
         responses={
             200: utils.OpenApiResponse(

--- a/backend/pong/users/views/list.py
+++ b/backend/pong/users/views/list.py
@@ -34,18 +34,18 @@ class UsersListView(views.APIView):
                     utils.OpenApiExample(
                         "Example 200 response",
                         value={
-                            "status": "ok",
-                            "data": [
+                            custom_response.STATUS: custom_response.Status.OK,
+                            custom_response.DATA: [
                                 {
-                                    "id": 2,
-                                    "username": "username1",
-                                    "display_name": "display_name1",
+                                    constants.UserFields.ID: 2,
+                                    constants.UserFields.USERNAME: "username1",
+                                    constants.PlayerFields.DISPLAY_NAME: "display_name1",
                                     # todo: avatar追加
                                 },
                                 {
-                                    "id": 3,
-                                    "username": "username2",
-                                    "display_name": "display_name2",
+                                    constants.UserFields.ID: 3,
+                                    constants.UserFields.USERNAME: "username2",
+                                    constants.PlayerFields.DISPLAY_NAME: "display_name2",
                                     # todo: avatar追加
                                 },
                                 {"...", "..."},

--- a/backend/pong/users/views/me.py
+++ b/backend/pong/users/views/me.py
@@ -43,25 +43,18 @@ class UsersMeView(views.APIView):
                     ),
                 ],
             ),
-            # todo: 現在Djangoが自動で返している401のスキーマも書く？
-            # todo: 404ではないかも
-            404: utils.OpenApiResponse(
-                description="The user does not exist.",
+            # todo: 現在Djangoが自動で返している。CustomResponseが使えたら併せて変更する
+            401: utils.OpenApiResponse(
+                description="Not authenticated",
                 response={
                     "type": "object",
-                    "properties": {
-                        custom_response.STATUS: {"type": "string"},
-                        custom_response.ERRORS: {"type": "dict"},
-                    },
+                    "properties": {"detail": {"type": "string"}},
                 },
                 examples=[
                     utils.OpenApiExample(
-                        "Example 404 response",
+                        "Example 401 response",
                         value={
-                            custom_response.STATUS: custom_response.Status.ERROR,
-                            custom_response.ERRORS: {
-                                "user": "The user does not exist."
-                            },
+                            "detail": "Authentication credentials were not provided."
                         },
                     ),
                 ],
@@ -81,7 +74,7 @@ class UsersMeView(views.APIView):
         if not hasattr(user, "player"):
             return custom_response.CustomResponse(
                 errors={"user": "The user does not exist."},
-                status=status.HTTP_404_NOT_FOUND,  # todo: 404ではないかも
+                status=status.HTTP_404_NOT_FOUND,  # todo: 404ではないかも。schemaに書いてない
             )
 
         users_serializer: serializers.UsersSerializer = (
@@ -146,25 +139,18 @@ class UsersMeView(views.APIView):
                     ),
                 ],
             ),
-            # todo: 現在Djangoが自動で返している401のスキーマも書く？
-            # todo: 404ではないかも
-            404: utils.OpenApiResponse(
-                description="The user does not exist.",
+            # todo: 現在Djangoが自動で返している。CustomResponseが使えたら併せて変更する
+            401: utils.OpenApiResponse(
+                description="Not authenticated",
                 response={
                     "type": "object",
-                    "properties": {
-                        custom_response.STATUS: {"type": "string"},
-                        custom_response.ERRORS: {"type": "dict"},
-                    },
+                    "properties": {"detail": {"type": "string"}},
                 },
                 examples=[
                     utils.OpenApiExample(
-                        "Example 404 response",
+                        "Example 401 response",
                         value={
-                            custom_response.STATUS: custom_response.Status.ERROR,
-                            custom_response.ERRORS: {
-                                "user": "The user does not exist."
-                            },
+                            "detail": "Authentication credentials were not provided."
                         },
                     ),
                 ],
@@ -181,7 +167,7 @@ class UsersMeView(views.APIView):
         if not hasattr(user, "player"):
             return custom_response.CustomResponse(
                 errors={"user": "The user does not exist."},
-                status=status.HTTP_404_NOT_FOUND,  # todo: 404ではないかも
+                status=status.HTTP_404_NOT_FOUND,  # todo: 404ではないかも。schemaに書いてない
             )
         # serializer作成
         users_serializer: serializers.UsersSerializer = (

--- a/backend/pong/users/views/me.py
+++ b/backend/pong/users/views/me.py
@@ -1,3 +1,5 @@
+import logging
+
 from django.contrib.auth.models import AnonymousUser, User
 from drf_spectacular import utils
 from rest_framework import (
@@ -12,6 +14,8 @@ from accounts import constants
 from pong.custom_response import custom_response
 
 from .. import serializers
+
+logger = logging.getLogger(__name__)
 
 
 class UsersMeView(views.APIView):
@@ -74,6 +78,7 @@ class UsersMeView(views.APIView):
         # AnonymousUserの場合はget()に入る前にpermission_classesで弾かれるが、
         # AnonymousUserだとuser.playerが使えずmypyでエラーになるため、事前にチェックが必要
         if not hasattr(user, "player"):
+            # todo: この処理が必要ならlogger書く
             return custom_response.CustomResponse(
                 errors={"user": "The user does not exist."},
                 status=status.HTTP_404_NOT_FOUND,  # todo: 404ではないかも。schemaに書いてない
@@ -169,6 +174,7 @@ class UsersMeView(views.APIView):
         # リクエストのtokenからuserを取得
         user: User | AnonymousUser = request.user
         if not hasattr(user, "player"):
+            # todo: この処理が必要ならlogger書く
             return custom_response.CustomResponse(
                 errors={"user": "The user does not exist."},
                 status=status.HTTP_404_NOT_FOUND,  # todo: 404ではないかも。schemaに書いてない
@@ -183,6 +189,9 @@ class UsersMeView(views.APIView):
         )
         # 更新対象データ(request.data)のバリデーションを確認
         if not users_serializer.is_valid():
+            logger.error(
+                f"[400] Serializer's validation error: {users_serializer.errors}"
+            )
             return custom_response.CustomResponse(
                 errors=users_serializer.errors,
                 status=status.HTTP_400_BAD_REQUEST,

--- a/backend/pong/users/views/me.py
+++ b/backend/pong/users/views/me.py
@@ -59,6 +59,8 @@ class UsersMeView(views.APIView):
                     ),
                 ],
             ),
+            # todo: 詳細のschemaが必要であれば追加する
+            500: utils.OpenApiResponse(description="Internal server error"),
         },
     )
     # todo: try-exceptで全体を囲って500を返す？
@@ -155,6 +157,8 @@ class UsersMeView(views.APIView):
                     ),
                 ],
             ),
+            # todo: 詳細のschemaが必要であれば追加する
+            500: utils.OpenApiResponse(description="Internal server error"),
         },
     )
     # todo: try-exceptで全体を囲って500を返す

--- a/backend/pong/users/views/me.py
+++ b/backend/pong/users/views/me.py
@@ -19,6 +19,7 @@ class UsersMeView(views.APIView):
     自分のユーザープロフィールを取得・更新する
     """
 
+    # プロフィールを全て返すのでIsAuthenticatedをセットする必要がある
     permission_classes = [permissions.IsAuthenticated]
 
     @utils.extend_schema(

--- a/backend/pong/users/views/retrieve.py
+++ b/backend/pong/users/views/retrieve.py
@@ -20,7 +20,7 @@ class UsersRetrieveView(views.APIView):
     特定のuser_idのユーザープロフィールを取得するビュー
     """
 
-    # todo: IsAuthenticatedに変更する
+    # todo: IsAuthenticatedに変更する。extend_schemaにも401を追加する
     permission_classes = (permissions.AllowAny,)
 
     @utils.extend_schema(

--- a/backend/pong/users/views/retrieve.py
+++ b/backend/pong/users/views/retrieve.py
@@ -1,3 +1,5 @@
+import logging
+
 from django.core.exceptions import ObjectDoesNotExist
 from drf_spectacular import utils
 from rest_framework import (
@@ -13,6 +15,8 @@ from accounts.player import models
 from pong.custom_response import custom_response
 
 from .. import serializers
+
+logger = logging.getLogger(__name__)
 
 
 class UsersRetrieveView(views.APIView):
@@ -94,14 +98,16 @@ class UsersRetrieveView(views.APIView):
                 data=users_serializer.data,
                 status=status.HTTP_200_OK,
             )
-        except ObjectDoesNotExist:
+        except ObjectDoesNotExist as e:
             # user_idに紐づくPlayerが存在しない場合
+            logger.error(f"[404] {str(e)}: user_id={user_id} does not exist.")
             return custom_response.CustomResponse(
                 errors={"user_id": "The user does not exist."},
                 status=status.HTTP_404_NOT_FOUND,
             )
         except Exception as e:
             # MultipleObjectsReturnedなどの場合
+            logger.error(f"[500] Internal server error: {str(e)}")
             return custom_response.CustomResponse(
                 errors={"detail": str(e)},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,

--- a/backend/pong/users/views/retrieve.py
+++ b/backend/pong/users/views/retrieve.py
@@ -34,11 +34,11 @@ class UsersRetrieveView(views.APIView):
                     utils.OpenApiExample(
                         "Example 200 response",
                         value={
-                            "status": "ok",
-                            "data": {
-                                "id": 2,
-                                "username": "username1",
-                                "display_name": "display_name1",
+                            custom_response.STATUS: custom_response.Status.OK,
+                            custom_response.DATA: {
+                                constants.UserFields.ID: 2,
+                                constants.UserFields.USERNAME: "username1",
+                                constants.PlayerFields.DISPLAY_NAME: "display_name1",
                             },
                         },
                     ),
@@ -49,16 +49,18 @@ class UsersRetrieveView(views.APIView):
                 response={
                     "type": "object",
                     "properties": {
-                        "status": {"type": "string"},
-                        "errors": {"type": "dict"},
+                        custom_response.STATUS: {"type": "string"},
+                        custom_response.ERRORS: {"type": "dict"},
                     },
                 },
                 examples=[
                     utils.OpenApiExample(
                         "Example 404 response",
                         value={
-                            "status": "error",
-                            "errors": {"user_id": "The user does not exist."},
+                            custom_response.STATUS: custom_response.Status.ERROR,
+                            custom_response.ERRORS: {
+                                "user_id": "The user does not exist."
+                            },
                         },
                     ),
                 ],

--- a/backend/pong/users/views/retrieve.py
+++ b/backend/pong/users/views/retrieve.py
@@ -65,6 +65,8 @@ class UsersRetrieveView(views.APIView):
                     ),
                 ],
             ),
+            # todo: 詳細のschemaが必要であれば追加する
+            500: utils.OpenApiResponse(description="Internal server error"),
         },
     )
     def get(self, request: request.Request, user_id: int) -> response.Response:

--- a/backend/pong/users/views/retrieve.py
+++ b/backend/pong/users/views/retrieve.py
@@ -24,6 +24,7 @@ class UsersRetrieveView(views.APIView):
     permission_classes = (permissions.AllowAny,)
 
     @utils.extend_schema(
+        operation_id="get_users_retrieve",
         request=None,
         responses={
             200: utils.OpenApiResponse(


### PR DESCRIPTION
## タスクやディスカッションのリンク
<!-- - URLをここに貼る -->
- #270 
- users の流れ: #228 

## やったこと
<!-- - このタスクでやったことはなにか？ -->
- 挙動に関わる実装に変更はありません
- `users` app の 3 つの view (`UsersListView`, `UsersRetrieveView`, `UsersMeView`) について
  - logger の追加
  - extend_schema の変更
  - テストのリファクタリング

## やらないこと
<!-- - このタスクでやらないことはなにか？（やらない場合いつやるのか？無ければ「なし」を記述） -->
この PR は元々 try-except して 500 を返そうと思っていたのですが、`dispatch()` でできそうなため、分かり次第別 PR で 500 を返すようにします

## 動作確認
<!-- - どのような動作確認を行い、結果はどうだったのか？(適宜スクショ等添付) -->
- テストが今まで通り動くこと
```sh
make exec-be
make unit-test ARG=users
```
- swagger-ui にて
  - 以下のエンドポイントのスキーマに 500 が表示されること
    -  `/api/users/` の `GET`
    - `/api/users/{user_id}/`, の `GET`
    - `/api/users/me/` の `GET`, `PATCH`
  - 以下のエンドポイントのスキーマに 401 が表示されること
    - `/api/users/me/` の `GET`, `PATCH`

## 特にレビューをお願いしたい箇所
<!-- - 特にチェックをお願いしたいポイントを簡潔に記述する -->
実装に変更はないので、サラッと確認していただければと思います

## その他
<!-- - 実装上の懸念点、注意点等あれば記載する -->
特になし

## 参考リンク
<!-- - 実装に際し参考にした、記事やサイトのリンクを記載する -->
特になし

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit
- **バグ修正 / 改善**
  - ユーザー一覧、プロフィール取得・更新、個別ユーザー参照の各エンドポイントで、エラー発生時に適切なステータスコード（500、404など）と分かりやすいレスポンスが返されるよう、エラーハンドリングを強化しました。
  
- **セキュリティ向上**
  - プロフィール操作に認証を必須とし、認証情報がない場合は明確なエラーメッセージ（401）が返されるよう改善しました。

- **テストの改善**
  - テストメソッドの名称を変更し、HTTPステータスコードを明示化しました。また、ユーザー作成の確認を行う新しいテストメソッドを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->