### PR TITLE
⚡ [friends] 使用しない retrieve のエンドポイントは 405 が返るようにし、extend_schema からも削除

### DIFF
--- a/backend/pong/users/friends/views.py
+++ b/backend/pong/users/friends/views.py
@@ -84,3 +84,13 @@ class FriendsViewSet(viewsets.ModelViewSet):
         return custom_response.CustomResponse(
             data=list_serializer.data, status=status.HTTP_200_OK
         )
+
+    @utils.extend_schema(exclude=True)
+    def retrieve(
+        self, request: request.Request, *args: tuple, **kwargs: dict
+    ) -> response.Response:
+        """
+        `/api/users/me/friends/{friend_id}/`,GETメソッド用の関数
+        自動的に使用できるが仕様上不要なため、405を返しswagger-uiに表示されないようにしている
+        """
+        return response.Response(status=status.HTTP_405_METHOD_NOT_ALLOWED)


### PR DESCRIPTION
## タスクやディスカッションのリンク
<!-- - URLをここに貼る -->
- #327 

## やったこと
<!-- - このタスクでやったことはなにか？ -->
- viewset が GET を指定すると自動で作成するエンドポイント `/api/users/me/friends/{id}`, `GET` が今回の仕様では不要なので、405 not allowed を返し、extend_schema にも表示されないようにしました

## やらないこと
<!-- - このタスクでやらないことはなにか？（やらない場合いつやるのか？無ければ「なし」を記述） -->
特になし
## 動作確認
<!-- - どのような動作確認を行い、結果はどうだったのか？(適宜スクショ等添付) -->
- swagger-ui にて `/api/users/me/friends/{id}`, `GET` が表示されていないこと
- 405 が返ることも確かめたい場合は、88 行目の `@utils.extend_schema(exclude=True)` をコメントアウトして、swagger-ui でログイン後、リクエストを送ると 405 が返ります

## 特にレビューをお願いしたい箇所
<!-- - 特にチェックをお願いしたいポイントを簡潔に記述する -->
動作確認

## その他
<!-- - 実装上の懸念点、注意点等あれば記載する -->
他の not allowed method と同様に、CustomResponse ではなく DRF の response を返しました

## 参考リンク
<!-- - 実装に際し参考にした、記事やサイトのリンクを記載する -->
特になし

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - 将来的な拡張に向け、友達プロフィール取得機能のプレースホルダーを追加しました。現時点ではこの機能は利用不可の状態であり、既存の動作に影響はありません。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->