### PR TITLE
🌱 フレンド一覧の表示

### DIFF
--- a/frontend/pong/js/api/users/convertFriendData.js
+++ b/frontend/pong/js/api/users/convertFriendData.js
@@ -1,0 +1,13 @@
+export const convertFriendData = (friendData) => {
+  const {
+    friend_user_id,
+    friend: { username, display_name, avatar },
+  } = friendData;
+
+  return {
+    id: friend_user_id,
+    username,
+    displayName: display_name,
+    avatar,
+  };
+};

--- a/frontend/pong/js/api/users/convertUserData.js
+++ b/frontend/pong/js/api/users/convertUserData.js
@@ -1,8 +1,10 @@
 export const convertUserData = (userData) => {
+  const { id, username, display_name, avatar } = userData;
+
   return {
-    id: userData.id,
-    username: userData.username,
-    displayName: userData.display_name,
-    avatar: userData.avatar,
+    id,
+    username,
+    displayName: display_name,
+    avatar,
   };
 };

--- a/frontend/pong/js/api/users/getFriends.js
+++ b/frontend/pong/js/api/users/getFriends.js
@@ -1,0 +1,11 @@
+import { Endpoints } from "../../constants/Endpoints";
+import { fetchData } from "../utils/fetchData";
+import { convertFriendData } from "./convertFriendData";
+
+export async function getFriends() {
+  // TODO: 認証つきのものに変更
+  const { data, error } = await fetchData(Endpoints.FRIENDS.href);
+
+  const users = error ? [] : data.map(convertFriendData);
+  return { users, error };
+}

