### PR TITLE
🌱 [friends] フレンド解除の DELETE メソッドで使用する serializer 追加

### DIFF
--- a/backend/pong/users/friends/serializers/create_serializers.py
+++ b/backend/pong/users/friends/serializers/create_serializers.py
@@ -1,7 +1,6 @@
 from rest_framework import serializers
 
 from accounts import constants as accounts_constants
-from users import constants as users_constants
 from users import serializers as users_serializers
 
 from .. import constants, models
@@ -56,11 +55,6 @@ class FriendshipCreateSerializer(serializers.ModelSerializer):
         validators.invalid_same_user_validator(user_id, friend_user_id)
 
         # フレンドに追加したいユーザーが既にフレンドである場合にValidationErrorを発生させる
-        if validators.is_friendship_exists(user_id, friend_user_id):
-            raise serializers.ValidationError(
-                {
-                    constants.FriendshipFields.FRIEND_USER_ID: "The user is already a friend."
-                },
-                code=users_constants.Code.INVALID,
-            )
+        validators.already_friend_validator(user_id, friend_user_id)
+
         return data

--- a/backend/pong/users/friends/serializers/destroy_serializers.py
+++ b/backend/pong/users/friends/serializers/destroy_serializers.py
@@ -1,6 +1,7 @@
 from rest_framework import serializers
 
 from .. import constants, models
+from . import validators
 
 
 class FriendshipDestroySerializer(serializers.ModelSerializer):
@@ -13,3 +14,18 @@ class FriendshipDestroySerializer(serializers.ModelSerializer):
             constants.FriendshipFields.USER_ID,
             constants.FriendshipFields.FRIEND_USER_ID,
         )
+
+    def validate(self, data: dict) -> dict:
+        """
+        is_valid()内で呼ばれるvalidate()のオーバーライド
+
+        Raises:
+            serializers.ValidationError
+              - 自分自身をフレンド解除しようとした場合
+        """
+        user_id: int = data["user"]["id"]
+        friend_user_id: int = data["friend"]["id"]
+
+        # 自分自身をフレンド解除しようとした場合にValidationErrorを発生させる
+        validators.invalid_same_user_validator(user_id, friend_user_id)
+        return data

--- a/backend/pong/users/friends/serializers/destroy_serializers.py
+++ b/backend/pong/users/friends/serializers/destroy_serializers.py
@@ -1,7 +1,5 @@
 from rest_framework import serializers
 
-from users import constants as users_constants
-
 from .. import constants, models
 from . import validators
 
@@ -34,11 +32,6 @@ class FriendshipDestroySerializer(serializers.ModelSerializer):
         validators.invalid_same_user_validator(user_id, friend_user_id)
 
         # フレンド解除したいユーザーとフレンドではない場合にValidationErrorを発生させる
-        if not validators.is_friendship_exists(user_id, friend_user_id):
-            raise serializers.ValidationError(
-                {
-                    constants.FriendshipFields.FRIEND_USER_ID: "The user is not a friend."
-                },
-                code=users_constants.Code.INVALID,
-            )
+        validators.not_friend_validator(user_id, friend_user_id)
+
         return data

--- a/backend/pong/users/friends/serializers/destroy_serializers.py
+++ b/backend/pong/users/friends/serializers/destroy_serializers.py
@@ -1,0 +1,15 @@
+from rest_framework import serializers
+
+from .. import constants, models
+
+
+class FriendshipDestroySerializer(serializers.ModelSerializer):
+    user_id = serializers.IntegerField(source="user.id", min_value=1)
+    friend_user_id = serializers.IntegerField(source="friend.id", min_value=1)
+
+    class Meta:
+        model = models.Friendship
+        fields = (
+            constants.FriendshipFields.USER_ID,
+            constants.FriendshipFields.FRIEND_USER_ID,
+        )

