### PR TITLE
🌱 [friends] フレンド新規追加の POST メソッドで使用する serializer 追加

### DIFF
--- a/backend/pong/users/constants.py
+++ b/backend/pong/users/constants.py
@@ -7,4 +7,5 @@ from pong.custom_response import custom_response
 @dataclasses.dataclass(frozen=True)
 class Code:
     INVALID: Final[str] = "invalid"
+    NOT_EXISTS: Final[str] = "not_exists"
     INTERNAL_ERROR: Final[str] = custom_response.Code.INTERNAL_ERROR

--- a/backend/pong/users/friends/serializers/create_serializers.py
+++ b/backend/pong/users/friends/serializers/create_serializers.py
@@ -48,4 +48,12 @@ class FriendshipCreateSerializer(serializers.ModelSerializer):
         # 自分自身をフレンドに追加しようとした場合にValidationErrorを発生させる
         validators.invalid_same_user_validator(user_id, friend_user_id)
 
+        # フレンドに追加したいユーザーが既にフレンドである場合にValidationErrorを発生させる
+        if validators.is_friendship_exists(user_id, friend_user_id):
+            raise serializers.ValidationError(
+                {
+                    constants.FriendshipFields.FRIEND_USER_ID: "The user is already a friend."
+                },
+                code="invalid",  # todo: constantsに置き換え
+            )
         return data

--- a/backend/pong/users/friends/serializers/create_serializers.py
+++ b/backend/pong/users/friends/serializers/create_serializers.py
@@ -4,6 +4,7 @@ from accounts import constants as accounts_constants
 from users import serializers as users_serializers
 
 from .. import constants, models
+from . import validators
 
 
 class FriendshipCreateSerializer(serializers.ModelSerializer):
@@ -36,3 +37,15 @@ class FriendshipCreateSerializer(serializers.ModelSerializer):
         return models.Friendship.objects.create(
             user_id=user_id, friend_id=friend_user_id
         )
+
+    def validate(self, data: dict) -> dict:
+        """
+        is_valid()内で呼ばれるvalidate()のオーバーライド
+        """
+        user_id: int = data["user"]["id"]
+        friend_user_id: int = data["friend"]["id"]
+
+        # 自分自身をフレンドに追加しようとした場合にValidationErrorを発生させる
+        validators.invalid_same_user_validator(user_id, friend_user_id)
+
+        return data

--- a/backend/pong/users/friends/serializers/create_serializers.py
+++ b/backend/pong/users/friends/serializers/create_serializers.py
@@ -1,0 +1,38 @@
+from rest_framework import serializers
+
+from accounts import constants as accounts_constants
+from users import serializers as users_serializers
+
+from .. import constants, models
+
+
+class FriendshipCreateSerializer(serializers.ModelSerializer):
+    user_id = serializers.IntegerField(source="user.id", min_value=1)
+    friend_user_id = serializers.IntegerField(source="friend.id", min_value=1)
+    friend = users_serializers.UsersSerializer(
+        source="friend.player",
+        read_only=True,
+        fields=(  # emailは含めない
+            accounts_constants.UserFields.USERNAME,
+            accounts_constants.PlayerFields.DISPLAY_NAME,
+            # todo: avatar追加
+        ),
+    )
+
+    class Meta:
+        model = models.Friendship
+        fields = (
+            constants.FriendshipFields.USER_ID,
+            constants.FriendshipFields.FRIEND_USER_ID,
+            constants.FriendshipFields.FRIEND,
+        )
+
+    def create(self, data: dict) -> models.Friendship:
+        """
+        save()内で呼ばれるcreate()のオーバーライド
+        """
+        user_id: int = data["user"]["id"]
+        friend_user_id: int = data["friend"]["id"]
+        return models.Friendship.objects.create(
+            user_id=user_id, friend_id=friend_user_id
+        )

