### PR TITLE
⚡ [users] UsersSerializer に is_friend 追加

### DIFF
--- a/backend/pong/users/constants.py
+++ b/backend/pong/users/constants.py
@@ -9,3 +9,9 @@ class Code:
     INVALID: Final[str] = "invalid"
     NOT_EXISTS: Final[str] = "not_exists"
     INTERNAL_ERROR: Final[str] = custom_response.Code.INTERNAL_ERROR
+
+
+@dataclasses.dataclass(frozen=True)
+class UsersFields:
+    IS_FRIEND: Final[str] = "is_friend"
+    # todo: is_blocked,is_online,win_match,lose_match追加

--- a/backend/pong/users/serializers.py
+++ b/backend/pong/users/serializers.py
@@ -21,6 +21,7 @@ class UsersSerializer(serializers.Serializer):
     avatar = player_serializers.PlayerSerializer().fields[
         accounts_constants.PlayerFields.AVATAR
     ]
+    # todo: is_friend,is_blocked,is_online,win_match,lose_match追加
 
     class Meta:
         model = player_models.Player
@@ -30,6 +31,7 @@ class UsersSerializer(serializers.Serializer):
             accounts_constants.UserFields.EMAIL,
             accounts_constants.PlayerFields.DISPLAY_NAME,
             accounts_constants.PlayerFields.AVATAR,
+            # todo: is_friend,is_blocked,is_online,win_match,lose_match追加
         )
 
     # args,kwargsは型ヒントが複雑かつそのままsuper()に渡したいためignoreで対処

--- a/backend/pong/users/serializers.py
+++ b/backend/pong/users/serializers.py
@@ -1,7 +1,7 @@
 from rest_framework import serializers
 
 from accounts import constants as accounts_constants
-from accounts.player import models
+from accounts.player import models as player_models
 from accounts.player import serializers as player_serializers
 
 
@@ -23,7 +23,7 @@ class UsersSerializer(serializers.Serializer):
     ]
 
     class Meta:
-        model = models.Player
+        model = player_models.Player
         fields = (
             accounts_constants.UserFields.ID,
             accounts_constants.UserFields.USERNAME,
@@ -46,8 +46,8 @@ class UsersSerializer(serializers.Serializer):
                 self.fields.pop(field_name)
 
     def update(
-        self, player: models.Player, validated_data: dict
-    ) -> models.Player:
+        self, player: player_models.Player, validated_data: dict
+    ) -> player_models.Player:
         """
         Playerインスタンスを更新するupdate()のオーバーライド
         """

--- a/backend/pong/users/serializers.py
+++ b/backend/pong/users/serializers.py
@@ -1,6 +1,6 @@
 from rest_framework import serializers
 
-from accounts import constants
+from accounts import constants as accounts_constants
 from accounts.player import models
 from accounts.player import serializers as player_serializers
 
@@ -16,20 +16,20 @@ class UsersSerializer(serializers.Serializer):
     email = serializers.EmailField(source="user.email")
     # todo: 別のserializerをネストする方法で他に良い書き方があれば変更する
     display_name = player_serializers.PlayerSerializer().fields[
-        constants.PlayerFields.DISPLAY_NAME
+        accounts_constants.PlayerFields.DISPLAY_NAME
     ]
     avatar = player_serializers.PlayerSerializer().fields[
-        constants.PlayerFields.AVATAR
+        accounts_constants.PlayerFields.AVATAR
     ]
 
     class Meta:
         model = models.Player
         fields = (
-            constants.UserFields.ID,
-            constants.UserFields.USERNAME,
-            constants.UserFields.EMAIL,
-            constants.PlayerFields.DISPLAY_NAME,
-            constants.PlayerFields.AVATAR,
+            accounts_constants.UserFields.ID,
+            accounts_constants.UserFields.USERNAME,
+            accounts_constants.UserFields.EMAIL,
+            accounts_constants.PlayerFields.DISPLAY_NAME,
+            accounts_constants.PlayerFields.AVATAR,
         )
 
     # args,kwargsは型ヒントが複雑かつそのままsuper()に渡したいためignoreで対処
