### PR TITLE
⚡ [friends] `/api/users/me/friends/`, `POST` 実装 (フレンド追加)

### DIFF
--- a/backend/pong/users/friends/views.py
+++ b/backend/pong/users/friends/views.py
@@ -112,11 +112,22 @@ class FriendsViewSet(viewsets.ModelViewSet):
     def _handle_create_validation_error(
         self, errors: dict
     ) -> response.Response:
-        # todo: code取得してセット
-        return custom_response.CustomResponse(
-            errors=errors,
-            status=status.HTTP_400_BAD_REQUEST,
-        )
+        try:
+            # friend_user_idしか入っていない想定のためignoreで対応
+            code: str = errors.get(  # type: ignore
+                constants.FriendshipFields.FRIEND_USER_ID
+            )[0].code
+            return custom_response.CustomResponse(
+                code=[code],
+                errors=errors,
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        except Exception as inner_exception:
+            return custom_response.CustomResponse(
+                code=[users_constants.Code.INTERNAL_ERROR],
+                errors={"detail": str(inner_exception)},
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            )
 
     def create(self, request: request.Request) -> response.Response:
         """

--- a/backend/pong/users/friends/views.py
+++ b/backend/pong/users/friends/views.py
@@ -159,6 +159,7 @@ class FriendsViewSet(viewsets.ModelViewSet):
         list_serializer: list_serializers.FriendshipListSerializer = (
             list_serializers.FriendshipListSerializer(friends, many=True)
         )
+        # todo: logger.info追加
         return custom_response.CustomResponse(
             data=list_serializer.data, status=status.HTTP_200_OK
         )
@@ -182,8 +183,9 @@ class FriendsViewSet(viewsets.ModelViewSet):
             code: str = errors.get(  # type: ignore
                 constants.FriendshipFields.FRIEND_USER_ID
             )[0].code
+            # codeの取得に成功した場合
             logger.error(
-                f"[400] ValidationError: failed to create friendship(user_id={user_id},friend_user_id={friend_user_id}): {errors}"
+                f"[400] ValidationError: failed to create friendship(user_id={user_id},friend_user_id={friend_user_id}): code={code}: {errors}"
             )
             return custom_response.CustomResponse(
                 code=[code],
@@ -191,6 +193,10 @@ class FriendsViewSet(viewsets.ModelViewSet):
                 status=status.HTTP_400_BAD_REQUEST,
             )
         except Exception as inner_exception:
+            # codeの取得に失敗した場合
+            logger.error(
+                f"[500] Failed to create friendship(user_id={user_id},friend_user_id={friend_user_id}): {str(inner_exception)} from {errors}"
+            )
             return custom_response.CustomResponse(
                 code=[users_constants.Code.INTERNAL_ERROR],
                 errors={"detail": str(inner_exception)},
@@ -230,6 +236,9 @@ class FriendsViewSet(viewsets.ModelViewSet):
             )
         except Exception as e:
             # DatabaseErrorなど
+            logger.error(
+                f"[500] Failed to create friendship(user_id={user.id},friend_user_id={friend_user_id}): {str(e)}"
+            )
             return custom_response.CustomResponse(
                 code=[users_constants.Code.INTERNAL_ERROR],
                 errors={"detail": str(e)},

--- a/backend/pong/users/friends/views.py
+++ b/backend/pong/users/friends/views.py
@@ -62,6 +62,72 @@ from .serializers import create_serializers, list_serializers
             500: utils.OpenApiResponse(description="Internal server error"),
         },
     ),
+    create=utils.extend_schema(
+        request=utils.OpenApiRequest(
+            create_serializers.FriendshipCreateSerializer,
+            examples=[
+                utils.OpenApiExample(
+                    "Example request",
+                    value={constants.FriendshipFields.FRIEND_USER_ID: 1},
+                ),
+            ],
+        ),
+        responses={
+            201: create_serializers.FriendshipCreateSerializer,
+            400: utils.OpenApiResponse(
+                description="The user does not exist.",
+                response={
+                    "type": "object",
+                    "properties": {
+                        custom_response.STATUS: {"type": "string"},
+                        custom_response.CODE: {"type": "list"},
+                    },
+                },
+                examples=[
+                    utils.OpenApiExample(
+                        "Example 400 response - not_exists",
+                        value={
+                            custom_response.STATUS: custom_response.Status.ERROR,
+                            custom_response.CODE: users_constants.Code.NOT_EXISTS,
+                        },
+                    ),
+                    utils.OpenApiExample(
+                        "Example 400 response - invalid",
+                        value={
+                            custom_response.STATUS: custom_response.Status.ERROR,
+                            custom_response.CODE: users_constants.Code.INVALID,
+                        },
+                    ),
+                    utils.OpenApiExample(
+                        "Example 400 response - internal_error",
+                        value={
+                            custom_response.STATUS: custom_response.Status.ERROR,
+                            custom_response.CODE: users_constants.Code.INTERNAL_ERROR,
+                        },
+                    ),
+                ],
+            ),
+            # todo: 現在Djangoが自動で返している。CustomResponseが使えたら併せて変更する
+            401: utils.OpenApiResponse(
+                description="Not authenticated",
+                response={
+                    "type": "object",
+                    "properties": {"detail": {"type": "string"}},
+                },
+                examples=[
+                    utils.OpenApiExample(
+                        "Example 401 response",
+                        value={
+                            "detail": "Authentication credentials were not provided."
+                        },
+                    ),
+                ],
+            ),
+            # todo: 404は確定したら追加する
+            # todo: 詳細のschemaが必要であれば追加する
+            500: utils.OpenApiResponse(description="Internal server error"),
+        },
+    ),
 )
 # todo: 各メソッドにtry-exceptを書いて予期せぬエラー(実装上のミスを含む)の場合に500を返す
 class FriendsViewSet(viewsets.ModelViewSet):

--- a/backend/pong/users/friends/views.py
+++ b/backend/pong/users/friends/views.py
@@ -5,6 +5,7 @@ from rest_framework import permissions, request, response, status, viewsets
 
 from accounts import constants as accounts_constants
 from pong.custom_response import custom_response
+from users import constants as users_constants
 
 from . import constants, models
 from .serializers import list_serializers
@@ -28,6 +29,7 @@ from .serializers import list_serializers
                                     constants.FriendshipFields.FRIEND: {
                                         accounts_constants.UserFields.USERNAME: "username2",
                                         accounts_constants.PlayerFields.DISPLAY_NAME: "display_name2",
+                                        accounts_constants.PlayerFields.AVATAR: "/media/avatars/sample.png",
                                     },
                                 },
                                 {"...", "..."},
@@ -72,6 +74,7 @@ class FriendsViewSet(viewsets.ModelViewSet):
         user: User | AnonymousUser = request.user
         if isinstance(user, AnonymousUser):
             return custom_response.CustomResponse(
+                code=[users_constants.Code.INTERNAL_ERROR],
                 errors={"user": "The user does not exist."},
                 status=status.HTTP_404_NOT_FOUND,  # todo: 404ではないかも
             )


### PR DESCRIPTION
## タスクやディスカッションのリンク
<!-- - URLをここに貼る -->
- #251 
- friends の流れ : #228 

## やったこと
<!-- - このタスクでやったことはなにか？ -->
- #296 で作成した create() 用の serializer を使用して、`/api/users/me/friends/`, `POST` エンドポイントの実装を追加しました
- extend_schema・logger の追加

## やらないこと
<!-- - このタスクでやらないことはなにか？（やらない場合いつやるのか？無ければ「なし」を記述） -->
- integration test 追加 -> 多くなったので別 PR でします (#302 )

## 動作確認
<!-- - どのような動作確認を行い、結果はどうだったのか？(適宜スクショ等添付) -->
- swagger-ui にて
  - ログインする
  - `/api/users/me/friends/`, `POST` にリクエストを送る
    - 自分以外の存在するユーザーID を入力して送る
    -> `201` でフレンド追加が成功。DB の Friendship にログイン中のユーザーID とフレンドユーザーID が追加されている
    -> `/api/users/me/friends/`, `GET` で取得できることを確認しても良い
    - 存在しないユーザーIDをフレンド追加
    -> `400` : `not_exists`
    - 既にフレンドであるユーザーIDをフレンド追加
    -> `400` : `invalid`
    - 自分自身をフレンド追加
    -> `400` : `internal_error`
  - ログインしていない場合は 401 が返る

## 特にレビューをお願いしたい箇所
<!-- - 特にチェックをお願いしたいポイントを簡潔に記述する -->
swagger-ui にて挙動のチェックと、実装面で改善点などあればお願いします

## その他
<!-- - 実装上の懸念点、注意点等あれば記載する -->
~~トランザクションを使用して except で ValidationError をキャッチした場合、`serializer.errors` が使用できないようで、自分でセットした `code` を取得するのに型が複雑で結構大変になってしまいました…~~
-> is_valid() で例外を投げない方法に変えてみました

## 参考リンク
<!-- - 実装に際し参考にした、記事やサイトのリンクを記載する -->
特になし

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **新機能**
	- 認証済みユーザー向けに友達追加のリクエスト送信機能を追加し、POSTリクエストにも対応しました。これにより、ユーザー同士の関係作成がより直感的に行えるようになりました。

- **バグ修正**
	- 未認証ユーザーや入力エラー時に、より適切なエラーメッセージとステータスコードが返されるよう改善され、エラー処理が強化されました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->