### PR TITLE
⚡ ユーザーのアバターを使用

### DIFF
--- a/frontend/pong/js/api/users/convertUserData.js
+++ b/frontend/pong/js/api/users/convertUserData.js
@@ -3,5 +3,6 @@ export const convertUserData = (userData) => {
     id: userData.id,
     username: userData.username,
     displayName: userData.display_name,
+    avatar: userData.avatar,
   };
 };

--- a/frontend/pong/js/bootstrap/utilities/borders.js
+++ b/frontend/pong/js/bootstrap/utilities/borders.js
@@ -1,0 +1,14 @@
+import { setClassNames } from "../../utils/elements/setClassNames";
+
+const setRounded = (element) => {
+  return setClassNames(element, "rounded");
+};
+
+const setRoundedCircle = (element) => {
+  return setClassNames(element, "rounded-circle");
+};
+
+export const BootstrapBorders = {
+  setRounded,
+  setRoundedCircle,
+};

--- a/frontend/pong/js/components/user/UserListItem.js
+++ b/frontend/pong/js/components/user/UserListItem.js
@@ -19,6 +19,7 @@ export class UserListItem extends Component {
 
   _render() {
     const { item: user } = this._getState();
-    this.append(createNameplate(user));
+    const nameplate = createNameplate(user, "4vh");
+    this.append(nameplate);
   }
 }

--- a/frontend/pong/js/components/user/UserProfile.js
+++ b/frontend/pong/js/components/user/UserProfile.js
@@ -31,7 +31,7 @@ export class UserProfile extends Component {
       return;
     }
 