@@ -52,10 +52,12 @@ class UsersSerializer(serializers.Serializer):
         Playerインスタンスを更新するupdate()のオーバーライド
         """
         player.display_name = validated_data.get(
-            constants.PlayerFields.DISPLAY_NAME, player.display_name
+            accounts_constants.PlayerFields.DISPLAY_NAME, player.display_name
         )
         # todo: avatarも新しいものを代入・save()のupdate_fieldsにも追加
 
         # create()をオーバーライドしない場合、update()内でsave()は必須
-        player.save(update_fields=[constants.PlayerFields.DISPLAY_NAME])
+        player.save(
+            update_fields=[accounts_constants.PlayerFields.DISPLAY_NAME]
+        )
         return player

--- a/backend/pong/users/tests/integration/test_list.py
+++ b/backend/pong/users/tests/integration/test_list.py
@@ -9,6 +9,8 @@ from accounts import constants as accounts_constants
 from accounts.player import models as player_models
 from pong.custom_response import custom_response
 
+from ... import constants
+
 ID: Final[str] = accounts_constants.UserFields.ID
 USERNAME: Final[str] = accounts_constants.UserFields.USERNAME
 EMAIL: Final[str] = accounts_constants.UserFields.EMAIL
@@ -16,6 +18,7 @@ PASSWORD: Final[str] = accounts_constants.UserFields.PASSWORD
 USER: Final[str] = accounts_constants.PlayerFields.USER
 DISPLAY_NAME: Final[str] = accounts_constants.PlayerFields.DISPLAY_NAME
 AVATAR: Final[str] = accounts_constants.PlayerFields.AVATAR
+IS_FRIEND: Final[str] = constants.UsersFields.IS_FRIEND
 
 DATA: Final[str] = custom_response.DATA
 
@@ -65,6 +68,8 @@ class UsersListViewTests(test.APITestCase):
             self.user_data2, self.player_data2
         )
 
+        # todo: ログイン
+
     def test_create_user(self) -> None:
         """
         setUp()の情報で2人のユーザーを作成できることを確認
@@ -75,6 +80,8 @@ class UsersListViewTests(test.APITestCase):
     def test_200_no_users_exist(self) -> None:
         """
         ユーザーが存在しない場合、エラーにならず空のプロフィール一覧を取得できることを確認
+        -> todo: IsAuthenticatedにしたら、ユーザーが存在しない場合ログインユーザーもいないので401になる
+                 テスト内容と関数名も変更
         """
         User.objects.all().delete()
         response: drf_response.Response = self.client.get(self.url)
@@ -97,12 +104,16 @@ class UsersListViewTests(test.APITestCase):
                     USERNAME: self.user_data1[USERNAME],
                     DISPLAY_NAME: self.player_data1[DISPLAY_NAME],
                     AVATAR: self.player1.avatar.url,
+                    IS_FRIEND: False,
+                    # todo: is_blocked,is_online,win_match,lose_match追加
                 },
                 {
                     ID: self.user2.id,
                     USERNAME: self.user_data2[USERNAME],
                     DISPLAY_NAME: self.player_data2[DISPLAY_NAME],
                     AVATAR: self.player2.avatar.url,
+                    IS_FRIEND: False,
+                    # todo: is_blocked,is_online,win_match,lose_match追加
                 },
             ],
         )

--- a/backend/pong/users/tests/integration/test_list.py
+++ b/backend/pong/users/tests/integration/test_list.py
@@ -6,7 +6,7 @@ from rest_framework import response as drf_response
 from rest_framework import status, test
 
 from accounts import constants as accounts_constants
-from accounts.player import models
+from accounts.player import models as player_models
 from pong.custom_response import custom_response
 
 ID: Final[str] = accounts_constants.UserFields.ID
@@ -28,10 +28,12 @@ class UsersListViewTests(test.APITestCase):
 
         def _create_user_and_related_player(
             user_data: dict, player_data: dict
-        ) -> tuple[User, models.Player]:
+        ) -> tuple[User, player_models.Player]:
             user: User = User.objects.create_user(**user_data)
             player_data[USER] = user
-            player: models.Player = models.Player.objects.create(**player_data)
+            player: player_models.Player = player_models.Player.objects.create(
+                **player_data
+            )
             return user, player
 
         self.url: str = reverse("users:list")

--- a/backend/pong/users/tests/integration/test_list.py
+++ b/backend/pong/users/tests/integration/test_list.py
@@ -5,17 +5,17 @@ from django.urls import reverse
 from rest_framework import response as drf_response
 from rest_framework import status, test
 
-from accounts import constants
+from accounts import constants as accounts_constants
 from accounts.player import models
 from pong.custom_response import custom_response
 
-ID: Final[str] = constants.UserFields.ID
-USERNAME: Final[str] = constants.UserFields.USERNAME
-EMAIL: Final[str] = constants.UserFields.EMAIL
-PASSWORD: Final[str] = constants.UserFields.PASSWORD
-USER: Final[str] = constants.PlayerFields.USER
-DISPLAY_NAME: Final[str] = constants.PlayerFields.DISPLAY_NAME
-AVATAR: Final[str] = constants.PlayerFields.AVATAR
+ID: Final[str] = accounts_constants.UserFields.ID
+USERNAME: Final[str] = accounts_constants.UserFields.USERNAME
+EMAIL: Final[str] = accounts_constants.UserFields.EMAIL
+PASSWORD: Final[str] = accounts_constants.UserFields.PASSWORD
+USER: Final[str] = accounts_constants.PlayerFields.USER
+DISPLAY_NAME: Final[str] = accounts_constants.PlayerFields.DISPLAY_NAME
+AVATAR: Final[str] = accounts_constants.PlayerFields.AVATAR
 
 DATA: Final[str] = custom_response.DATA
 