--- a/backend/pong/users/friends/serializers/create_serializers.py
+++ b/backend/pong/users/friends/serializers/create_serializers.py
@@ -1,6 +1,7 @@
 from rest_framework import serializers
 
 from accounts import constants as accounts_constants
+from users import constants as users_constants
 from users import serializers as users_serializers
 
 from .. import constants, models
@@ -54,6 +55,6 @@ class FriendshipCreateSerializer(serializers.ModelSerializer):
                 {
                     constants.FriendshipFields.FRIEND_USER_ID: "The user is already a friend."
                 },
-                code="invalid",  # todo: constantsに置き換え
+                code=users_constants.Code.INVALID,
             )
         return data

--- a/backend/pong/users/friends/serializers/create_serializers.py
+++ b/backend/pong/users/friends/serializers/create_serializers.py
@@ -42,6 +42,12 @@ class FriendshipCreateSerializer(serializers.ModelSerializer):
     def validate(self, data: dict) -> dict:
         """
         is_valid()内で呼ばれるvalidate()のオーバーライド
+
+        Raises:
+            serializers.ValidationError
+              - 自分自身をフレンドに追加しようとした場合
+              - フレンドに追加したいユーザーが存在しない場合
+              - フレンドに追加したいユーザーが既にフレンドである場合
         """
         user_id: int = data["user"]["id"]
         friend_user_id: int = data["friend"]["id"]

--- a/backend/pong/users/friends/serializers/create_serializers.py
+++ b/backend/pong/users/friends/serializers/create_serializers.py
@@ -17,7 +17,7 @@ class FriendshipCreateSerializer(serializers.ModelSerializer):
         fields=(  # emailは含めない
             accounts_constants.UserFields.USERNAME,
             accounts_constants.PlayerFields.DISPLAY_NAME,
-            # todo: avatar追加
+            accounts_constants.PlayerFields.AVATAR,
         ),
     )
 

--- a/backend/pong/users/friends/serializers/list_serializers.py
+++ b/backend/pong/users/friends/serializers/list_serializers.py
@@ -19,6 +19,7 @@ class FriendshipListSerializer(drf_serializers.ModelSerializer):
         fields=(  # emailは含めない
             accounts_constants.UserFields.USERNAME,
             accounts_constants.PlayerFields.DISPLAY_NAME,
+            accounts_constants.PlayerFields.AVATAR,
         ),
     )
 

--- a/backend/pong/users/friends/serializers/tests/test_create_serializers.py
+++ b/backend/pong/users/friends/serializers/tests/test_create_serializers.py
@@ -1,0 +1,53 @@
+from typing import Final
+
+from django.contrib.auth.models import User
+from django.test import TestCase
+
+from accounts import constants as accounts_constants
+from accounts.player import models as players_models
+
+from ... import constants
+
+ID: Final[str] = accounts_constants.UserFields.ID
+USERNAME: Final[str] = accounts_constants.UserFields.USERNAME
+EMAIL: Final[str] = accounts_constants.UserFields.EMAIL
+PASSWORD: Final[str] = accounts_constants.UserFields.PASSWORD
+USER: Final[str] = accounts_constants.PlayerFields.USER
+DISPLAY_NAME: Final[str] = accounts_constants.PlayerFields.DISPLAY_NAME
+
+USER_ID: Final[str] = constants.FriendshipFields.USER_ID
+FRIEND_USER_ID: Final[str] = constants.FriendshipFields.FRIEND_USER_ID
+FRIEND: Final[str] = constants.FriendshipFields.FRIEND
+
+
+class FriendshipCreateSerializerTests(TestCase):
+    def setUp(self) -> None:
+        """
+        TestCaseのsetUpメソッドのオーバーライド
+        """
+
+        def _create_user(user_data: dict, player_data: dict) -> User:
+            user: User = User.objects.create_user(**user_data)
+            player_data[USER] = user
+            players_models.Player.objects.create(**player_data)
+            return user
+
+        # 2人のuserを作成
+        self.user_data_1: dict = {
+            USERNAME: "testuser1",
+            EMAIL: "testuser1@example.com",
+            PASSWORD: "testpassword",
+        }
+        self.user_data_2: dict = {
+            USERNAME: "testuser2",
+            EMAIL: "testuser2@example.com",
+            PASSWORD: "testpassword",
+        }
+        self.player_data_1: dict = {
+            DISPLAY_NAME: "display_name1",
+        }
+        self.player_data_2: dict = {
+            DISPLAY_NAME: "display_name2",
+        }
+        self.user1: User = _create_user(self.user_data_1, self.player_data_1)
+        self.user2: User = _create_user(self.user_data_2, self.player_data_2)

