### PR TITLE
⚡ [custom response] CustomResponse に code を追加

### DIFF
--- a/backend/pong/pong/custom_response/custom_response.py
+++ b/backend/pong/pong/custom_response/custom_response.py
@@ -15,6 +15,12 @@ class Status:
     ERROR: str = "error"
 
 
+@dataclasses.dataclass(frozen=True)
+class Code:
+    INTERNAL_ERROR: str = "internal_error"
+    UNAUTHORIZED: str = "unauthorized"
+
+
 class CustomResponse(response.Response):
     """
     全appでレスポンスの形式を統一するためのクラス

--- a/backend/pong/pong/custom_response/custom_response.py
+++ b/backend/pong/pong/custom_response/custom_response.py
@@ -5,6 +5,7 @@ from rest_framework import response
 
 STATUS: Final[str] = "status"
 DATA: Final[str] = "data"
+CODE: Final[str] = "code"
 ERRORS: Final[str] = "errors"
 
 
@@ -20,18 +21,21 @@ class CustomResponse(response.Response):
 
     Args:
         data  : 成功時のレスポンスデータ
-        errors: エラー時のエラーメッセージ
+        code  : エラー時のエラーコード(FEでエラーの種類を判別するために定められたコード)
+        errors: エラー時のエラーメッセージ(主に開発者向けのエラーメッセージ)
         status: ステータスコード
 
     レスポンスのJSON形式(self.data):
         {
             "status": "ok" | "error",
             "data": {...},
+            "code": ["string", ...],
             "errors": {...}
         }
 
         - status: 必須。300番台までは"ok"、400番台以上は"error"を格納
         - data  : 成功時のみ、返すデータのdictを格納
+        - code  : エラー時のみ、エラーコードのlistを格納
         - errors: エラー時のみ、エラーメッセージのdictを格納
     """
 
@@ -40,6 +44,7 @@ class CustomResponse(response.Response):
     def __init__(
         self,
         data: dict | None = None,
+        code: list[str] | None = None,
         errors: dict | None = None,
         status: int = 200,
     ):
@@ -55,4 +60,5 @@ class CustomResponse(response.Response):
         else:
             # 400番台以上のエラーレスポンス
             self.data[STATUS] = Status.ERROR
+            self.data[CODE] = code if code else []
             self.data[ERRORS] = errors if errors else {}

--- a/backend/pong/pong/custom_response/custom_response.py
+++ b/backend/pong/pong/custom_response/custom_response.py
@@ -1,5 +1,5 @@
 import dataclasses
-from typing import Final
+from typing import Final, Optional
 
 from rest_framework import response
 
@@ -43,9 +43,9 @@ class CustomResponse(response.Response):
     # https://github.com/django/django/blob/main/django/http/response.py#L111
     def __init__(
         self,
-        data: dict | None = None,
-        code: list[str] | None = None,
-        errors: dict | None = None,
+        data: Optional[dict] = None,
+        code: Optional[list[str]] = None,
+        errors: Optional[dict] = None,
         status: int = 200,
     ):
         # 内部で100-599番以外のステータスコードは例外を発生させる
@@ -56,9 +56,9 @@ class CustomResponse(response.Response):
         if status < 400:
             # 300番台までの成功レスポンス
             self.data[STATUS] = Status.OK
-            self.data[DATA] = data if data else {}
+            self.data[DATA] = data or {}
         else:
             # 400番台以上のエラーレスポンス
             self.data[STATUS] = Status.ERROR
-            self.data[CODE] = code if code else []
-            self.data[ERRORS] = errors if errors else {}
+            self.data[CODE] = code or []
+            self.data[ERRORS] = errors or {}

--- a/backend/pong/pong/custom_response/test_custom_response.py
+++ b/backend/pong/pong/custom_response/test_custom_response.py
@@ -7,6 +7,7 @@ from . import custom_response
 
 STATUS: Final[str] = custom_response.STATUS
 DATA: Final[str] = custom_response.DATA
+CODE: Final[str] = custom_response.CODE
 ERRORS: Final[str] = custom_response.ERRORS
 
 STATUS_OK: Final[str] = custom_response.Status.OK