--- a/backend/pong/users/tests/integration/test_me.py
+++ b/backend/pong/users/tests/integration/test_me.py
@@ -19,6 +19,7 @@ PASSWORD: Final[str] = accounts_constants.UserFields.PASSWORD
 USER: Final[str] = accounts_constants.PlayerFields.USER
 DISPLAY_NAME: Final[str] = accounts_constants.PlayerFields.DISPLAY_NAME
 AVATAR: Final[str] = accounts_constants.PlayerFields.AVATAR
+IS_FRIEND: Final[str] = constants.UsersFields.IS_FRIEND
 
 DATA: Final[str] = custom_response.DATA
 CODE: Final[str] = custom_response.CODE
@@ -89,6 +90,8 @@ class UsersMeViewTests(test.APITestCase):
                 EMAIL: self.user_data[EMAIL],
                 DISPLAY_NAME: self.player_data[DISPLAY_NAME],
                 AVATAR: self.player.avatar.url,
+                IS_FRIEND: False,
+                # todo: is_blocked,is_online,win_match,lose_match追加
             },
         )
 

--- a/backend/pong/users/tests/integration/test_me.py
+++ b/backend/pong/users/tests/integration/test_me.py
@@ -12,6 +12,7 @@ from pong.custom_response import custom_response
 
 from ... import constants
 
+ID: Final[str] = accounts_constants.UserFields.ID
 USERNAME: Final[str] = accounts_constants.UserFields.USERNAME
 EMAIL: Final[str] = accounts_constants.UserFields.EMAIL
 PASSWORD: Final[str] = accounts_constants.UserFields.PASSWORD
@@ -80,13 +81,16 @@ class UsersMeViewTests(test.APITestCase):
         )
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        response_data: dict = response.data[DATA]
-        self.assertEqual(response_data[USERNAME], self.user_data[USERNAME])
-        self.assertEqual(response_data[EMAIL], self.user_data[EMAIL])
         self.assertEqual(
-            response_data[DISPLAY_NAME], self.player_data[DISPLAY_NAME]
+            response.data[DATA],
+            {
+                ID: self.user.id,
+                USERNAME: self.user_data[USERNAME],
+                EMAIL: self.user_data[EMAIL],
+                DISPLAY_NAME: self.player_data[DISPLAY_NAME],
+                AVATAR: self.player.avatar.url,
+            },
         )
-        self.assertEqual(response_data[AVATAR], self.player.avatar.url)
 
     def test_get_401_unauthenticated_user(self) -> None:
         """

--- a/backend/pong/users/tests/integration/test_retrieve.py
+++ b/backend/pong/users/tests/integration/test_retrieve.py
@@ -18,6 +18,7 @@ PASSWORD: Final[str] = accounts_constants.UserFields.PASSWORD
 USER: Final[str] = accounts_constants.PlayerFields.USER
 DISPLAY_NAME: Final[str] = accounts_constants.PlayerFields.DISPLAY_NAME
 AVATAR: Final[str] = accounts_constants.PlayerFields.AVATAR
+IS_FRIEND: Final[str] = constants.UsersFields.IS_FRIEND
 
 DATA: Final[str] = custom_response.DATA
 CODE: Final[str] = custom_response.CODE
@@ -67,6 +68,8 @@ class UsersRetrieveViewTests(test.APITestCase):
             self.user_data2, self.player_data2
         )
 
+        # todo: ログイン
+
     def _create_url(self, user_id: int) -> str:
         return reverse("users:retrieve", kwargs={"user_id": user_id})
 
@@ -91,16 +94,15 @@ class UsersRetrieveViewTests(test.APITestCase):
             )
 
             self.assertEqual(response.status_code, status.HTTP_200_OK)
-            response_data: dict = response.data[DATA]
-            self.assertEqual(response_data[ID], user.id)
-            self.assertEqual(response_data[USERNAME], user_data[USERNAME])
             self.assertEqual(
-                response_data[DISPLAY_NAME], player_data[DISPLAY_NAME]
-            )
-            self.assertNotIn(EMAIL, response_data)
-            self.assertEqual(
-                response_data[AVATAR],
-                user.player.avatar.url,
+                response.data[DATA],
+                {
+                    ID: user.id,
+                    USERNAME: user_data[USERNAME],
+                    DISPLAY_NAME: player_data[DISPLAY_NAME],
+                    AVATAR: user.player.avatar.url,
+                    IS_FRIEND: False,
+                },
             )
 
     # todo: IsAuthenticatedにしたら、test_401_unauthenticated_user()を追加

--- a/backend/pong/users/tests/integration/test_retrieve.py
+++ b/backend/pong/users/tests/integration/test_retrieve.py
@@ -6,7 +6,7 @@ from rest_framework import response as drf_response
 from rest_framework import status, test
 
 from accounts import constants as accounts_constants
-from accounts.player import models
+from accounts.player import models as player_models
 from pong.custom_response import custom_response
 
 from ... import constants
@@ -32,10 +32,12 @@ class UsersRetrieveViewTests(test.APITestCase):
 
         def _create_user_and_related_player(
             user_data: dict, player_data: dict
-        ) -> tuple[User, models.Player]:
+        ) -> tuple[User, player_models.Player]:
             user: User = User.objects.create_user(**user_data)
             player_data[USER] = user
-            player: models.Player = models.Player.objects.create(**player_data)
+            player: player_models.Player = player_models.Player.objects.create(
+                **player_data
+            )
             return user, player
 
         # 1人目のユーザーデータ

--- a/backend/pong/users/tests/unit/test_users_serializer.py
+++ b/backend/pong/users/tests/unit/test_users_serializer.py
@@ -6,7 +6,7 @@ from django.db.models.query import QuerySet
 from django.test import TestCase
 
 from accounts import constants as accounts_constants
-from accounts.player import models
+from accounts.player import models as player_models
 
 from ... import serializers
 
@@ -28,10 +28,12 @@ class UsersSerializerTests(TestCase):
 
         def _create_user_and_related_player(
             user_data: dict, player_data: dict
-        ) -> tuple[User, models.Player]:
+        ) -> tuple[User, player_models.Player]:
             user: User = User.objects.create_user(**user_data)
             player_data[USER] = user
-            player: models.Player = models.Player.objects.create(**player_data)
+            player: player_models.Player = player_models.Player.objects.create(
+                **player_data
+            )
             return user, player
 
         self.user_data_1: dict = {
@@ -58,8 +60,8 @@ class UsersSerializerTests(TestCase):
         正常なインスタンスが複数渡された場合に、dataにインスタンス分の値が入っていることを確認
         """
         # Userに紐づくPlayer全てのQuerySetを取得