--- a/backend/pong/users/friends/serializers/tests/test_create_serializers.py
+++ b/backend/pong/users/friends/serializers/tests/test_create_serializers.py
@@ -154,3 +154,5 @@ class FriendshipCreateSerializerTests(TestCase):
             create_serializer.errors[FRIEND_USER_ID][0].code,
             CODE_NOT_EXISTS,
         )
+
+    # todo: requestから取得するfriend_user_idがNoneの場合のテストを追加(今は自動でcode="null"が返る)

--- a/backend/pong/users/friends/serializers/tests/test_create_serializers.py
+++ b/backend/pong/users/friends/serializers/tests/test_create_serializers.py
@@ -127,3 +127,23 @@ class FriendshipCreateSerializerTests(TestCase):
             create_serializer.errors[FRIEND_USER_ID][0].code,
             "invalid",  # todo: constantsに置き換え
         )
+
+    def test_not_exist_friend(self) -> None:
+        """
+        存在しないユーザーをフレンドに追加しようとした場合にエラーになることを確認
+        """
+        # user1が存在しないユーザーをフレンドに追加しようとする
+        friendship_data: dict = {
+            USER_ID: self.user1.id,
+            FRIEND_USER_ID: 9999,
+        }
+        create_serializer: create_serializers.FriendshipCreateSerializer = (
+            create_serializers.FriendshipCreateSerializer(data=friendship_data)
+        )
+
+        self.assertFalse(create_serializer.is_valid())
+        self.assertIn(FRIEND_USER_ID, create_serializer.errors)
+        self.assertEqual(
+            create_serializer.errors[FRIEND_USER_ID][0].code,
+            "not_exists",  # todo: constantsに置き換え
+        )

--- a/backend/pong/users/friends/serializers/tests/test_create_serializers.py
+++ b/backend/pong/users/friends/serializers/tests/test_create_serializers.py
@@ -7,6 +7,7 @@ from accounts import constants as accounts_constants
 from accounts.player import models as players_models
 
 from ... import constants
+from .. import create_serializers
 
 ID: Final[str] = accounts_constants.UserFields.ID
 USERNAME: Final[str] = accounts_constants.UserFields.USERNAME
@@ -51,3 +52,36 @@ class FriendshipCreateSerializerTests(TestCase):
         }
         self.user1: User = _create_user(self.user_data_1, self.player_data_1)
         self.user2: User = _create_user(self.user_data_2, self.player_data_2)
+
+    def test_valid_friendship_create(self) -> None:
+        """
+        正常にフレンド追加ができることを確認
+        """
+        # user1がuser2をフレンドに追加する
+        friendship_data: dict = {
+            USER_ID: self.user1.id,
+            FRIEND_USER_ID: self.user2.id,
+        }
+        create_serializer: create_serializers.FriendshipCreateSerializer = (
+            create_serializers.FriendshipCreateSerializer(data=friendship_data)
+        )
+
+        # validate()確認
+        self.assertTrue(create_serializer.is_valid())
+        self.assertEqual(
+            create_serializer.validated_data,
+            {USER: {ID: self.user1.id}, FRIEND: {ID: self.user2.id}},
+        )
+        # create()確認
+        create_serializer.save()
+        self.assertEqual(
+            create_serializer.data,
+            {
+                USER_ID: self.user1.id,
+                FRIEND_USER_ID: self.user2.id,
+                FRIEND: {
+                    USERNAME: self.user_data_2[USERNAME],
+                    DISPLAY_NAME: self.player_data_2[DISPLAY_NAME],
+                },
+            },
+        )