--- a/frontend/pong/js/components/user/UserListContainer.js
+++ b/frontend/pong/js/components/user/UserListContainer.js
@@ -16,7 +16,7 @@ export class UserListContainer extends Component {
   #userProfileContainer;
 
   constructor(state) {
-    super({ isError: false, ...state });
+    super({ isError: false, fetchUsers: getUsers, ...state });
   }
 
   _setStyle() {
@@ -38,7 +38,8 @@ export class UserListContainer extends Component {
     });
     this.#userProfileContainer = new UserProfileContainer();
 
-    getUsers().then(({ users, error }) => {
+    const { fetchUsers } = this._getState();
+    fetchUsers().then(({ users, error }) => {
       if (error) {
         this._updateState({ isError: true });
         return;
@@ -60,9 +61,7 @@ export class UserListContainer extends Component {
   _render() {
     const { isError } = this._getState();
     if (isError) {
-      this.append(
-        new ErrorContainer({ message: "ユーザー一覧情報の取得" }),
-      );
+      this.append(new ErrorContainer({ message: "一覧情報の取得" }));
       return;
     }
 

--- a/frontend/pong/js/components/views/FriendsView.js
+++ b/frontend/pong/js/components/views/FriendsView.js
@@ -1,9 +1,29 @@
+import { getFriends } from "../../api/users/getFriends";
+import { BootstrapDisplay } from "../../bootstrap/utilities/display";
+import { BootstrapFlex } from "../../bootstrap/utilities/flex";
+import { BootstrapSizing } from "../../bootstrap/utilities/sizing";
 import { View } from "../../core/View";
+import { UserListContainer } from "../user/UserListContainer";
 
 export class FriendsView extends View {
+  #friendsListContainer;
+
+  _setStyle() {
+    BootstrapDisplay.setFlex(this);
+    BootstrapFlex.setFlexColumn(this);
+    BootstrapFlex.setJustifyContentCenter(this);
+    BootstrapFlex.setAlignItemsCenter(this);
+    BootstrapSizing.setWidth100(this);
+    BootstrapSizing.setHeight100(this);
+  }
+
+  _onConnect() {
+    this.#friendsListContainer = new UserListContainer({
+      fetchUsers: getFriends,
+    });
+  }
+
   _render() {
-    const title = document.createElement("h2");
-    title.textContent = "Friends View";
-    this.appendChild(title);
+    this.append(this.#friendsListContainer);
   }
 }

--- a/frontend/pong/js/components/views/UsersView.js
+++ b/frontend/pong/js/components/views/UsersView.js
@@ -1,3 +1,4 @@
+import { getUsers } from "../../api/users/getUsers";
 import { BootstrapDisplay } from "../../bootstrap/utilities/display";
 import { BootstrapFlex } from "../../bootstrap/utilities/flex";
 import { BootstrapSizing } from "../../bootstrap/utilities/sizing";
@@ -17,7 +18,9 @@ export class UsersView extends View {
   }
 
   _onConnect() {
-    this.#userListContainer = new UserListContainer();
+    this.#userListContainer = new UserListContainer({
+      fetchUsers: getUsers,
+    });
   }
 
   _render() {

--- a/frontend/pong/js/constants/Endpoints.js
+++ b/frontend/pong/js/constants/Endpoints.js
@@ -14,4 +14,5 @@ export const Endpoints = Object.freeze({
     withId: (userId) => new URL(`${userId}`, Endpoints.USERS.default),
     defaultAvatar: new URL(DEFAULT_AVATAR_IMAGE_PATH, BASE_URL),
   },
+  FRIENDS: new URL("/api/users/me/friends/", BASE_URL),
 });

--- a/frontend/pong/js/mocks/handlers/friends.js
+++ b/frontend/pong/js/mocks/handlers/friends.js
@@ -1,0 +1,12 @@
+import { http, HttpResponse } from "msw";
+import { Endpoints } from "../../constants/Endpoints";
+import { sampleFriends } from "../utils/createSamples";
+
+export const handlers = [
+  http.get(Endpoints.FRIENDS.href, async () => {
+    return HttpResponse.json({
+      status: "ok",
+      data: sampleFriends,
+    });
+  }),
+];

--- a/frontend/pong/js/mocks/handlers/index.js
+++ b/frontend/pong/js/mocks/handlers/index.js
@@ -1,3 +1,4 @@
+import { handlers as friendsHandlers } from "./friends";
 import { handlers as healthHandlers } from "./health";
 import { handlers as usersHandlers } from "./users";
 import { handlers as webSocketHandlers } from "./webSocket";
@@ -5,5 +6,6 @@ import { handlers as webSocketHandlers } from "./webSocket";
 export const handlers = [
   ...healthHandlers,
   ...usersHandlers,
+  ...friendsHandlers,
   ...webSocketHandlers,
 ];

--- a/frontend/pong/js/mocks/handlers/users.js
+++ b/frontend/pong/js/mocks/handlers/users.js
@@ -1,17 +1,6 @@
 import { http, HttpResponse } from "msw";
 import { Endpoints } from "../../constants/Endpoints";
-
-const SAMPLE_COUNT = 30;
-const createSampleUser = (number) =>
-  Object.freeze({
-    id: `${number}`,
-    username: `pong${number}`,
-    display_name: `DISPLAY${number}`,
-    avatar: "https://placehold.co/30",
-  });
-const sampleUsers = Array.from({ length: SAMPLE_COUNT }).map(
-  (_, idx) => createSampleUser(idx + 1),
-);
+import { sampleUsers } from "../utils/createSamples";
 
 export const handlers = [
   http.get(Endpoints.USERS.default.href, async () => {

--- a/frontend/pong/js/mocks/utils/createSamples.js
+++ b/frontend/pong/js/mocks/utils/createSamples.js
@@ -1,5 +1,6 @@
-const MY_USER_ID = 21;
-const SAMPLE_COUNT = 30;
+const SAMPLE_COUNT = 30; // userId: 1 ~ SAMPLE_COUNT
+
+const MY_USER_ID = 1;
 
 const createSampleUser = (number) =>
   Object.freeze({
@@ -24,8 +25,8 @@ const createSampleFriend = (idx) =>
     },
   });
 
-const sampleFriends = Array.from({ length: SAMPLE_COUNT / 2 }).map(
-  (_, idx) => createSampleFriend(2 * idx),
-);
+const sampleFriends = Array.from({ length: SAMPLE_COUNT / 2 })
+  .map((_, idx) => createSampleFriend(2 * idx))
+  .filter((friend) => friend.user_id !== friend.friend_user_id);
 
 export { sampleUsers, sampleFriends };

--- a/frontend/pong/js/mocks/utils/createSamples.js
+++ b/frontend/pong/js/mocks/utils/createSamples.js
@@ -1,0 +1,31 @@
+const MY_USER_ID = 21;
+const SAMPLE_COUNT = 30;
+
+const createSampleUser = (number) =>
+  Object.freeze({
+    id: `${number}`,
+    username: `pong${number}`,
+    display_name: `DISPLAY${number}`,
+    avatar: "https://placehold.co/30",
+  });
+
+const sampleUsers = Array.from({ length: SAMPLE_COUNT }).map(
+  (_, idx) => createSampleUser(idx + 1),
+);
+
+const createSampleFriend = (idx) =>
+  Object.freeze({
+    user_id: `${MY_USER_ID}`,
+    friend_user_id: sampleUsers[idx].id,
+    friend: {
+      username: sampleUsers[idx].username,
+      display_name: sampleUsers[idx].display_name,
+      avatar: sampleUsers[idx].avatar,
+    },
+  });
+
+const sampleFriends = Array.from({ length: SAMPLE_COUNT / 2 }).map(
+  (_, idx) => createSampleFriend(2 * idx),
+);
+
+export { sampleUsers, sampleFriends };


### PR DESCRIPTION
## タスクやディスカッションのリンク
- #240 

## やったこと
- ユーザー一覧の表示と同じように、フレンド一覧も表示
- 簡単なモック作成

## やらないこと
- 認証つきの対応はしていなく、フレンドデータがあるときにそれを一旦表示しています。
- ユーザー一覧と同様に、フレンド追加やブロック対応などはまだ行っていません。

## 動作確認
- `cd frontend/pong && npm install && npm run dev`
- フレンド一覧を確認

## 特にレビューをお願いしたい箇所
なし

## その他
- モックですが、サンプルデータは 30 人ほど作成して自分は先頭の人として奇数番目の人と友達になるようにしてみました。

## 参考リンク
- https://www.notion.so/007-15af1b77f6c2804bbf09d16fc90fd854?pvs=4
- #279 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- フレンド情報を統一フォーマットで取得・表示する仕組みを追加し、ユーザーやフレンドリストの更新をより柔軟に実施できるようになりました。
	- フレンドデータ取得用の新しいエンドポイントを導入し、データ反映の正確性と迅速な読み込みを実現しました。
- **スタイル**
	- フレンドビューのレイアウトとエラーメッセージの表示を改善し、より快適な利用体験を提供します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->