### PR TITLE
:zap: (BE:jwt) `/api/token` POST 作成

### DIFF
--- a/backend/pong/tmp_jwt/create_access_and_refresh_token.py
+++ b/backend/pong/tmp_jwt/create_access_and_refresh_token.py
@@ -6,6 +6,8 @@ from tmp_jwt import jwt
 logger = logging.getLogger(__name__)
 
 
+# todo: リファクタリング
+# - typによってexpの時間を変える関数作成
 def create_access_and_refresh_token(user_id: int) -> dict:
     jwt_handler: jwt.JWT = jwt.JWT()
     now: int = int(datetime.utcnow().timestamp())

--- a/backend/pong/tmp_jwt/create_access_and_refresh_token.py
+++ b/backend/pong/tmp_jwt/create_access_and_refresh_token.py
@@ -1,0 +1,33 @@
+import logging
+from datetime import datetime
+
+from tmp_jwt import jwt
+
+logger = logging.getLogger(__name__)
+
+
+def create_access_and_refresh_token(user_id: int) -> dict:
+    jwt_handler: jwt.JWT = jwt.JWT()
+    now: int = int(datetime.utcnow().timestamp())
+    # アクセストークンの有効期限は10分にしています
+    access_payload: dict = {
+        "sub": user_id,
+        "exp": now + 500,
+        "iat": now,
+        "typ": "access",
+    }
+    # リフレッシュトークンの有効期限は1時間にしています
+    refresh_payload: dict = {
+        "sub": user_id,
+        "exp": now + 3600,
+        "iat": now,
+        "typ": "refresh",
+    }
+    tokens: dict = {}
+    try:
+        tokens["access"] = jwt_handler.encode(access_payload)
+        tokens["refresh"] = jwt_handler.encode(refresh_payload)
+    except ValueError as e:
+        # 本来起こらないエラー
+        logger.error(e)
+    return tokens