--- a/backend/pong/users/friends/serializers/destroy_serializers.py
+++ b/backend/pong/users/friends/serializers/destroy_serializers.py
@@ -25,6 +25,7 @@ class FriendshipDestroySerializer(serializers.ModelSerializer):
             serializers.ValidationError
               - フレンド解除したいユーザーがフレンドではない場合
               - 自分自身をフレンド解除しようとした場合
+              - フレンド解除したいユーザーが存在しない場合
         """
         user_id: int = data["user"]["id"]
         friend_user_id: int = data["friend"]["id"]

--- a/backend/pong/users/friends/serializers/destroy_serializers.py
+++ b/backend/pong/users/friends/serializers/destroy_serializers.py
@@ -1,5 +1,7 @@
 from rest_framework import serializers
 
+from users import constants as users_constants
+
 from .. import constants, models
 from . import validators
 
@@ -21,6 +23,7 @@ class FriendshipDestroySerializer(serializers.ModelSerializer):
 
         Raises:
             serializers.ValidationError
+              - フレンド解除したいユーザーがフレンドではない場合
               - 自分自身をフレンド解除しようとした場合
         """
         user_id: int = data["user"]["id"]
@@ -28,4 +31,13 @@ class FriendshipDestroySerializer(serializers.ModelSerializer):
 
         # 自分自身をフレンド解除しようとした場合にValidationErrorを発生させる
         validators.invalid_same_user_validator(user_id, friend_user_id)
+
+        # フレンド解除したいユーザーとフレンドではない場合にValidationErrorを発生させる
+        if not validators.is_friendship_exists(user_id, friend_user_id):
+            raise serializers.ValidationError(
+                {
+                    constants.FriendshipFields.FRIEND_USER_ID: "The user is not a friend."
+                },
+                code=users_constants.Code.INVALID,
+            )
         return data

--- a/backend/pong/users/friends/serializers/tests/test_destroy_serializer.py
+++ b/backend/pong/users/friends/serializers/tests/test_destroy_serializer.py
@@ -22,6 +22,7 @@ FRIEND_USER_ID: Final[str] = constants.FriendshipFields.FRIEND_USER_ID
 FRIEND: Final[str] = constants.FriendshipFields.FRIEND
 
 CODE_INVALID: Final[str] = users_constants.Code.INVALID
+CODE_NOT_EXISTS: Final[str] = users_constants.Code.NOT_EXISTS
 CODE_INTERNAL_ERROR: Final[str] = users_constants.Code.INTERNAL_ERROR
 
 
@@ -137,4 +138,26 @@ class FriendshipCreateSerializerTests(TestCase):
         self.assertEqual(
             destroy_serializer.errors[FRIEND_USER_ID][0].code,
             CODE_INVALID,
+        )
+
+    def test_error_not_exist_friend(self) -> None:
+        """
+        存在しないユーザーをフレンド解除しようとした場合にエラーが発生することを確認
+        """
+        # user1が存在しないユーザーをフレンド解除しようとする
+        friendship_data: dict = {
+            USER_ID: self.user1.id,
+            FRIEND_USER_ID: 9999,
+        }
+        destroy_serializer: destroy_serializers.FriendshipDestroySerializer = (
+            destroy_serializers.FriendshipDestroySerializer(
+                data=friendship_data
+            )
+        )
+
+        self.assertFalse(destroy_serializer.is_valid())
+        self.assertIn(FRIEND_USER_ID, destroy_serializer.errors)
+        self.assertEqual(
+            destroy_serializer.errors[FRIEND_USER_ID][0].code,
+            users_constants.Code.NOT_EXISTS,
         )