-    const nameplate = createNameplate(user);
+    const nameplate = createNameplate(user, "8vh");
     const profileButtonPanel = createProfileMenu();
     this.append(
       createDefaultCard({

--- a/frontend/pong/js/constants/Endpoints.js
+++ b/frontend/pong/js/constants/Endpoints.js
@@ -3,6 +3,8 @@ const HOST = "localhost:8000";
 const BASE_URL = new URL(`http://${HOST}`);
 const WEBSOCKET_BASE_URL = new URL(`ws://${HOST}`);
 
+const DEFAULT_AVATAR_IMAGE_PATH = "/media/avatars/sample.png";
+
 export const Endpoints = Object.freeze({
   create: (pathname) => new URL(pathname, BASE_URL),
   HEALTH: new URL("/api/health/", BASE_URL),
@@ -10,5 +12,6 @@ export const Endpoints = Object.freeze({
   USERS: {
     default: new URL("/api/users/", BASE_URL),
     withId: (userId) => new URL(`${userId}`, Endpoints.USERS.default),
+    defaultAvatar: new URL(DEFAULT_AVATAR_IMAGE_PATH, BASE_URL),
   },
 });

--- a/frontend/pong/js/constants/Endpoints.js
+++ b/frontend/pong/js/constants/Endpoints.js
@@ -4,6 +4,7 @@ const BASE_URL = new URL(`http://${HOST}`);
 const WEBSOCKET_BASE_URL = new URL(`ws://${HOST}`);
 
 export const Endpoints = Object.freeze({
+  create: (pathname) => new URL(pathname, BASE_URL),
   HEALTH: new URL("/api/health/", BASE_URL),
   WEBSOCKET: new URL("/ws/", WEBSOCKET_BASE_URL),
   USERS: {

--- a/frontend/pong/js/mocks/handlers/users.js
+++ b/frontend/pong/js/mocks/handlers/users.js
@@ -7,6 +7,7 @@ const createSampleUser = (number) =>
     id: `${number}`,
     username: `pong${number}`,
     display_name: `DISPLAY${number}`,
+    avatar: "https://placehold.co/30",
   });
 const sampleUsers = Array.from({ length: SAMPLE_COUNT }).map(
   (_, idx) => createSampleUser(idx + 1),

--- a/frontend/pong/js/utils/elements/div/createNameplate.js
+++ b/frontend/pong/js/utils/elements/div/createNameplate.js
@@ -12,7 +12,7 @@ export const createNameplate = (user, avatarHeight = "") => {
 
   const avatar = createAvatarImage({
     pathname: user.avatar,
-    alt: nameTagText + "'s avatar`",
+    alt: `${nameTagText}'s avatar`,
     height: avatarHeight,
   });
   const nameTag = createElement("span", {

--- a/frontend/pong/js/utils/elements/div/createNameplate.js
+++ b/frontend/pong/js/utils/elements/div/createNameplate.js
@@ -3,12 +3,14 @@ import { BootstrapFlex } from "../../../bootstrap/utilities/flex";
 import { BootstrapSpacing } from "../../../bootstrap/utilities/spacing";
 import { BootstrapText } from "../../../bootstrap/utilities/text";
 import { createElement } from "../createElement";
+import { setHeight } from "../style/setHeight";
 
-export const createNameplate = (user) => {
+export const createNameplate = (user, avatarHeight = "") => {
   // TODO: 実際のアバターを使用
   const avatar = new Image();
   avatar.src = "https://placehold.co/30";
   avatar.alt = "sample image";
+  if (avatarHeight) setHeight(avatar, avatarHeight);
 
   const nameTag = createElement("span", {
     textContent: `${user.displayName}#${user.username}`,

--- a/frontend/pong/js/utils/elements/div/createNameplate.js
+++ b/frontend/pong/js/utils/elements/div/createNameplate.js
@@ -1,16 +1,18 @@
+import { BootstrapBorders } from "../../../bootstrap/utilities/borders";
 import { BootstrapDisplay } from "../../../bootstrap/utilities/display";
 import { BootstrapFlex } from "../../../bootstrap/utilities/flex";
 import { BootstrapSpacing } from "../../../bootstrap/utilities/spacing";
 import { BootstrapText } from "../../../bootstrap/utilities/text";
+import { Endpoints } from "../../../constants/Endpoints";
 import { createElement } from "../createElement";
 import { setHeight } from "../style/setHeight";
 
 export const createNameplate = (user, avatarHeight = "") => {
-  // TODO: 実際のアバターを使用
   const avatar = new Image();
-  avatar.src = "https://placehold.co/30";
-  avatar.alt = "sample image";
+  avatar.src = Endpoints.create(user.avatar).href;
+  avatar.alt = `${user.displayName}#${user.username}'s avatar`;
   if (avatarHeight) setHeight(avatar, avatarHeight);
+  BootstrapBorders.setRoundedCircle(avatar);
 
   const nameTag = createElement("span", {
     textContent: `${user.displayName}#${user.username}`,

--- a/frontend/pong/js/utils/elements/div/createNameplate.js
+++ b/frontend/pong/js/utils/elements/div/createNameplate.js
@@ -34,6 +34,10 @@ const createAvatarImage = (params) => {
   const image = new Image();
   image.src = Endpoints.create(pathname).href;
   image.alt = alt;
+  image.onerror = () => {
+    image.onerror = null;
+    image.src = Endpoints.USERS.defaultAvatar.href;
+  };
   if (height) setHeight(image, height);
   BootstrapBorders.setRoundedCircle(image);
   return image;

--- a/frontend/pong/js/utils/elements/div/createNameplate.js
+++ b/frontend/pong/js/utils/elements/div/createNameplate.js
@@ -8,14 +8,15 @@ import { createElement } from "../createElement";
 import { setHeight } from "../style/setHeight";
 
 export const createNameplate = (user, avatarHeight = "") => {
-  const avatar = new Image();
-  avatar.src = Endpoints.create(user.avatar).href;
-  avatar.alt = `${user.displayName}#${user.username}'s avatar`;
-  if (avatarHeight) setHeight(avatar, avatarHeight);
-  BootstrapBorders.setRoundedCircle(avatar);
+  const nameTagText = `${user.displayName}#${user.username}`;
 
+  const avatar = createAvatarImage({
+    pathname: user.avatar,
+    alt: nameTagText + "'s avatar`",
+    height: avatarHeight,
+  });
   const nameTag = createElement("span", {
-    textContent: `${user.displayName}#${user.username}`,
+    textContent: nameTagText,
   });
   BootstrapText.setTextTruncate(nameTag);
 
@@ -25,4 +26,15 @@ export const createNameplate = (user, avatarHeight = "") => {
   BootstrapSpacing.setGap(nameplate);
   nameplate.append(avatar, nameTag);
   return nameplate;
+};
+
+const createAvatarImage = (params) => {
+  const { pathname, alt, height } = params;
+
+  const image = new Image();
+  image.src = Endpoints.create(pathname).href;
+  image.alt = alt;
+  if (height) setHeight(image, height);
+  BootstrapBorders.setRoundedCircle(image);
+  return image;
 };


### PR DESCRIPTION
## タスクやディスカッションのリンク
なし

## やったこと
- 仮のアバターイメージではなく、ユーザーのアバターイメージを表示
- イメージの高さを設定できるように修正
- モックとしては、続けて仮のアバターイメージを使用

## やらないこと
なし

## 動作確認

#### FE 単体
- `cd frontend/pong && npm install && npm run dev`
- `http://localhost:5173/users` より仮のアバターイメージを確認

#### 統合
- `make build-up`
-  swagger-ui などから、サンプルアカウントをいくつか追加
- `http://localhost:8080/users` よりデフォルトのアバターイメージを確認

## 特にレビューをお願いしたい箇所
共有済みですが、高さ設定や丸く表示するなど、どう表示するかも少し変更していますので確認いただければと思います。

## その他
なし

## 参考リンク
- https://www.notion.so/006-15af1b77f6c280f0bb45da34a964fafb?pvs=4
- https://developer.mozilla.org/ja/docs/Web/HTML/Element/img#%E7%94%BB%E5%83%8F%E8%AA%AD%E3%81%BF%E8%BE%BC%E3%81%BF%E3%82%A8%E3%83%A9%E3%83%BC


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **新機能**
  - ユーザープロフィールおよびリスト表示に、アバター画像が追加され、より充実した情報が提供されます。
  - 名前タグの表示にカスタムサイズが適用され、各ユーザーの情報が見やすくなりました。
  - 新しいボーダースタイル設定機能により、要素に丸みを持たせることができるようになりました。
  - サンプルユーザー生成時にアバターのプロパティが追加され、テストデータの質が向上しました。
  - ユーザー情報を取得する際のエンドポイントが更新され、デフォルトのアバター画像パスが設定されました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->