--- a/backend/pong/tmp_jwt/tests/integrations/test_token.py
+++ b/backend/pong/tmp_jwt/tests/integrations/test_token.py
@@ -1,0 +1,21 @@
+from django.contrib.auth.models import User
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+
+class TokenViewTestCase(APITestCase):
+    def setUp(self) -> None:
+        self.user = User.objects.create_user(
+            username="testuser", email="user@example.com", password="password"
+        )
+        self.url = reverse("tmp_jwt:token_obtain_pair")
+
+    def test_api_token_success(self) -> None:
+        """
+        存在するユーザーのemailとpasswordでアクセストークンとリフレッシュトークンが取得できることを確認
+        """
+        data = {"email": "user@example.com", "password": "password"}
+        response = self.client.post(self.url, data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        # todo: アクセストークンとリフレッシュトークンが返されることを確認

--- a/backend/pong/tmp_jwt/tests/integrations/test_token.py
+++ b/backend/pong/tmp_jwt/tests/integrations/test_token.py
@@ -18,7 +18,11 @@ class TokenViewTestCase(APITestCase):
         data = {"email": "user@example.com", "password": "password"}
         response = self.client.post(self.url, data, format="json")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        # todo: アクセストークンとリフレッシュトークンが返されることを確認
+        response_data = response.json()["data"]
+        self.assertIn("access", response_data)
+        self.assertIn("refresh", response_data)
+        self.assertTrue(response_data["access"])
+        self.assertTrue(response_data["refresh"])
 
     def test_api_token_user_not_exists(self) -> None:
         """

--- a/backend/pong/tmp_jwt/tests/integrations/test_token.py
+++ b/backend/pong/tmp_jwt/tests/integrations/test_token.py
@@ -32,3 +32,11 @@ class TokenViewTestCase(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
         self.assertEqual(response.data["code"][0], "not_exists")
 
+    def test_api_token_incorrect_password(self) -> None:
+        """
+        存在するユーザーのemailで間違ったpasswordを渡した場合、'incorrect_password' エラーが返されることを確認
+        """
+        data = {"email": self.user.email, "password": "wrongpassword"}
+        response = self.client.post(self.url, data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual(response.data["code"][0], "incorrect_password")

--- a/backend/pong/tmp_jwt/tests/integrations/test_token.py
+++ b/backend/pong/tmp_jwt/tests/integrations/test_token.py
@@ -44,3 +44,16 @@ class TokenViewTestCase(APITestCase):
         response = self.client.post(self.url, data, format="json")
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
         self.assertEqual(response.data["code"][0], "incorrect_password")
+
+    def test_api_token_invalid_request(self) -> None:
+        """
+        emailとpassword以外のリクエストの値を渡した場合、'internal_error' エラーが返されることを確認
+        """
+        data = {
+            "user": 1,
+            "email": self.user.email,
+            "password": self.user.password,
+        }
+        response = self.client.post(self.url, data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data["code"][0], "internal_error")

--- a/backend/pong/tmp_jwt/tests/integrations/test_token.py
+++ b/backend/pong/tmp_jwt/tests/integrations/test_token.py
@@ -19,3 +19,16 @@ class TokenViewTestCase(APITestCase):
         response = self.client.post(self.url, data, format="json")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         # todo: アクセストークンとリフレッシュトークンが返されることを確認
+
+    def test_api_token_user_not_exists(self) -> None:
+        """
+        存在しないユーザーのemailでリクエストした場合、'not_exists' エラーが返されることを確認
+        """
+        data = {
+            "email": "nonexistent@example.com",
+            "password": self.user.password,
+        }
+        response = self.client.post(self.url, data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual(response.data["code"][0], "not_exists")
+

--- a/backend/pong/tmp_jwt/views/token.py
+++ b/backend/pong/tmp_jwt/views/token.py
@@ -2,6 +2,8 @@ from drf_spectacular import utils
 from rest_framework import permissions, request, response, views
 from rest_framework_simplejwt.serializers import TokenObtainPairSerializer
 
+from pong.custom_response import custom_response
+
 
 class TokenObtainView(views.APIView):
     """
@@ -11,7 +13,18 @@ class TokenObtainView(views.APIView):
     permission_classes = (permissions.AllowAny,)
 
     @utils.extend_schema(
-        request=TokenObtainPairSerializer,
+        request=utils.OpenApiRequest(
+            TokenObtainPairSerializer,
+            examples=[
+                utils.OpenApiExample(
+                    "Example request",
+                    value={
+                        "email": "user@example.com",
+                        "password": "password",
+                    },
+                ),
+            ],
+        ),
         responses={
             200: utils.OpenApiResponse(
                 description="アクセストークンとリフレッシュトークンを返す",
@@ -84,5 +97,12 @@ class TokenObtainView(views.APIView):
         """
         アクセストークンとリフレッシュトークンを取得するPOSTメソッド
         """
+        # todo: JWT作成
         pass
         return response.Response()
+        # 1. ユーザーが存在するかどうか
+        # 2. パスワードが正しいかどうか
+        # 3. user_idをペイロード作成
+        # 4. ペイロードからJWTにエンコード
+        # 5. アクセストークンとリフレッシュトークンを返す
+        return custom_response.CustomResponse(status=status.HTTP_200_OK)

--- a/backend/pong/tmp_jwt/views/token.py
+++ b/backend/pong/tmp_jwt/views/token.py
@@ -1,5 +1,6 @@
 import logging
 
+from django.contrib.auth import authenticate
 from django.contrib.auth.models import User
 from drf_spectacular import utils
 from rest_framework import permissions, request, response, status, views
@@ -110,10 +111,14 @@ class TokenObtainView(views.APIView):
             return custom_response.CustomResponse(
                 code=["not_exists"], status=status.HTTP_401_UNAUTHORIZED
             )
-        pass
-        return response.Response()
-        # 1. ユーザーが存在するかどうか
-        # 2. パスワードが正しいかどうか
+
+        password = request.data.get("password")
+        if authenticate(username=user.username, password=password) is None:
+            logger.error(f"Password is incorrect: {password}")
+            return custom_response.CustomResponse(
+                code=["incorrect_password"],
+                status=status.HTTP_401_UNAUTHORIZED,
+            )
         # 3. user_idをペイロード作成
         # 4. ペイロードからJWTにエンコード
         # 5. アクセストークンとリフレッシュトークンを返す

--- a/backend/pong/tmp_jwt/views/token.py
+++ b/backend/pong/tmp_jwt/views/token.py
@@ -1,8 +1,13 @@
+import logging
+
+from django.contrib.auth.models import User
 from drf_spectacular import utils
-from rest_framework import permissions, request, response, views
+from rest_framework import permissions, request, response, status, views
 from rest_framework_simplejwt.serializers import TokenObtainPairSerializer
 
 from pong.custom_response import custom_response
+
+logger = logging.getLogger(__name__)
 
 
 class TokenObtainView(views.APIView):
@@ -98,6 +103,13 @@ class TokenObtainView(views.APIView):
         アクセストークンとリフレッシュトークンを取得するPOSTメソッド
         """
         # todo: JWT作成
+        email = request.data.get("email")
+        user = User.objects.filter(email=email).first()
+        if user is None:
+            logger.error(f"Email does not register: {email}")
+            return custom_response.CustomResponse(
+                code=["not_exists"], status=status.HTTP_401_UNAUTHORIZED
+            )
         pass
         return response.Response()
         # 1. ユーザーが存在するかどうか

--- a/backend/pong/tmp_jwt/views/token.py
+++ b/backend/pong/tmp_jwt/views/token.py
@@ -104,6 +104,14 @@ class TokenObtainView(views.APIView):
         """
         アクセストークンとリフレッシュトークンを取得するPOSTメソッド
         """
+        required_keys: set = {"email", "password"}
+        request_keys: set = set(request.data.keys())
+        if request_keys != required_keys:
+            return custom_response.CustomResponse(
+                code=["internal_error"],
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
         email = request.data.get("email")
         user = User.objects.filter(email=email).first()
         if user is None:

--- a/backend/pong/tmp_jwt/views/token.py
+++ b/backend/pong/tmp_jwt/views/token.py
@@ -21,6 +21,7 @@ class TokenObtainView(views.APIView):
 
     @utils.extend_schema(
         request=utils.OpenApiRequest(
+            # todo: email, passwordをシリアライズ作成する
             TokenObtainPairSerializer,
             examples=[
                 utils.OpenApiExample(
@@ -103,7 +104,20 @@ class TokenObtainView(views.APIView):
     def post(self, request: request.Request) -> response.Response:
         """
         アクセストークンとリフレッシュトークンを取得するPOSTメソッド
+
+        Responses:
+            - 200: アクセストークンとリフレッシュトークンを返す
+            - 400:
+                - internal_error: リクエスト形式が不正の場合
+            - 401:
+                - not_exists: アカウントが存在しない場合
+                - incorrect_password: パスワードが間違っている場合
+            - 500:
+                - internal_error:
+                    - JWTトークンの生成に失敗した場合
+                    - 予期せぬエラーが発生した場合
         """
+        # todo: email, passwordをシリアライズ作成する
         required_keys: set = {"email", "password"}
         request_keys: set = set(request.data.keys())
         if request_keys != required_keys:
@@ -122,7 +136,7 @@ class TokenObtainView(views.APIView):
 
         password = request.data.get("password")
         if authenticate(username=user.username, password=password) is None:
-            logger.error(f"Password is incorrect: {password}")
+            logger.error("Password is incorrect")
             return custom_response.CustomResponse(
                 code=["incorrect_password"],
                 status=status.HTTP_401_UNAUTHORIZED,


### PR DESCRIPTION
## タスクやディスカッションのリンク
<!-- - URLをここに貼る -->
- #295 
## やったこと
<!-- - このタスクでやったことはなにか？ -->
`/api/token` POSTの作成
成功時にアクセストークンとリフレッシュトークンを作成するようにした
- 存在するユーザーでemailとpasswordが正しい場合

エラー
- `code: incorrect_password`:  存在するユーザーでpasswordが異なる場合
- `code: not_exsits`: ユーザーが存在しないemailの場合

ユーザーに表示するエラーメッセージの書式の定義の詳細
https://www.notion.so/440370c7d06c497abfda19ac0fbc95e7?pvs=4#6c5e4d0928cc4e97a75d616e6d17ad21

## やらないこと
<!-- - このタスクでやらないことはなにか？（やらない場合いつやるのか？無ければ「なし」を記述） -->
- アクセストークンとリフレッシュトークンを作成する関数のリファクタリング
- ありえなそうなテストケースは作成していないです！
  - emailがNone, 空文字、@が存在しない、文字数が255以上など
  - passwordがNone, 空文字
  - リクエストが`{}`
  - アクセストークン、リフレッシュトークンの有効性

## 動作確認
<!-- - どのような動作確認を行い、結果はどうだったのか？(適宜スクショ等添付) -->
```
make exec-be
python3 manage.py test tmp_jwt.tests.integrations
```

swagger-uiで期待通りのレスポンスできているかどうか
<img width="1435" alt="Screenshot 2025-02-13 at 19 02 12" src="https://github.com/user-attachments/assets/4ac3feaa-69fe-48e2-9fc7-197c1aa722d9" />

## 特にレビューをお願いしたい箇所
<!-- - 特にチェックをお願いしたいポイントを簡潔に記述する -->
他にも追加した方がいいテストケースあれば！

[質問]
パスワードやemailが正しいかどうか`TokenSerializers`っていうクラスを作成し、返り値を検証済みのemailとpasswordを返すようにしようと思っているのですが、どう思いますか？

## その他
<!-- - 実装上の懸念点、注意点等あれば記載する -->
アクセストークンの有効期限は10分、リフレッシュトークンの有効期限は1時間にしています

## 参考リンク
<!-- - 実装に際し参考にした、記事やサイトのリンクを記載する -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **新機能**
	- 認証エンドポイントを強化し、ユーザーのログイン時に短時間のアクセス・長時間のリフレッシュトークンを発行できるようになりました。
	- 入力不足、不正な認証情報、存在しないアカウントに対して、適切なエラーメッセージが返されるよう改善しました。

- **テスト**
	- 新たな認証シナリオを検証する自動テストケースを追加し、品質と信頼性を向上させています。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->