--- a/backend/pong/users/friends/serializers/tests/test_create_serializers.py
+++ b/backend/pong/users/friends/serializers/tests/test_create_serializers.py
@@ -85,3 +85,23 @@ class FriendshipCreateSerializerTests(TestCase):
                 },
             },
         )
+
+    def test_error_same_user(self) -> None:
+        """
+        自分自身をフレンドに追加しようとした場合にエラーになることを確認
+        """
+        # user1が自分自身をフレンドに追加しようとする
+        friendship_data: dict = {
+            USER_ID: self.user1.id,
+            FRIEND_USER_ID: self.user1.id,
+        }
+        create_serializer: create_serializers.FriendshipCreateSerializer = (
+            create_serializers.FriendshipCreateSerializer(data=friendship_data)
+        )
+
+        self.assertFalse(create_serializer.is_valid())
+        self.assertIn(FRIEND_USER_ID, create_serializer.errors)
+        self.assertEqual(
+            create_serializer.errors[FRIEND_USER_ID][0].code,
+            "internal_error",  # todo: constantsに置き換え
+        )

--- a/backend/pong/users/friends/serializers/tests/test_create_serializers.py
+++ b/backend/pong/users/friends/serializers/tests/test_create_serializers.py
@@ -16,6 +16,7 @@ EMAIL: Final[str] = accounts_constants.UserFields.EMAIL
 PASSWORD: Final[str] = accounts_constants.UserFields.PASSWORD
 USER: Final[str] = accounts_constants.PlayerFields.USER
 DISPLAY_NAME: Final[str] = accounts_constants.PlayerFields.DISPLAY_NAME
+AVATAR: Final[str] = accounts_constants.PlayerFields.AVATAR
 
 USER_ID: Final[str] = constants.FriendshipFields.USER_ID
 FRIEND_USER_ID: Final[str] = constants.FriendshipFields.FRIEND_USER_ID
@@ -87,6 +88,7 @@ class FriendshipCreateSerializerTests(TestCase):
                 FRIEND: {
                     USERNAME: self.user_data_2[USERNAME],
                     DISPLAY_NAME: self.player_data_2[DISPLAY_NAME],
+                    AVATAR: "/media/avatars/sample.png",  # todo: デフォルト画像が変更になったら修正
                 },
             },
         )

--- a/backend/pong/users/friends/serializers/tests/test_create_serializers.py
+++ b/backend/pong/users/friends/serializers/tests/test_create_serializers.py
@@ -5,6 +5,7 @@ from django.test import TestCase
 
 from accounts import constants as accounts_constants
 from accounts.player import models as players_models
+from users import constants as users_constants
 
 from ... import constants, models
 from .. import create_serializers
@@ -19,6 +20,10 @@ DISPLAY_NAME: Final[str] = accounts_constants.PlayerFields.DISPLAY_NAME
 USER_ID: Final[str] = constants.FriendshipFields.USER_ID
 FRIEND_USER_ID: Final[str] = constants.FriendshipFields.FRIEND_USER_ID
 FRIEND: Final[str] = constants.FriendshipFields.FRIEND
+
+CODE_INVALID: Final[str] = users_constants.Code.INVALID
+CODE_NOT_EXISTS: Final[str] = users_constants.Code.NOT_EXISTS
+CODE_INTERNAL_ERROR: Final[str] = users_constants.Code.INTERNAL_ERROR
 
 
 class FriendshipCreateSerializerTests(TestCase):