@@ -49,6 +50,7 @@ class ResponseTests(test.TestCase):
         """
         response: custom_response.CustomResponse = (
             custom_response.CustomResponse(
+                code=["invalid"],
                 errors={"key": "value"},
                 status=status.HTTP_400_BAD_REQUEST,
             )
@@ -57,7 +59,11 @@ class ResponseTests(test.TestCase):
         self.assertEqual(response.status, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(
             response.data,
-            {STATUS: STATUS_ERROR, ERRORS: {"key": "value"}},
+            {
+                STATUS: STATUS_ERROR,
+                CODE: ["invalid"],
+                ERRORS: {"key": "value"},
+            },
         )
 
     # -------------------------------------------------------------------------

--- a/backend/pong/pong/custom_response/test_custom_response.py
+++ b/backend/pong/pong/custom_response/test_custom_response.py
@@ -1,5 +1,6 @@
-from typing import Final
+from typing import Final, Optional
 
+import parameterized  # type: ignore[import-untyped]
 from django import test
 from rest_framework import status
 
@@ -31,7 +32,7 @@ class ResponseTests(test.TestCase):
 
     def test_201_with_data(self) -> None:
         """
-        201で呼ばれた際に、成功レスポンスが形式に沿って返されることを確認
+        201(デフォルト値の200以外)で呼ばれた際に、成功レスポンスが形式に沿って返されることを確認
         """
         response: custom_response.CustomResponse = (
             custom_response.CustomResponse(
@@ -44,13 +45,29 @@ class ResponseTests(test.TestCase):
             response.data, {STATUS: STATUS_OK, DATA: {"key": "value"}}
         )
 
-    def test_400_with_errors(self) -> None:
+    @parameterized.parameterized.expand(
+        [
+            ("codeが引数に渡されない場合", None, []),
+            ("codeが1つの場合", ["invalid"], ["invalid"]),
+            (
+                "codeが複数の場合",
+                ["invalid1", "invalid2"],
+                ["invalid1", "invalid2"],
+            ),
+        ]
+    )
+    def test_400_with_code(
+        self,
+        testcase_name: str,
+        code: Optional[list[str]],
+        expected_code: Optional[list[str]],
+    ) -> None:
         """
-        400で呼ばれた際に、エラーレスポンスが形式に沿って返されることを確認
+        エラー時に400で呼ばれた際に、エラーレスポンスが形式に沿って返されることを確認
         """
         response: custom_response.CustomResponse = (
             custom_response.CustomResponse(
-                code=["invalid"],
+                code=code,
                 errors={"key": "value"},
                 status=status.HTTP_400_BAD_REQUEST,
             )
@@ -61,7 +78,7 @@ class ResponseTests(test.TestCase):
             response.data,
             {
                 STATUS: STATUS_ERROR,
-                CODE: ["invalid"],
+                CODE: expected_code,
                 ERRORS: {"key": "value"},
             },
         )


### PR DESCRIPTION
## タスクやディスカッションのリンク
<!-- - URLをここに貼る -->
- #281 

## やったこと
<!-- - このタスクでやったことはなにか？ -->
エラー時にレスポンスに `code` を使用することになったため、`CustomResponse` に `code` フィールド(？) を追加しました


## やらないこと
<!-- - このタスクでやらないことはなにか？（やらない場合いつやるのか？無ければ「なし」を記述） -->
旧エラー時に使用していた `errors` は削除していません
`errors` を消すと変更箇所が多いこと・開発者用に logger とは別で swagger-ui で見られるエラーメッセージの格納場所としてこのまま残しておいても良いかもと思ったので残しました
extend_schema の examples には errors は不要だと思います
何かあれば教えてください！

## 動作確認
<!-- - どのような動作確認を行い、結果はどうだったのか？(適宜スクショ等添付) -->
テストが今まで通りとおること
```sh
make exec-be
make test
```

## 特にレビューをお願いしたい箇所
<!-- - 特にチェックをお願いしたいポイントを簡潔に記述する -->
- `code` の追加について問題ないかどうか
- `errors` について残しておいても良いかどうか

## その他
<!-- - 実装上の懸念点、注意点等あれば記載する -->
なし

## 参考リンク
<!-- - 実装に際し参考にした、記事やサイトのリンクを記載する -->
なし

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
	- エラー対応が強化され、エラー発生時にエラーコードのリストが付加されるようになりました。これにより、問題発生時の原因特定が容易になり、ユーザーにとってエラー内容の把握がしやすくなりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->