### PR TITLE
🐛 [response] data が空 list の場合にそのまま返すように修正 

### DIFF
--- a/backend/pong/pong/custom_response/custom_response.py
+++ b/backend/pong/pong/custom_response/custom_response.py
@@ -62,9 +62,9 @@ class CustomResponse(response.Response):
         if status < 400:
             # 300番台までの成功レスポンス
             self.data[STATUS] = Status.OK
-            self.data[DATA] = data or {}
+            self.data[DATA] = data if data is not None else {}
         else:
             # 400番台以上のエラーレスポンス
             self.data[STATUS] = Status.ERROR
-            self.data[CODE] = code or []
-            self.data[ERRORS] = errors or {}
+            self.data[CODE] = code if code is not None else []
+            self.data[ERRORS] = errors if errors is not None else {}

--- a/backend/pong/pong/custom_response/custom_response.py
+++ b/backend/pong/pong/custom_response/custom_response.py
@@ -34,7 +34,7 @@ class CustomResponse(response.Response):
     レスポンスのJSON形式(self.data):
         {
             "status": "ok" | "error",
-            "data": {...},
+            "data": {...} | [...],
             "code": ["string", ...],
             "errors": {...}
         }
@@ -49,7 +49,7 @@ class CustomResponse(response.Response):
     # https://github.com/django/django/blob/main/django/http/response.py#L111
     def __init__(
         self,
-        data: Optional[dict] = None,
+        data: Optional[dict | list] = None,
         code: Optional[list[str]] = None,
         errors: Optional[dict] = None,
         status: int = 200,

--- a/backend/pong/pong/custom_response/test_custom_response.py
+++ b/backend/pong/pong/custom_response/test_custom_response.py
@@ -30,6 +30,17 @@ class ResponseTests(test.TestCase):
         self.assertEqual(response.status, status.HTTP_200_OK)
         self.assertEqual(response.data, {STATUS: STATUS_OK, DATA: {}})
 
+    def test_200_with_empty_data(self) -> None:
+        """
+        引数にNoneではなく空listが渡された際に、デフォルトの空辞書ではなくそのまま返されることを確認
+        """
+        response: custom_response.CustomResponse = (
+            custom_response.CustomResponse(data=[])
+        )
+
+        self.assertEqual(response.status, status.HTTP_200_OK)
+        self.assertEqual(response.data, {STATUS: STATUS_OK, DATA: []})
+
     def test_201_with_data(self) -> None:
         """
         201(デフォルト値の200以外)で呼ばれた際に、成功レスポンスが形式に沿って返されることを確認

--- a/backend/pong/users/friends/tests/integration/test_list_views.py
+++ b/backend/pong/users/friends/tests/integration/test_list_views.py
@@ -118,7 +118,7 @@ class FriendsListViewTests(test.APITestCase):
         response: drf_response.Response = self.client.get(self.url)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data[DATA], {})
+        self.assertEqual(response.data[DATA], [])
 
     def test_200_get_friends_list(self) -> None:
         """

--- a/backend/pong/users/tests/integration/test_list.py
+++ b/backend/pong/users/tests/integration/test_list.py
@@ -78,7 +78,7 @@ class UsersListViewTests(test.APITestCase):
         response: drf_response.Response = self.client.get(self.url)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data[DATA], {})
+        self.assertEqual(response.data[DATA], [])
 
     def test_200_get_users_list(self) -> None:
         """


### PR DESCRIPTION
## タスクやディスカッションのリンク
<!-- - URLをここに貼る -->
- #319 

## やったこと
<!-- - このタスクでやったことはなにか？ -->
- 一覧取得のエンドポイントから、空リスト `[]` ではなく custom_response のデフォルト値である空辞書 `{}` が返ってしまっていたので、None ではない場合は空でもそのままレスポンスの data にセットするように修正しました

## やらないこと
<!-- - このタスクでやらないことはなにか？（やらない場合いつやるのか？無ければ「なし」を記述） -->
特になし

## 動作確認
<!-- - どのような動作確認を行い、結果はどうだったのか？(適宜スクショ等添付) -->
- テスト確認
```sh
make exec-be
make test ARG=pong
```
- swagger-ui にて確認
  - ユーザー一覧取得で空リストが返ることを試すためにユーザーを全部消すのは面倒だと思うので、フレンドがいないユーザーでログインし、フレンド一覧取得 `/api/users/me/friends/`, `GET` をすると空辞書ではく空リストが返ることを確認できるかと思います
  ```
  {
    "status": "ok",
    "data": []
  }
  ```

## 特にレビューをお願いしたい箇所
<!-- - 特にチェックをお願いしたいポイントを簡潔に記述する -->
複数のデータをリストで返す際に、問題ありそうな箇所がまだあればお願いします

## その他
<!-- - 実装上の懸念点、注意点等あれば記載する -->
特になし
## 参考リンク
<!-- - 実装に際し参考にした、記事やサイトのリンクを記載する -->
特になし

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
  - APIの応答処理を改善し、返却されるデータ形式が柔軟になりました。これにより、データが存在しない場合は従来の空オブジェクトではなく、空の配列が返されるようになり、より一貫性のある形式となります。
- **Bug Fixes**
  - ユーザーやフレンドリストのデータ取得時に発生していた、空データ返却時の不整合な形式の問題を修正し、期待通りのレスポンスが得られるようになりました。
- **Tests**
  - 新しいテストケースを追加し、空のデータが渡された際の応答が適切であることを確認しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->