-        all_players_with_users: QuerySet[models.Player] = (
-            models.Player.objects.select_related(USER).all()
+        all_players_with_users: QuerySet[player_models.Player] = (
+            player_models.Player.objects.select_related(USER).all()
         )
         # serializer作成
         serializer: serializers.UsersSerializer = serializers.UsersSerializer(
@@ -93,8 +95,8 @@ class UsersSerializerTests(TestCase):
         # User,紐づくPlayerを全て削除
         User.objects.all().delete()
 
-        all_players_with_users: QuerySet[models.Player] = (
-            models.Player.objects.select_related(USER).all()
+        all_players_with_users: QuerySet[player_models.Player] = (
+            player_models.Player.objects.select_related(USER).all()
         )
         serializer: serializers.UsersSerializer = serializers.UsersSerializer(
             all_players_with_users, many=True

--- a/backend/pong/users/tests/unit/test_users_serializer.py
+++ b/backend/pong/users/tests/unit/test_users_serializer.py
@@ -10,6 +10,7 @@ from accounts.player import models
 
 from ... import serializers
 
+ID: Final[str] = accounts_constants.UserFields.ID
 USERNAME: Final[str] = accounts_constants.UserFields.USERNAME
 EMAIL: Final[str] = accounts_constants.UserFields.EMAIL
 PASSWORD: Final[str] = accounts_constants.UserFields.PASSWORD
@@ -65,17 +66,25 @@ class UsersSerializerTests(TestCase):
             all_players_with_users, many=True
         )
 
-        # シリアライズ済みdataからusernameのみのlistを作成
-        serializer_data_usernames: list[str] = [
-            data[USERNAME] for data in serializer.data
-        ]
-        self.assertEqual(len(serializer.data), 2)
-        for username in (
-            self.user_data_1[USERNAME],
-            self.user_data_2[USERNAME],
-        ):
-            self.assertIn(username, serializer_data_usernames)
-            # todo: display_nameも確認する
+        self.assertEqual(
+            serializer.data,
+            [
+                {
+                    ID: self.user_1.id,
+                    USERNAME: self.user_data_1[USERNAME],
+                    EMAIL: self.user_data_1[EMAIL],
+                    DISPLAY_NAME: self.player_data_1[DISPLAY_NAME],
+                    AVATAR: self.player_1.avatar.url,
+                },
+                {
+                    ID: self.user_2.id,
+                    USERNAME: self.user_data_2[USERNAME],
+                    EMAIL: self.user_data_2[EMAIL],
+                    DISPLAY_NAME: self.player_data_2[DISPLAY_NAME],
+                    AVATAR: self.player_2.avatar.url,
+                },
+            ],
+        )
 
     def test_non_users(self) -> None:
         """

--- a/backend/pong/users/tests/unit/test_users_serializer.py
+++ b/backend/pong/users/tests/unit/test_users_serializer.py
@@ -5,17 +5,17 @@ from django.contrib.auth.models import User
 from django.db.models.query import QuerySet
 from django.test import TestCase
 
-from accounts import constants
+from accounts import constants as accounts_constants
 from accounts.player import models
 
 from ... import serializers
 
-USERNAME: Final[str] = constants.UserFields.USERNAME
-EMAIL: Final[str] = constants.UserFields.EMAIL
-PASSWORD: Final[str] = constants.UserFields.PASSWORD
-USER: Final[str] = constants.PlayerFields.USER
-DISPLAY_NAME: Final[str] = constants.PlayerFields.DISPLAY_NAME
-AVATAR: Final[str] = constants.PlayerFields.AVATAR
+USERNAME: Final[str] = accounts_constants.UserFields.USERNAME
+EMAIL: Final[str] = accounts_constants.UserFields.EMAIL
+PASSWORD: Final[str] = accounts_constants.UserFields.PASSWORD
+USER: Final[str] = accounts_constants.PlayerFields.USER
+DISPLAY_NAME: Final[str] = accounts_constants.PlayerFields.DISPLAY_NAME
+AVATAR: Final[str] = accounts_constants.PlayerFields.AVATAR
 
 
 class UsersSerializerTests(TestCase):
@@ -100,7 +100,7 @@ class UsersSerializerTests(TestCase):
         # 新しいdisplay_name
         new_valid_display_name: str = "new_name"
         request_data: dict = {
-            constants.PlayerFields.DISPLAY_NAME: new_valid_display_name,
+            DISPLAY_NAME: new_valid_display_name,
         }
         serializer: serializers.UsersSerializer = serializers.UsersSerializer(
             self.player_1, data=request_data, partial=True
@@ -133,14 +133,14 @@ class UsersSerializerTests(TestCase):
             new_invalid_display_name: 新しく更新したいdisplay_nameの値
         """
         request_data: dict = {
-            constants.PlayerFields.DISPLAY_NAME: new_invalid_display_name,
+            DISPLAY_NAME: new_invalid_display_name,
         }
         serializer: serializers.UsersSerializer = serializers.UsersSerializer(
             self.player_1, data=request_data, partial=True
         )
 
         self.assertFalse(serializer.is_valid())
-        self.assertIn(constants.PlayerFields.DISPLAY_NAME, serializer.errors)
+        self.assertIn(DISPLAY_NAME, serializer.errors)
         # 更新されずに元のdisplay_nameが保持されていることを確認
         self.player_1.refresh_from_db()  # 最新のDBの情報に更新
         self.assertEqual(

--- a/backend/pong/users/views/list.py
+++ b/backend/pong/users/views/list.py
@@ -9,7 +9,7 @@ from rest_framework import (
 )
 
 from accounts import constants as accounts_constants
-from accounts.player import models
+from accounts.player import models as player_models
 from pong.custom_response import custom_response
 
 from .. import serializers
@@ -64,8 +64,8 @@ class UsersListView(views.APIView):
         ユーザープロフィール一覧を取得するGETメソッド
         """
         # Userに紐づくPlayer全てのQuerySetを取得
-        all_players_with_users: QuerySet[models.Player] = (
-            models.Player.objects.select_related(
+        all_players_with_users: QuerySet[player_models.Player] = (
+            player_models.Player.objects.select_related(
                 accounts_constants.PlayerFields.USER
             ).all()
         )

--- a/backend/pong/users/views/list.py
+++ b/backend/pong/users/views/list.py
@@ -8,7 +8,7 @@ from rest_framework import (
     views,
 )
 
-from accounts import constants
+from accounts import constants as accounts_constants
 from accounts.player import models
 from pong.custom_response import custom_response
 
@@ -37,16 +37,16 @@ class UsersListView(views.APIView):
                             custom_response.STATUS: custom_response.Status.OK,
                             custom_response.DATA: [
                                 {
-                                    constants.UserFields.ID: 2,
-                                    constants.UserFields.USERNAME: "username1",
-                                    constants.PlayerFields.DISPLAY_NAME: "display_name1",
-                                    constants.PlayerFields.AVATAR: "avatars/sample1.png",
+                                    accounts_constants.UserFields.ID: 2,
+                                    accounts_constants.UserFields.USERNAME: "username1",
+                                    accounts_constants.PlayerFields.DISPLAY_NAME: "display_name1",
+                                    accounts_constants.PlayerFields.AVATAR: "avatars/sample1.png",
                                 },
                                 {
-                                    constants.UserFields.ID: 3,
-                                    constants.UserFields.USERNAME: "username2",
-                                    constants.PlayerFields.DISPLAY_NAME: "display_name2",
-                                    constants.PlayerFields.AVATAR: "avatars/sample2.png",
+                                    accounts_constants.UserFields.ID: 3,
+                                    accounts_constants.UserFields.USERNAME: "username2",
+                                    accounts_constants.PlayerFields.DISPLAY_NAME: "display_name2",
+                                    accounts_constants.PlayerFields.AVATAR: "avatars/sample2.png",
                                 },
                                 {"...", "..."},
                             ],
@@ -66,7 +66,7 @@ class UsersListView(views.APIView):
         # Userに紐づくPlayer全てのQuerySetを取得
         all_players_with_users: QuerySet[models.Player] = (
             models.Player.objects.select_related(
-                constants.PlayerFields.USER
+                accounts_constants.PlayerFields.USER
             ).all()
         )
         # 複数のオブジェクトをシリアライズ
@@ -75,10 +75,10 @@ class UsersListView(views.APIView):
             many=True,
             # emailは含めない
             fields=(
-                constants.UserFields.ID,
-                constants.UserFields.USERNAME,
-                constants.PlayerFields.DISPLAY_NAME,
-                constants.PlayerFields.AVATAR,
+                accounts_constants.UserFields.ID,
+                accounts_constants.UserFields.USERNAME,
+                accounts_constants.PlayerFields.DISPLAY_NAME,
+                accounts_constants.PlayerFields.AVATAR,
             ),
         )
         return custom_response.CustomResponse(

--- a/backend/pong/users/views/list.py
+++ b/backend/pong/users/views/list.py
@@ -11,8 +11,9 @@ from rest_framework import (
 from accounts import constants as accounts_constants
 from accounts.player import models as player_models
 from pong.custom_response import custom_response
+from users.friends import constants as friends_constants
 
-from .. import serializers
+from .. import constants, serializers
 
 
 class UsersListView(views.APIView):
@@ -41,14 +42,16 @@ class UsersListView(views.APIView):
                                     accounts_constants.UserFields.USERNAME: "username1",
                                     accounts_constants.PlayerFields.DISPLAY_NAME: "display_name1",
                                     accounts_constants.PlayerFields.AVATAR: "avatars/sample1.png",
-                                    # todo: is_friend,is_blocked,is_online,win_match,lose_match追加
+                                    constants.UsersFields.IS_FRIEND: False,
+                                    # todo: is_blocked,is_online,win_match,lose_match追加
                                 },
                                 {
                                     accounts_constants.UserFields.ID: 3,
                                     accounts_constants.UserFields.USERNAME: "username2",
                                     accounts_constants.PlayerFields.DISPLAY_NAME: "display_name2",
                                     accounts_constants.PlayerFields.AVATAR: "avatars/sample2.png",
-                                    # todo: is_friend,is_blocked,is_online,win_match,lose_match追加
+                                    constants.UsersFields.IS_FRIEND: False,
+                                    # todo: is_blocked,is_online,win_match,lose_match追加
                                 },
                                 {"...", "..."},
                             ],
@@ -81,8 +84,12 @@ class UsersListView(views.APIView):
                 accounts_constants.UserFields.USERNAME,
                 accounts_constants.PlayerFields.DISPLAY_NAME,
                 accounts_constants.PlayerFields.AVATAR,
-                # todo: is_friend,is_blocked,is_online,win_match,lose_match追加
+                constants.UsersFields.IS_FRIEND,
+                # todo: is_blocked,is_online,win_match,lose_match追加
             ),
+            context={
+                friends_constants.FriendshipFields.USER_ID: request.user.id
+            },
         )
         return custom_response.CustomResponse(
             data=serializer.data, status=status.HTTP_200_OK

--- a/backend/pong/users/views/list.py
+++ b/backend/pong/users/views/list.py
@@ -41,12 +41,14 @@ class UsersListView(views.APIView):
                                     accounts_constants.UserFields.USERNAME: "username1",
                                     accounts_constants.PlayerFields.DISPLAY_NAME: "display_name1",
                                     accounts_constants.PlayerFields.AVATAR: "avatars/sample1.png",
+                                    # todo: is_friend,is_blocked,is_online,win_match,lose_match追加
                                 },
                                 {
                                     accounts_constants.UserFields.ID: 3,
                                     accounts_constants.UserFields.USERNAME: "username2",
                                     accounts_constants.PlayerFields.DISPLAY_NAME: "display_name2",
                                     accounts_constants.PlayerFields.AVATAR: "avatars/sample2.png",
+                                    # todo: is_friend,is_blocked,is_online,win_match,lose_match追加
                                 },
                                 {"...", "..."},
                             ],
@@ -79,6 +81,7 @@ class UsersListView(views.APIView):
                 accounts_constants.UserFields.USERNAME,
                 accounts_constants.PlayerFields.DISPLAY_NAME,
                 accounts_constants.PlayerFields.AVATAR,
+                # todo: is_friend,is_blocked,is_online,win_match,lose_match追加
             ),
         )
         return custom_response.CustomResponse(

--- a/backend/pong/users/views/me.py
+++ b/backend/pong/users/views/me.py
@@ -43,6 +43,7 @@ class UsersMeView(views.APIView):
                                 accounts_constants.UserFields.EMAIL: "username1@example.com",
                                 accounts_constants.PlayerFields.DISPLAY_NAME: "display_name1",
                                 accounts_constants.PlayerFields.AVATAR: "avatars/sample.png",
+                                # todo: is_friend,is_blocked,is_online,win_match,lose_match追加
                             },
                         },
                     ),
@@ -87,7 +88,9 @@ class UsersMeView(views.APIView):
             )
 
         users_serializer: serializers.UsersSerializer = (
-            serializers.UsersSerializer(user.player)
+            serializers.UsersSerializer(
+                user.player
+            )  # 全て取得するのでfieldsは指定しない
         )
         return custom_response.CustomResponse(
             data=users_serializer.data,
@@ -122,6 +125,7 @@ class UsersMeView(views.APIView):
                                 accounts_constants.UserFields.EMAIL: "username1@example.com",
                                 accounts_constants.PlayerFields.DISPLAY_NAME: "display_name1",
                                 accounts_constants.PlayerFields.AVATAR: "avatars/sample.png",
+                                # todo: is_friend,is_blocked,is_online,win_match,lose_match追加
                             },
                         },
                     ),
@@ -186,6 +190,7 @@ class UsersMeView(views.APIView):
                 user.player,
                 data=request.data,
                 partial=True,  # 部分的な更新を許可
+                # 全て取得するのでfieldsは指定しない
             )
         )
         # 更新対象データ(request.data)のバリデーションを確認

--- a/backend/pong/users/views/me.py
+++ b/backend/pong/users/views/me.py
@@ -12,6 +12,7 @@ from rest_framework import (
 
 from accounts import constants as accounts_constants
 from pong.custom_response import custom_response
+from users.friends import constants as friends_constants
 
 from .. import constants, serializers
 
@@ -43,7 +44,8 @@ class UsersMeView(views.APIView):
                                 accounts_constants.UserFields.EMAIL: "username1@example.com",
                                 accounts_constants.PlayerFields.DISPLAY_NAME: "display_name1",
                                 accounts_constants.PlayerFields.AVATAR: "avatars/sample.png",
-                                # todo: is_friend,is_blocked,is_online,win_match,lose_match追加
+                                constants.UsersFields.IS_FRIEND: False,
+                                # todo: is_blocked,is_online,win_match,lose_match追加
                             },
                         },
                     ),
@@ -89,8 +91,10 @@ class UsersMeView(views.APIView):
 
         users_serializer: serializers.UsersSerializer = (
             serializers.UsersSerializer(
-                user.player
-            )  # 全て取得するのでfieldsは指定しない
+                user.player,
+                # 全て取得するのでfieldsは指定しない
+                context={friends_constants.FriendshipFields.USER_ID: user.id},
+            )
         )
         return custom_response.CustomResponse(
             data=users_serializer.data,
@@ -125,7 +129,8 @@ class UsersMeView(views.APIView):
                                 accounts_constants.UserFields.EMAIL: "username1@example.com",
                                 accounts_constants.PlayerFields.DISPLAY_NAME: "display_name1",
                                 accounts_constants.PlayerFields.AVATAR: "avatars/sample.png",
-                                # todo: is_friend,is_blocked,is_online,win_match,lose_match追加
+                                constants.UsersFields.IS_FRIEND: False,
+                                # todo: is_blocked,is_online,win_match,lose_match追加
                             },
                         },
                     ),
@@ -191,6 +196,7 @@ class UsersMeView(views.APIView):
                 data=request.data,
                 partial=True,  # 部分的な更新を許可
                 # 全て取得するのでfieldsは指定しない
+                context={friends_constants.FriendshipFields.USER_ID: user.id},
             )
         )
         # 更新対象データ(request.data)のバリデーションを確認

--- a/backend/pong/users/views/retrieve.py
+++ b/backend/pong/users/views/retrieve.py
@@ -13,6 +13,7 @@ from rest_framework import (
 from accounts import constants as accounts_constants
 from accounts.player import models as player_models
 from pong.custom_response import custom_response
+from users.friends import constants as friends_constants
 
 from .. import constants, serializers
 
@@ -44,7 +45,8 @@ class UsersRetrieveView(views.APIView):
                                 accounts_constants.UserFields.USERNAME: "username1",
                                 accounts_constants.PlayerFields.DISPLAY_NAME: "display_name1",
                                 accounts_constants.PlayerFields.AVATAR: "avatars/sample.png",
-                                # todo: is_friend,is_blocked,is_online,win_match,lose_match追加
+                                constants.UsersFields.IS_FRIEND: True,
+                                # todo: is_blocked,is_online,win_match,lose_match追加
                             },
                         },
                     ),
@@ -87,18 +89,20 @@ class UsersRetrieveView(views.APIView):
             player: player_models.Player = player_models.Player.objects.get(
                 user_id=user_id
             )
-            users_serializer: serializers.UsersSerializer = (
-                serializers.UsersSerializer(
-                    player,
-                    # emailは含めない
-                    fields=(
-                        accounts_constants.UserFields.ID,
-                        accounts_constants.UserFields.USERNAME,
-                        accounts_constants.PlayerFields.DISPLAY_NAME,
-                        accounts_constants.PlayerFields.AVATAR,
-                        # todo: is_friend,is_blocked,is_online,win_match,lose_match追加
-                    ),
-                )
+            users_serializer: serializers.UsersSerializer = serializers.UsersSerializer(
+                player,
+                # emailは含めない
+                fields=(
+                    accounts_constants.UserFields.ID,
+                    accounts_constants.UserFields.USERNAME,
+                    accounts_constants.PlayerFields.DISPLAY_NAME,
+                    accounts_constants.PlayerFields.AVATAR,
+                    constants.UsersFields.IS_FRIEND,
+                    # todo: is_blocked,is_online,win_match,lose_match追加
+                ),
+                context={
+                    friends_constants.FriendshipFields.USER_ID: request.user.id
+                },
             )
             return custom_response.CustomResponse(
                 data=users_serializer.data,

--- a/backend/pong/users/views/retrieve.py
+++ b/backend/pong/users/views/retrieve.py
@@ -11,7 +11,7 @@ from rest_framework import (
 )
 
 from accounts import constants as accounts_constants
-from accounts.player import models
+from accounts.player import models as player_models
 from pong.custom_response import custom_response
 
 from .. import constants, serializers
@@ -83,7 +83,9 @@ class UsersRetrieveView(views.APIView):
         """
         try:
             # user_idに紐づくPlayerを取得
-            player: models.Player = models.Player.objects.get(user_id=user_id)
+            player: player_models.Player = player_models.Player.objects.get(
+                user_id=user_id
+            )
             users_serializer: serializers.UsersSerializer = (
                 serializers.UsersSerializer(
                     player,

--- a/backend/pong/users/views/retrieve.py
+++ b/backend/pong/users/views/retrieve.py
@@ -44,6 +44,7 @@ class UsersRetrieveView(views.APIView):
                                 accounts_constants.UserFields.USERNAME: "username1",
                                 accounts_constants.PlayerFields.DISPLAY_NAME: "display_name1",
                                 accounts_constants.PlayerFields.AVATAR: "avatars/sample.png",
+                                # todo: is_friend,is_blocked,is_online,win_match,lose_match追加
                             },
                         },
                     ),
@@ -95,6 +96,7 @@ class UsersRetrieveView(views.APIView):
                         accounts_constants.UserFields.USERNAME,
                         accounts_constants.PlayerFields.DISPLAY_NAME,
                         accounts_constants.PlayerFields.AVATAR,
+                        # todo: is_friend,is_blocked,is_online,win_match,lose_match追加
                     ),
                 )
             )