@@ -103,7 +108,7 @@ class FriendshipCreateSerializerTests(TestCase):
         self.assertIn(FRIEND_USER_ID, create_serializer.errors)
         self.assertEqual(
             create_serializer.errors[FRIEND_USER_ID][0].code,
-            "internal_error",  # todo: constantsに置き換え
+            CODE_INTERNAL_ERROR,
         )
 
     def test_error_already_friend(self) -> None:
@@ -125,7 +130,7 @@ class FriendshipCreateSerializerTests(TestCase):
         self.assertIn(FRIEND_USER_ID, create_serializer.errors)
         self.assertEqual(
             create_serializer.errors[FRIEND_USER_ID][0].code,
-            "invalid",  # todo: constantsに置き換え
+            CODE_INVALID,
         )
 
     def test_not_exist_friend(self) -> None:
@@ -145,5 +150,5 @@ class FriendshipCreateSerializerTests(TestCase):
         self.assertIn(FRIEND_USER_ID, create_serializer.errors)
         self.assertEqual(
             create_serializer.errors[FRIEND_USER_ID][0].code,
-            "not_exists",  # todo: constantsに置き換え
+            CODE_NOT_EXISTS,
         )

--- a/backend/pong/users/friends/serializers/tests/test_list_serializers.py
+++ b/backend/pong/users/friends/serializers/tests/test_list_serializers.py
@@ -15,6 +15,7 @@ EMAIL: Final[str] = accounts_constants.UserFields.EMAIL
 PASSWORD: Final[str] = accounts_constants.UserFields.PASSWORD
 USER: Final[str] = accounts_constants.PlayerFields.USER
 DISPLAY_NAME: Final[str] = accounts_constants.PlayerFields.DISPLAY_NAME
+AVATAR: Final[str] = accounts_constants.PlayerFields.AVATAR
 
 USER_ID: Final[str] = constants.FriendshipFields.USER_ID
 FRIEND_USER_ID: Final[str] = constants.FriendshipFields.FRIEND_USER_ID
@@ -87,6 +88,7 @@ class FriendshipListSerializerTests(TestCase):
                     FRIEND: {
                         USERNAME: self.user_data_2[USERNAME],
                         DISPLAY_NAME: self.player_data_2[DISPLAY_NAME],
+                        AVATAR: "/media/avatars/sample.png",  # todo: デフォルト画像が変更になったら修正
                     },
                 },
                 {
@@ -95,6 +97,7 @@ class FriendshipListSerializerTests(TestCase):
                     FRIEND: {
                         USERNAME: self.user_data_3[USERNAME],
                         DISPLAY_NAME: self.player_data_3[DISPLAY_NAME],
+                        AVATAR: "/media/avatars/sample.png",  # todo: デフォルト画像が変更になったら修正
                     },
                 },
             ],

--- a/backend/pong/users/friends/serializers/validators.py
+++ b/backend/pong/users/friends/serializers/validators.py
@@ -1,6 +1,6 @@
 from rest_framework import serializers
 
-from .. import constants
+from .. import constants, models
 
 
 def invalid_same_user_validator(user_id: int, friend_user_id: int) -> None:
@@ -22,3 +22,24 @@ def invalid_same_user_validator(user_id: int, friend_user_id: int) -> None:
             },
             code="internal_error",  # todo: constantsに置き換え
         )
+
+
+def is_friendship_exists(user_id: int, friend_user_id: int) -> bool:
+    """
+    user_idが既にfriend_user_idをフレンドに追加済みであるかどうかを返す
+    create,destroyのserializerのvalidate()で呼ばれる想定
+
+    Args:
+        user_id: リクエストを送信したユーザーのID
+        friend_user_id: フレンド追加対象・削除対象のユーザーのID
+
+    Returns:
+        bool: 2人が既にフレンドであればTrue、そうでなければFalse
+
+    Raises:
+        serializers.ValidationError: フレンドに追加したいidがDBに存在せず、フレンドかどうかの判定ができない場合
+    """
+    # 既にフレンドであるかどうか
+    return models.Friendship.objects.filter(
+        user_id=user_id, friend_id=friend_user_id
+    ).exists()