--- a/backend/pong/users/friends/serializers/tests/test_destroy_serializer.py
+++ b/backend/pong/users/friends/serializers/tests/test_destroy_serializer.py
@@ -1,0 +1,56 @@
+from typing import Final
+
+from django.contrib.auth.models import User
+from django.test import TestCase
+
+from accounts import constants as accounts_constants
+from accounts.player import models as players_models
+
+from ... import constants, models
+
+ID: Final[str] = accounts_constants.UserFields.ID
+USERNAME: Final[str] = accounts_constants.UserFields.USERNAME
+EMAIL: Final[str] = accounts_constants.UserFields.EMAIL
+PASSWORD: Final[str] = accounts_constants.UserFields.PASSWORD
+USER: Final[str] = accounts_constants.PlayerFields.USER
+DISPLAY_NAME: Final[str] = accounts_constants.PlayerFields.DISPLAY_NAME
+
+USER_ID: Final[str] = constants.FriendshipFields.USER_ID
+FRIEND_USER_ID: Final[str] = constants.FriendshipFields.FRIEND_USER_ID
+FRIEND: Final[str] = constants.FriendshipFields.FRIEND
+
+
+class FriendshipCreateSerializerTests(TestCase):
+    def setUp(self) -> None:
+        """
+        TestCaseのsetUpメソッドのオーバーライド
+        """
+
+        def _create_user(user_data: dict, player_data: dict) -> User:
+            user: User = User.objects.create_user(**user_data)
+            player_data[USER] = user
+            players_models.Player.objects.create(**player_data)
+            return user
+
+        # 2人のuserを作成
+        self.user_data_1: dict = {
+            USERNAME: "testuser1",
+            EMAIL: "testuser1@example.com",
+            PASSWORD: "testpassword",
+        }
+        self.user_data_2: dict = {
+            USERNAME: "testuser2",
+            EMAIL: "testuser2@example.com",
+            PASSWORD: "testpassword",
+        }
+        self.player_data_1: dict = {
+            DISPLAY_NAME: "display_name1",
+        }
+        self.player_data_2: dict = {
+            DISPLAY_NAME: "display_name2",
+        }
+        self.user1: User = _create_user(self.user_data_1, self.player_data_1)
+        self.user2: User = _create_user(self.user_data_2, self.player_data_2)
+
+        # user1がuser2をフレンドに追加
+        models.Friendship.objects.create(user=self.user1, friend=self.user2)


### PR DESCRIPTION
## タスクやディスカッションのリンク
<!-- - URLをここに貼る -->
- #303 
- friends の流れ : #228 

## やったこと
<!-- - このタスクでやったことはなにか？ -->
- フレンド削除のエンドポイントである `/api/users/me/friends/{id}`, `DELETE` (view は別 PR で実装) で使用する、 `FriendshipDestroySerializer` とそのユニットテストを先に追加しました
- POST の時と同じ流れで、serializer 追加 -> view 追加 -> integration test 追加 と PR を分けています

## やらないこと
<!-- - このタスクでやらないことはなにか？（やらない場合いつやるのか？無ければ「なし」を記述） -->
この serializer を使用した DELETE の view の作成 -> 別 PR でします

## 動作確認
<!-- - どのような動作確認を行い、結果はどうだったのか？(適宜スクショ等添付) -->
- テスト確認
```sh
make exec-be
make test ARG=users.friends
```
- swagger-ui に特に追加なしです


## 特にレビューをお願いしたい箇所
<!-- - 特にチェックをお願いしたいポイントを簡潔に記述する -->
バリデーション内容とそのテストが十分かどうか

## その他
<!-- - 実装上の懸念点、注意点等あれば記載する -->

## 参考リンク
<!-- - 実装に際し参考にした、記事やサイトのリンクを記載する -->
Notion, code: https://www.notion.so/440370c7d06c497abfda19ac0fbc95e7?pvs=4#9023baf6290842e99188e34f745ea928

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - ユーザーが友達関係を解除する操作をサポートしました。エラー時には適切な通知が表示され、無効な操作を防ぎます。

- **リファクタリング**
  - 友達追加時の検証ロジックを整理し、全体の処理の一貫性と保守性を向上させました。

- **テスト**
  - 友達解除の各ケース（自分自身の解除、非友達への操作、非存在ユーザーへの操作）をカバーするテストケースを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->