### PR DESCRIPTION
## タスクやディスカッションのリンク
<!-- - URLをここに貼る -->
- #311 

## やったこと
<!-- - このタスクでやったことはなにか？ -->
- レスポンスで返すユーザープロフィールの中に、ログインユーザーとフレンドかどうかのフィールド `is_friend` を追加しました (89cfb64fd6fa9fb3d85624340ee199c98c889e1f)
- 上記以外は、テストのリファクタ・修正がほとんどです

## やらないこと
<!-- - このタスクでやらないことはなにか？（やらない場合いつやるのか？無ければ「なし」を記述） -->
`is_friend` 以外のフィールド追加 -> code 内に todo コメントで残してます

## 動作確認
<!-- - どのような動作確認を行い、結果はどうだったのか？(適宜スクショ等添付) -->
- テスト確認
```sh
make exec-be
make test ARG=users.tests
```
- swagger-ui にて
  - `users` の上 4 つのエンドポイントの example に `is_friend` が追加されていること
  - ログインして実際にリクエストを送り、レスポンスにも `is_friend` が追加されていること
  - ログインユーザーのフレンドの `is_friend` が `true` になっていて、フレンド以外(自分含む) は `false` になっていること

## 特にレビューをお願いしたい箇所
<!-- - 特にチェックをお願いしたいポイントを簡潔に記述する -->
主に挙動チェックと、実装内容で何かあれば何でも

## その他
<!-- - 実装上の懸念点、注意点等あれば記載する -->
特になし

## 参考リンク
<!-- - 実装に際し参考にした、記事やサイトのリンクを記載する -->
- DRF, `SerializerMethodField` : https://www.django-rest-framework.org/api-guide/fields/#serializermethodfield

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新機能**
  - ユーザープロフィールに「is_friend」フィールドを追加し、各ユーザー間のフレンド状態が明確に表示されるようになりました。これにより、プロフィールの情報がより充実し、ユーザー同士の関係性を簡単に把握できるよう改善されています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->