--- a/backend/pong/users/friends/serializers/validators.py
+++ b/backend/pong/users/friends/serializers/validators.py
@@ -1,0 +1,24 @@
+from rest_framework import serializers
+
+from .. import constants
+
+
+def invalid_same_user_validator(user_id: int, friend_user_id: int) -> None:
+    """
+    Friendshipに渡すfriend_user_idが自分自身である場合に例外を発生させる
+    create,destroyのserializerのvalidate()で呼ばれる想定
+
+    Args:
+        user_id: リクエストを送信したユーザーのID
+        friend_user_id: フレンド追加対象・削除対象のユーザーのID
+
+    Raises:
+        serializers.ValidationError: フレンドとして追加したいユーザーが自分自身の場合
+    """
+    if user_id == friend_user_id:
+        raise serializers.ValidationError(
+            {
+                constants.FriendshipFields.FRIEND_USER_ID: "The friend_user_id cannot be the same as user_id."
+            },
+            code="internal_error",  # todo: constantsに置き換え
+        )

--- a/backend/pong/users/friends/serializers/validators.py
+++ b/backend/pong/users/friends/serializers/validators.py
@@ -1,3 +1,4 @@
+from django.contrib.auth.models import User
 from rest_framework import serializers
 
 from .. import constants, models
@@ -39,6 +40,14 @@ def is_friendship_exists(user_id: int, friend_user_id: int) -> bool:
     Raises:
         serializers.ValidationError: フレンドに追加したいidがDBに存在せず、フレンドかどうかの判定ができない場合
     """
+    # フレンドに追加したいidがDBに存在しない場合はエラー
+    if not User.objects.filter(id=friend_user_id).exists():
+        raise serializers.ValidationError(
+            {
+                constants.FriendshipFields.FRIEND_USER_ID: "The user does not exist."
+            },
+            code="not_exists",  # todo: constantsに置き換え
+        )
     # 既にフレンドであるかどうか
     return models.Friendship.objects.filter(
         user_id=user_id, friend_id=friend_user_id

--- a/backend/pong/users/friends/serializers/validators.py
+++ b/backend/pong/users/friends/serializers/validators.py
@@ -1,6 +1,8 @@
 from django.contrib.auth.models import User
 from rest_framework import serializers
 
+from users import constants as users_constants
+
 from .. import constants, models
 
 
@@ -21,7 +23,7 @@ def invalid_same_user_validator(user_id: int, friend_user_id: int) -> None:
             {
                 constants.FriendshipFields.FRIEND_USER_ID: "The friend_user_id cannot be the same as user_id."
             },
-            code="internal_error",  # todo: constantsに置き換え
+            code=users_constants.Code.INTERNAL_ERROR,
         )
 
 
@@ -46,7 +48,7 @@ def is_friendship_exists(user_id: int, friend_user_id: int) -> bool:
             {
                 constants.FriendshipFields.FRIEND_USER_ID: "The user does not exist."
             },
-            code="not_exists",  # todo: constantsに置き換え
+            code=users_constants.Code.NOT_EXISTS,
         )
     # 既にフレンドであるかどうか
     return models.Friendship.objects.filter(

--- a/backend/pong/users/friends/tests/integration/test_list_views.py
+++ b/backend/pong/users/friends/tests/integration/test_list_views.py
@@ -16,6 +16,7 @@ EMAIL: Final[str] = accounts_constants.UserFields.EMAIL
 PASSWORD: Final[str] = accounts_constants.UserFields.PASSWORD
 USER: Final[str] = accounts_constants.PlayerFields.USER
 DISPLAY_NAME: Final[str] = accounts_constants.PlayerFields.DISPLAY_NAME
+AVATAR: Final[str] = accounts_constants.PlayerFields.AVATAR
 
 USER_ID: Final[str] = constants.FriendshipFields.USER_ID
 FRIEND_USER_ID: Final[str] = constants.FriendshipFields.FRIEND_USER_ID
@@ -135,6 +136,7 @@ class FriendsListViewTests(test.APITestCase):
                     FRIEND: {
                         USERNAME: self.user_data2[USERNAME],
                         DISPLAY_NAME: self.player_data2[DISPLAY_NAME],
+                        AVATAR: "/media/avatars/sample.png",  # todo: デフォルト画像が変更になったら修正
                     },
                 },
                 {
@@ -143,6 +145,7 @@ class FriendsListViewTests(test.APITestCase):
                     FRIEND: {
                         USERNAME: self.user_data3[USERNAME],
                         DISPLAY_NAME: self.player_data3[DISPLAY_NAME],
+                        AVATAR: "/media/avatars/sample.png",  # todo: デフォルト画像が変更になったら修正
                     },
                 },
             ],
@@ -167,6 +170,7 @@ class FriendsListViewTests(test.APITestCase):
                     FRIEND: {
                         USERNAME: self.user_data3[USERNAME],
                         DISPLAY_NAME: self.player_data3[DISPLAY_NAME],
+                        AVATAR: "/media/avatars/sample.png",  # todo: デフォルト画像が変更になったら修正
                     },
                 },
             ],


### PR DESCRIPTION
## タスクやディスカッションのリンク
<!-- - URLをここに貼る -->
- #294 
- friends の流れ : #228 

## やったこと
<!-- - このタスクでやったことはなにか？ -->
- フレンド追加のエンドポイントである `/api/users/me/friends/`, `POST` (view は別 PR で実装) で使用する、 `FriendshipCreateSerializer` とそのユニットテストを先に追加しました
- GET(list) と POST(create) で serializer を分けている理由は、POST(create) と追加予定の DELETE(destroy) で `validate()` 内容が異なるため別の serializer にしたいからです。GET, POST も統一して別の serializer にすることにしました

## やらないこと
<!-- - このタスクでやらないことはなにか？（やらない場合いつやるのか？無ければ「なし」を記述） -->
この serializer を使用した POST の view の作成 -> 別 PR でします

## 動作確認
<!-- - どのような動作確認を行い、結果はどうだったのか？(適宜スクショ等添付) -->
- テスト確認
```sh
make exec-be
make test ARG=users.friends
```
- swagger-ui に特に追加なしです

## 特にレビューをお願いしたい箇所
<!-- - 特にチェックをお願いしたいポイントを簡潔に記述する -->
バリデーション内容とそのテストが十分かどうか

## その他
<!-- - 実装上の懸念点、注意点等あれば記載する -->
- required field が request に渡されない場合、code に自動で `"null"` が入りますが、このような場合も全部 `internal_error` に置き換えて返すのはフィールドの required 制約をなくしたりしないといけなくて無理矢理感がすごかったので、一旦 null を返すままにしてあります
FE に、決められた code が取得できない場合は全部 internal_error として扱ってもらう、みたいなルールを定めても良いかもしれません。また mtg で出してみます！

## 参考リンク
<!-- - 実装に際し参考にした、記事やサイトのリンクを記載する -->
Notion, code: https://www.notion.so/440370c7d06c497abfda19ac0fbc95e7?pvs=4#9023baf6290842e99188e34f745ea928

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - ユーザー間での友達追加機能が導入され、自己追加、重複追加、存在しないユーザーへのリクエストに対して明確なエラーメッセージが表示されるようになりました。
  - 友達リストに友達のアバター情報が追加され、より豊富なデータが提供されるようになりました。

- **テスト**
  - 友達追加の各シナリオ（正常動作およびエラーケース）を厳密に検証するテストが追加され、信頼性が向上しました。
  - 友達リストのシリアライザーに対するテストが強化され、アバター情報が正しくシリアライズされることが確認されました。

- **バリデーション**
  - 自分自身を友達として追加できないことを確認するバリデーション機能が追加されました。
  - すでに友達関係にあるかどうかを確認するバリデーション機能が追加されました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->