### PR TITLE
⚡ [users, friend] ユーザープロフィールとして返す情報を統一する

### DIFF
--- a/backend/pong/users/friends/serializers/create_serializers.py
+++ b/backend/pong/users/friends/serializers/create_serializers.py
@@ -18,9 +18,11 @@ class FriendshipCreateSerializer(serializers.ModelSerializer):
         source="friend.player",
         read_only=True,
         fields=(  # emailは含めない
+            accounts_constants.UserFields.ID,
             accounts_constants.UserFields.USERNAME,
             accounts_constants.PlayerFields.DISPLAY_NAME,
             accounts_constants.PlayerFields.AVATAR,
+            # todo: is_friend,is_blocked,is_online,win_match,lose_match追加
         ),
     )
 

--- a/backend/pong/users/friends/serializers/create_serializers.py
+++ b/backend/pong/users/friends/serializers/create_serializers.py
@@ -8,8 +8,12 @@ from . import validators
 
 
 class FriendshipCreateSerializer(serializers.ModelSerializer):
-    user_id = serializers.IntegerField(source="user.id", min_value=1)
-    friend_user_id = serializers.IntegerField(source="friend.id", min_value=1)
+    user_id = serializers.IntegerField(
+        source="user.id", min_value=1, write_only=True
+    )
+    friend_user_id = serializers.IntegerField(
+        source="friend.id", min_value=1, write_only=True
+    )
     friend = users_serializers.UsersSerializer(
         source="friend.player",
         read_only=True,

--- a/backend/pong/users/friends/serializers/create_serializers.py
+++ b/backend/pong/users/friends/serializers/create_serializers.py
@@ -9,9 +9,6 @@ from . import validators
 
 
 class FriendshipCreateSerializer(serializers.ModelSerializer):
-    user_id = serializers.IntegerField(
-        source="user.id", min_value=1, write_only=True
-    )
     friend_user_id = serializers.IntegerField(
         source="friend.id", min_value=1, write_only=True
     )
@@ -31,7 +28,6 @@ class FriendshipCreateSerializer(serializers.ModelSerializer):
     class Meta:
         model = models.Friendship
         fields = (
-            constants.FriendshipFields.USER_ID,
             constants.FriendshipFields.FRIEND_USER_ID,
             constants.FriendshipFields.FRIEND,
         )
@@ -40,7 +36,7 @@ class FriendshipCreateSerializer(serializers.ModelSerializer):
         """
         save()内で呼ばれるcreate()のオーバーライド
         """
-        user_id: int = data["user"]["id"]
+        user_id: int = self.context[constants.FriendshipFields.USER_ID]
         friend_user_id: int = data["friend"]["id"]
         return models.Friendship.objects.create(
             user_id=user_id, friend_id=friend_user_id
@@ -56,7 +52,7 @@ class FriendshipCreateSerializer(serializers.ModelSerializer):
               - フレンドに追加したいユーザーが存在しない場合
               - フレンドに追加したいユーザーが既にフレンドである場合
         """
-        user_id: int = data["user"]["id"]
+        user_id: int = self.context[constants.FriendshipFields.USER_ID]
         friend_user_id: int = data["friend"]["id"]
 
         # 自分自身をフレンドに追加しようとした場合にValidationErrorを発生させる

--- a/backend/pong/users/friends/serializers/create_serializers.py
+++ b/backend/pong/users/friends/serializers/create_serializers.py
@@ -1,6 +1,7 @@
 from rest_framework import serializers
 
 from accounts import constants as accounts_constants
+from users import constants as users_constants
 from users import serializers as users_serializers
 
 from .. import constants, models
@@ -22,7 +23,8 @@ class FriendshipCreateSerializer(serializers.ModelSerializer):
             accounts_constants.UserFields.USERNAME,
             accounts_constants.PlayerFields.DISPLAY_NAME,
             accounts_constants.PlayerFields.AVATAR,
-            # todo: is_friend,is_blocked,is_online,win_match,lose_match追加
+            users_constants.UsersFields.IS_FRIEND,
+            # todo: is_blocked,is_online,win_match,lose_match追加
         ),
     )
 

--- a/backend/pong/users/friends/serializers/destroy_serializers.py
+++ b/backend/pong/users/friends/serializers/destroy_serializers.py
@@ -5,8 +5,12 @@ from . import validators
 
 
 class FriendshipDestroySerializer(serializers.ModelSerializer):
-    user_id = serializers.IntegerField(source="user.id", min_value=1)
-    friend_user_id = serializers.IntegerField(source="friend.id", min_value=1)
+    user_id = serializers.IntegerField(
+        source="user.id", min_value=1, write_only=True
+    )
+    friend_user_id = serializers.IntegerField(
+        source="friend.id", min_value=1, write_only=True
+    )
 
     class Meta:
         model = models.Friendship

--- a/backend/pong/users/friends/serializers/destroy_serializers.py
+++ b/backend/pong/users/friends/serializers/destroy_serializers.py
@@ -5,19 +5,13 @@ from . import validators
 
 
 class FriendshipDestroySerializer(serializers.ModelSerializer):
-    user_id = serializers.IntegerField(
-        source="user.id", min_value=1, write_only=True
-    )
     friend_user_id = serializers.IntegerField(
         source="friend.id", min_value=1, write_only=True
     )
 
     class Meta:
         model = models.Friendship
-        fields = (
-            constants.FriendshipFields.USER_ID,
-            constants.FriendshipFields.FRIEND_USER_ID,
-        )
+        fields = (constants.FriendshipFields.FRIEND_USER_ID,)
 
     def validate(self, data: dict) -> dict:
         """
@@ -29,7 +23,7 @@ class FriendshipDestroySerializer(serializers.ModelSerializer):
               - 自分自身をフレンド解除しようとした場合
               - フレンド解除したいユーザーが存在しない場合
         """
-        user_id: int = data["user"]["id"]
+        user_id: int = self.context[constants.FriendshipFields.USER_ID]
         friend_user_id: int = data["friend"]["id"]
 
         # 自分自身をフレンド解除しようとした場合にValidationErrorを発生させる

--- a/backend/pong/users/friends/serializers/list_serializers.py
+++ b/backend/pong/users/friends/serializers/list_serializers.py
@@ -11,9 +11,11 @@ class FriendshipListSerializer(drf_serializers.ModelSerializer):
         source="friend.player",
         read_only=True,
         fields=(  # emailは含めない
+            accounts_constants.UserFields.ID,
             accounts_constants.UserFields.USERNAME,
             accounts_constants.PlayerFields.DISPLAY_NAME,
             accounts_constants.PlayerFields.AVATAR,
+            # todo: is_friend,is_blocked,is_online,win_match,lose_match追加
         ),
     )
 

--- a/backend/pong/users/friends/serializers/list_serializers.py
+++ b/backend/pong/users/friends/serializers/list_serializers.py
@@ -7,12 +7,6 @@ from .. import constants, models
 
 
 class FriendshipListSerializer(drf_serializers.ModelSerializer):
-    user_id = drf_serializers.IntegerField(
-        source="user.id", min_value=1, read_only=True
-    )
-    friend_user_id = drf_serializers.IntegerField(
-        source="friend.id", min_value=1, read_only=True
-    )
     friend = users_serializers.UsersSerializer(
         source="friend.player",
         read_only=True,
@@ -25,8 +19,4 @@ class FriendshipListSerializer(drf_serializers.ModelSerializer):
 
     class Meta:
         model = models.Friendship
-        fields = (
-            constants.FriendshipFields.USER_ID,
-            constants.FriendshipFields.FRIEND_USER_ID,
-            constants.FriendshipFields.FRIEND,
-        )
+        fields = (constants.FriendshipFields.FRIEND,)

--- a/backend/pong/users/friends/serializers/list_serializers.py
+++ b/backend/pong/users/friends/serializers/list_serializers.py
@@ -1,6 +1,7 @@
 from rest_framework import serializers as drf_serializers
 
 from accounts import constants as accounts_constants
+from users import constants as users_constants
 from users import serializers as users_serializers
 
 from .. import constants, models
@@ -15,7 +16,8 @@ class FriendshipListSerializer(drf_serializers.ModelSerializer):
             accounts_constants.UserFields.USERNAME,
             accounts_constants.PlayerFields.DISPLAY_NAME,
             accounts_constants.PlayerFields.AVATAR,
-            # todo: is_friend,is_blocked,is_online,win_match,lose_match追加
+            users_constants.UsersFields.IS_FRIEND,
+            # todo: is_blocked,is_online,win_match,lose_match追加
         ),
     )
 

--- a/backend/pong/users/friends/serializers/tests/test_create_serializers.py
+++ b/backend/pong/users/friends/serializers/tests/test_create_serializers.py
@@ -66,7 +66,6 @@ class FriendshipCreateSerializerTests(TestCase):
         """
         # user1がuser2をフレンドに追加する
         friendship_data: dict = {
-            USER_ID: self.user1.id,
             FRIEND_USER_ID: self.user2.id,
         }
         create_serializer: create_serializers.FriendshipCreateSerializer = (
@@ -78,8 +77,7 @@ class FriendshipCreateSerializerTests(TestCase):
         # validate()確認
         self.assertTrue(create_serializer.is_valid())
         self.assertEqual(
-            create_serializer.validated_data,
-            {USER: {ID: self.user1.id}, FRIEND: {ID: self.user2.id}},
+            create_serializer.validated_data, {FRIEND: {ID: self.user2.id}}
         )
         # create()確認
         create_serializer.save()
@@ -103,7 +101,6 @@ class FriendshipCreateSerializerTests(TestCase):
         """
         # user1が自分自身をフレンドに追加しようとする
         friendship_data: dict = {
-            USER_ID: self.user1.id,
             FRIEND_USER_ID: self.user1.id,
         }
         create_serializer: create_serializers.FriendshipCreateSerializer = (
@@ -127,7 +124,6 @@ class FriendshipCreateSerializerTests(TestCase):
         models.Friendship.objects.create(user=self.user1, friend=self.user2)
         # 再度、user1がuser2をフレンドに追加しようとする
         friendship_data: dict = {
-            USER_ID: self.user1.id,
             FRIEND_USER_ID: self.user2.id,
         }
         create_serializer: create_serializers.FriendshipCreateSerializer = (
@@ -149,7 +145,6 @@ class FriendshipCreateSerializerTests(TestCase):
         """
         # user1が存在しないユーザーをフレンドに追加しようとする
         friendship_data: dict = {
-            USER_ID: self.user1.id,
             FRIEND_USER_ID: 9999,
         }
         create_serializer: create_serializers.FriendshipCreateSerializer = (

--- a/backend/pong/users/friends/serializers/tests/test_create_serializers.py
+++ b/backend/pong/users/friends/serializers/tests/test_create_serializers.py
@@ -83,8 +83,6 @@ class FriendshipCreateSerializerTests(TestCase):
         self.assertEqual(
             create_serializer.data,
             {
-                USER_ID: self.user1.id,
-                FRIEND_USER_ID: self.user2.id,
                 FRIEND: {
                     USERNAME: self.user_data_2[USERNAME],
                     DISPLAY_NAME: self.player_data_2[DISPLAY_NAME],

--- a/backend/pong/users/friends/serializers/tests/test_create_serializers.py
+++ b/backend/pong/users/friends/serializers/tests/test_create_serializers.py
@@ -17,6 +17,7 @@ PASSWORD: Final[str] = accounts_constants.UserFields.PASSWORD
 USER: Final[str] = accounts_constants.PlayerFields.USER
 DISPLAY_NAME: Final[str] = accounts_constants.PlayerFields.DISPLAY_NAME
 AVATAR: Final[str] = accounts_constants.PlayerFields.AVATAR
+IS_FRIEND: Final[str] = users_constants.UsersFields.IS_FRIEND
 
 USER_ID: Final[str] = constants.FriendshipFields.USER_ID
 FRIEND_USER_ID: Final[str] = constants.FriendshipFields.FRIEND_USER_ID
@@ -69,7 +70,9 @@ class FriendshipCreateSerializerTests(TestCase):
             FRIEND_USER_ID: self.user2.id,
         }
         create_serializer: create_serializers.FriendshipCreateSerializer = (
-            create_serializers.FriendshipCreateSerializer(data=friendship_data)
+            create_serializers.FriendshipCreateSerializer(
+                data=friendship_data, context={USER_ID: self.user1.id}
+            )
         )
 
         # validate()確認
@@ -88,7 +91,8 @@ class FriendshipCreateSerializerTests(TestCase):
                     USERNAME: self.user_data_2[USERNAME],
                     DISPLAY_NAME: self.player_data_2[DISPLAY_NAME],
                     AVATAR: "/media/avatars/sample.png",  # todo: デフォルト画像が変更になったら修正
-                    # todo: is_friend,is_blocked,is_online,win_match,lose_match追加
+                    IS_FRIEND: True,
+                    # todo: is_blocked,is_online,win_match,lose_match追加
                 },
             },
         )
@@ -103,7 +107,9 @@ class FriendshipCreateSerializerTests(TestCase):
             FRIEND_USER_ID: self.user1.id,
         }
         create_serializer: create_serializers.FriendshipCreateSerializer = (
-            create_serializers.FriendshipCreateSerializer(data=friendship_data)
+            create_serializers.FriendshipCreateSerializer(
+                data=friendship_data, context={USER_ID: self.user1.id}
+            )
         )
 
         self.assertFalse(create_serializer.is_valid())
@@ -125,7 +131,9 @@ class FriendshipCreateSerializerTests(TestCase):
             FRIEND_USER_ID: self.user2.id,
         }
         create_serializer: create_serializers.FriendshipCreateSerializer = (
-            create_serializers.FriendshipCreateSerializer(data=friendship_data)
+            create_serializers.FriendshipCreateSerializer(
+                data=friendship_data, context={USER_ID: self.user1.id}
+            )
         )
 
         self.assertFalse(create_serializer.is_valid())
@@ -145,7 +153,9 @@ class FriendshipCreateSerializerTests(TestCase):
             FRIEND_USER_ID: 9999,
         }
         create_serializer: create_serializers.FriendshipCreateSerializer = (
-            create_serializers.FriendshipCreateSerializer(data=friendship_data)
+            create_serializers.FriendshipCreateSerializer(
+                data=friendship_data, context={USER_ID: self.user1.id}
+            )
         )
 
         self.assertFalse(create_serializer.is_valid())

--- a/backend/pong/users/friends/serializers/tests/test_create_serializers.py
+++ b/backend/pong/users/friends/serializers/tests/test_create_serializers.py
@@ -84,9 +84,11 @@ class FriendshipCreateSerializerTests(TestCase):
             create_serializer.data,
             {
                 FRIEND: {
+                    ID: self.user2.id,
                     USERNAME: self.user_data_2[USERNAME],
                     DISPLAY_NAME: self.player_data_2[DISPLAY_NAME],
                     AVATAR: "/media/avatars/sample.png",  # todo: デフォルト画像が変更になったら修正
+                    # todo: is_friend,is_blocked,is_online,win_match,lose_match追加
                 },
             },
         )

--- a/backend/pong/users/friends/serializers/tests/test_destroy_serializer.py
+++ b/backend/pong/users/friends/serializers/tests/test_destroy_serializer.py
@@ -67,21 +67,17 @@ class FriendshipCreateSerializerTests(TestCase):
         """
         正常にフレンド解除ができることを確認
         """
-        friendship_data: dict = {
-            USER_ID: self.user1.id,
-            FRIEND_USER_ID: self.user2.id,
-        }
+        friendship_data: dict = {FRIEND_USER_ID: self.user2.id}
         destroy_serializer: destroy_serializers.FriendshipDestroySerializer = (
             destroy_serializers.FriendshipDestroySerializer(
-                data=friendship_data
+                data=friendship_data, context={USER_ID: self.user1.id}
             )
         )
 
         # validate()確認
         self.assertTrue(destroy_serializer.is_valid())
         self.assertEqual(
-            destroy_serializer.validated_data,
-            {USER: {ID: self.user1.id}, FRIEND: {ID: self.user2.id}},
+            destroy_serializer.validated_data, {FRIEND: {ID: self.user2.id}}
         )
         # destroy()確認
         friendship: models.Friendship = models.Friendship.objects.get(
@@ -99,13 +95,10 @@ class FriendshipCreateSerializerTests(TestCase):
         自分自身をフレンド解除しようとした場合にエラーが発生することを確認
         """
         # user1が自分自身をフレンド解除しようとする
-        friendship_data: dict = {
-            USER_ID: self.user1.id,
-            FRIEND_USER_ID: self.user1.id,
-        }
+        friendship_data: dict = {FRIEND_USER_ID: self.user1.id}
         destroy_serializer: destroy_serializers.FriendshipDestroySerializer = (
             destroy_serializers.FriendshipDestroySerializer(
-                data=friendship_data
+                data=friendship_data, context={USER_ID: self.user1.id}
             )
         )
 
@@ -123,13 +116,10 @@ class FriendshipCreateSerializerTests(TestCase):
         # user1がuser2をフレンド解除する
         self.friendship.delete()
         # user1が再度user2をフレンド解除しようとする
-        friendship_data: dict = {
-            USER_ID: self.user1.id,
-            FRIEND_USER_ID: self.user2.id,
-        }
+        friendship_data: dict = {FRIEND_USER_ID: self.user2.id}
         destroy_serializer: destroy_serializers.FriendshipDestroySerializer = (
             destroy_serializers.FriendshipDestroySerializer(
-                data=friendship_data
+                data=friendship_data, context={USER_ID: self.user1.id}
             )
         )
 
@@ -144,14 +134,11 @@ class FriendshipCreateSerializerTests(TestCase):
         """
         存在しないユーザーをフレンド解除しようとした場合にエラーが発生することを確認
         """
-        # user1が存在しないユーザーをフレンド解除しようとする
-        friendship_data: dict = {
-            USER_ID: self.user1.id,
-            FRIEND_USER_ID: 9999,
-        }
+        # user1が、存在しないユーザーをフレンド解除しようとする
+        friendship_data: dict = {FRIEND_USER_ID: 9999}  # 存在しないユーザー
         destroy_serializer: destroy_serializers.FriendshipDestroySerializer = (
             destroy_serializers.FriendshipDestroySerializer(
-                data=friendship_data
+                data=friendship_data, context={USER_ID: self.user1.id}
             )
         )
 

--- a/backend/pong/users/friends/serializers/tests/test_list_serializers.py
+++ b/backend/pong/users/friends/serializers/tests/test_list_serializers.py
@@ -17,8 +17,6 @@ USER: Final[str] = accounts_constants.PlayerFields.USER
 DISPLAY_NAME: Final[str] = accounts_constants.PlayerFields.DISPLAY_NAME
 AVATAR: Final[str] = accounts_constants.PlayerFields.AVATAR
 
-USER_ID: Final[str] = constants.FriendshipFields.USER_ID
-FRIEND_USER_ID: Final[str] = constants.FriendshipFields.FRIEND_USER_ID
 FRIEND: Final[str] = constants.FriendshipFields.FRIEND
 
 
@@ -83,8 +81,6 @@ class FriendshipListSerializerTests(TestCase):
             list_serializer.data,
             [
                 {
-                    USER_ID: self.user1.id,
-                    FRIEND_USER_ID: self.user2.id,
                     FRIEND: {
                         USERNAME: self.user_data_2[USERNAME],
                         DISPLAY_NAME: self.player_data_2[DISPLAY_NAME],
@@ -92,8 +88,6 @@ class FriendshipListSerializerTests(TestCase):
                     },
                 },
                 {
-                    USER_ID: self.user1.id,
-                    FRIEND_USER_ID: self.user3.id,
                     FRIEND: {
                         USERNAME: self.user_data_3[USERNAME],
                         DISPLAY_NAME: self.player_data_3[DISPLAY_NAME],

--- a/backend/pong/users/friends/serializers/tests/test_list_serializers.py
+++ b/backend/pong/users/friends/serializers/tests/test_list_serializers.py
@@ -6,6 +6,7 @@ from django.test import TestCase
 
 from accounts import constants as accounts_constants
 from accounts.player import models as players_models
+from users import constants as users_constants
 
 from ... import constants, models
 from .. import list_serializers
@@ -17,7 +18,9 @@ PASSWORD: Final[str] = accounts_constants.UserFields.PASSWORD
 USER: Final[str] = accounts_constants.PlayerFields.USER
 DISPLAY_NAME: Final[str] = accounts_constants.PlayerFields.DISPLAY_NAME
 AVATAR: Final[str] = accounts_constants.PlayerFields.AVATAR
+IS_FRIEND: Final[str] = users_constants.UsersFields.IS_FRIEND
 
+USER_ID: Final[str] = constants.FriendshipFields.USER_ID
 FRIEND: Final[str] = constants.FriendshipFields.FRIEND
 
 
@@ -75,7 +78,9 @@ class FriendshipListSerializerTests(TestCase):
             models.Friendship.objects.filter(user=self.user1)
         )
         list_serializer: list_serializers.FriendshipListSerializer = (
-            list_serializers.FriendshipListSerializer(friends, many=True)
+            list_serializers.FriendshipListSerializer(
+                friends, many=True, context={USER_ID: self.user1.id}
+            )
         )
 
         self.assertEqual(
@@ -87,7 +92,8 @@ class FriendshipListSerializerTests(TestCase):
                         USERNAME: self.user_data_2[USERNAME],
                         DISPLAY_NAME: self.player_data_2[DISPLAY_NAME],
                         AVATAR: "/media/avatars/sample.png",  # todo: デフォルト画像が変更になったら修正
-                        # todo: is_friend,is_blocked,is_online,win_match,lose_match追加
+                        IS_FRIEND: True,
+                        # todo: is_blocked,is_online,win_match,lose_match追加
                     },
                 },
                 {
@@ -96,7 +102,8 @@ class FriendshipListSerializerTests(TestCase):
                         USERNAME: self.user_data_3[USERNAME],
                         DISPLAY_NAME: self.player_data_3[DISPLAY_NAME],
                         AVATAR: "/media/avatars/sample.png",  # todo: デフォルト画像が変更になったら修正
-                        # todo: is_friend,is_blocked,is_online,win_match,lose_match追加
+                        IS_FRIEND: True,
+                        # todo: is_blocked,is_online,win_match,lose_match追加
                     },
                 },
             ],
@@ -107,11 +114,14 @@ class FriendshipListSerializerTests(TestCase):
         フレンドが存在しない場合に、エラーにならず空のフレンド一覧が返されることを確認
         """
         # フレンドがいないuser2のフレンド一覧を取得
+        user_id: int = self.user2.id
         friends: QuerySet[models.Friendship] = (
-            models.Friendship.objects.filter(user=self.user2)
+            models.Friendship.objects.filter(user_id=user_id)
         )
         list_serializer: list_serializers.FriendshipListSerializer = (
-            list_serializers.FriendshipListSerializer(friends, many=True)
+            list_serializers.FriendshipListSerializer(
+                friends, many=True, context={USER_ID: user_id}
+            )
         )
 
         self.assertEqual(list_serializer.data, [])

--- a/backend/pong/users/friends/serializers/tests/test_list_serializers.py
+++ b/backend/pong/users/friends/serializers/tests/test_list_serializers.py
@@ -10,6 +10,7 @@ from accounts.player import models as players_models
 from ... import constants, models
 from .. import list_serializers
 
+ID: Final[str] = accounts_constants.UserFields.ID
 USERNAME: Final[str] = accounts_constants.UserFields.USERNAME
 EMAIL: Final[str] = accounts_constants.UserFields.EMAIL
 PASSWORD: Final[str] = accounts_constants.UserFields.PASSWORD
@@ -82,16 +83,20 @@ class FriendshipListSerializerTests(TestCase):
             [
                 {
                     FRIEND: {
+                        ID: self.user2.id,
                         USERNAME: self.user_data_2[USERNAME],
                         DISPLAY_NAME: self.player_data_2[DISPLAY_NAME],
                         AVATAR: "/media/avatars/sample.png",  # todo: デフォルト画像が変更になったら修正
+                        # todo: is_friend,is_blocked,is_online,win_match,lose_match追加
                     },
                 },
                 {
                     FRIEND: {
+                        ID: self.user3.id,
                         USERNAME: self.user_data_3[USERNAME],
                         DISPLAY_NAME: self.player_data_3[DISPLAY_NAME],
                         AVATAR: "/media/avatars/sample.png",  # todo: デフォルト画像が変更になったら修正
+                        # todo: is_friend,is_blocked,is_online,win_match,lose_match追加
                     },
                 },
             ],

--- a/backend/pong/users/friends/tests/integration/test_create_views.py
+++ b/backend/pong/users/friends/tests/integration/test_create_views.py
@@ -19,6 +19,7 @@ PASSWORD: Final[str] = accounts_constants.UserFields.PASSWORD
 USER: Final[str] = accounts_constants.PlayerFields.USER
 DISPLAY_NAME: Final[str] = accounts_constants.PlayerFields.DISPLAY_NAME
 AVATAR: Final[str] = accounts_constants.PlayerFields.AVATAR
+IS_FRIEND: Final[str] = users_constants.UsersFields.IS_FRIEND
 
 USER_ID: Final[str] = constants.FriendshipFields.USER_ID
 FRIEND_USER_ID: Final[str] = constants.FriendshipFields.FRIEND_USER_ID
@@ -106,7 +107,8 @@ class FriendsCreateViewTests(test.APITestCase):
                     USERNAME: self.user_data2[USERNAME],
                     DISPLAY_NAME: self.player_data2[DISPLAY_NAME],
                     AVATAR: "/media/avatars/sample.png",  # todo: デフォルト画像が変更になったら修正
-                    # todo: is_friend,is_blocked,is_online,win_match,lose_match追加
+                    IS_FRIEND: True,
+                    # todo: is_blocked,is_online,win_match,lose_match追加
                 },
             },
         )

--- a/backend/pong/users/friends/tests/integration/test_create_views.py
+++ b/backend/pong/users/friends/tests/integration/test_create_views.py
@@ -100,8 +100,6 @@ class FriendsCreateViewTests(test.APITestCase):
         self.assertEqual(
             response.data[DATA],
             {
-                USER_ID: self.user1.id,
-                FRIEND_USER_ID: self.user2.id,
                 FRIEND: {
                     USERNAME: self.user_data2[USERNAME],
                     DISPLAY_NAME: self.player_data2[DISPLAY_NAME],

--- a/backend/pong/users/friends/tests/integration/test_create_views.py
+++ b/backend/pong/users/friends/tests/integration/test_create_views.py
@@ -12,6 +12,7 @@ from users import constants as users_constants
 
 from ... import constants, models
 
+ID: Final[str] = accounts_constants.UserFields.ID
 USERNAME: Final[str] = accounts_constants.UserFields.USERNAME
 EMAIL: Final[str] = accounts_constants.UserFields.EMAIL
 PASSWORD: Final[str] = accounts_constants.UserFields.PASSWORD
@@ -101,9 +102,11 @@ class FriendsCreateViewTests(test.APITestCase):
             response.data[DATA],
             {
                 FRIEND: {
+                    ID: self.user2.id,
                     USERNAME: self.user_data2[USERNAME],
                     DISPLAY_NAME: self.player_data2[DISPLAY_NAME],
                     AVATAR: "/media/avatars/sample.png",  # todo: デフォルト画像が変更になったら修正
+                    # todo: is_friend,is_blocked,is_online,win_match,lose_match追加
                 },
             },
         )

--- a/backend/pong/users/friends/tests/integration/test_list_views.py
+++ b/backend/pong/users/friends/tests/integration/test_list_views.py
@@ -8,6 +8,7 @@ from rest_framework import status, test
 from accounts import constants as accounts_constants
 from accounts.player import models as players_models
 from pong.custom_response import custom_response
+from users import constants as users_constants
 
 from ... import constants, models
 
@@ -18,6 +19,7 @@ PASSWORD: Final[str] = accounts_constants.UserFields.PASSWORD
 USER: Final[str] = accounts_constants.PlayerFields.USER
 DISPLAY_NAME: Final[str] = accounts_constants.PlayerFields.DISPLAY_NAME
 AVATAR: Final[str] = accounts_constants.PlayerFields.AVATAR
+IS_FRIEND: Final[str] = users_constants.UsersFields.IS_FRIEND
 
 FRIEND: Final[str] = constants.FriendshipFields.FRIEND
 
@@ -135,7 +137,8 @@ class FriendsListViewTests(test.APITestCase):
                         USERNAME: self.user_data2[USERNAME],
                         DISPLAY_NAME: self.player_data2[DISPLAY_NAME],
                         AVATAR: "/media/avatars/sample.png",  # todo: デフォルト画像が変更になったら修正
-                        # todo: is_friend,is_blocked,is_online,win_match,lose_match追加
+                        IS_FRIEND: True,
+                        # todo: is_blocked,is_online,win_match,lose_match追加
                     },
                 },
                 {
@@ -144,7 +147,8 @@ class FriendsListViewTests(test.APITestCase):
                         USERNAME: self.user_data3[USERNAME],
                         DISPLAY_NAME: self.player_data3[DISPLAY_NAME],
                         AVATAR: "/media/avatars/sample.png",  # todo: デフォルト画像が変更になったら修正
-                        # todo: is_friend,is_blocked,is_online,win_match,lose_match追加
+                        IS_FRIEND: True,
+                        # todo: is_blocked,is_online,win_match,lose_match追加
                     },
                 },
             ],
@@ -169,7 +173,8 @@ class FriendsListViewTests(test.APITestCase):
                         USERNAME: self.user_data3[USERNAME],
                         DISPLAY_NAME: self.player_data3[DISPLAY_NAME],
                         AVATAR: "/media/avatars/sample.png",  # todo: デフォルト画像が変更になったら修正
-                        # todo: is_friend,is_blocked,is_online,win_match,lose_match追加
+                        IS_FRIEND: True,
+                        # todo: is_blocked,is_online,win_match,lose_match追加
                     },
                 },
             ],

--- a/backend/pong/users/friends/tests/integration/test_list_views.py
+++ b/backend/pong/users/friends/tests/integration/test_list_views.py
@@ -11,6 +11,7 @@ from pong.custom_response import custom_response
 
 from ... import constants, models
 
+ID: Final[str] = accounts_constants.UserFields.ID
 USERNAME: Final[str] = accounts_constants.UserFields.USERNAME
 EMAIL: Final[str] = accounts_constants.UserFields.EMAIL
 PASSWORD: Final[str] = accounts_constants.UserFields.PASSWORD
@@ -130,16 +131,20 @@ class FriendsListViewTests(test.APITestCase):
             [
                 {
                     FRIEND: {
+                        ID: self.user2.id,
                         USERNAME: self.user_data2[USERNAME],
                         DISPLAY_NAME: self.player_data2[DISPLAY_NAME],
                         AVATAR: "/media/avatars/sample.png",  # todo: デフォルト画像が変更になったら修正
+                        # todo: is_friend,is_blocked,is_online,win_match,lose_match追加
                     },
                 },
                 {
                     FRIEND: {
+                        ID: self.user3.id,
                         USERNAME: self.user_data3[USERNAME],
                         DISPLAY_NAME: self.player_data3[DISPLAY_NAME],
                         AVATAR: "/media/avatars/sample.png",  # todo: デフォルト画像が変更になったら修正
+                        # todo: is_friend,is_blocked,is_online,win_match,lose_match追加
                     },
                 },
             ],
@@ -160,9 +165,11 @@ class FriendsListViewTests(test.APITestCase):
             [
                 {
                     FRIEND: {
+                        ID: self.user3.id,
                         USERNAME: self.user_data3[USERNAME],
                         DISPLAY_NAME: self.player_data3[DISPLAY_NAME],
                         AVATAR: "/media/avatars/sample.png",  # todo: デフォルト画像が変更になったら修正
+                        # todo: is_friend,is_blocked,is_online,win_match,lose_match追加
                     },
                 },
             ],

--- a/backend/pong/users/friends/tests/integration/test_list_views.py
+++ b/backend/pong/users/friends/tests/integration/test_list_views.py
@@ -18,8 +18,6 @@ USER: Final[str] = accounts_constants.PlayerFields.USER
 DISPLAY_NAME: Final[str] = accounts_constants.PlayerFields.DISPLAY_NAME
 AVATAR: Final[str] = accounts_constants.PlayerFields.AVATAR
 
-USER_ID: Final[str] = constants.FriendshipFields.USER_ID
-FRIEND_USER_ID: Final[str] = constants.FriendshipFields.FRIEND_USER_ID
 FRIEND: Final[str] = constants.FriendshipFields.FRIEND
 
 DATA: Final[str] = custom_response.DATA
@@ -131,8 +129,6 @@ class FriendsListViewTests(test.APITestCase):
             response.data[DATA],
             [
                 {
-                    USER_ID: self.user1.id,
-                    FRIEND_USER_ID: self.user2.id,
                     FRIEND: {
                         USERNAME: self.user_data2[USERNAME],
                         DISPLAY_NAME: self.player_data2[DISPLAY_NAME],
@@ -140,8 +136,6 @@ class FriendsListViewTests(test.APITestCase):
                     },
                 },
                 {
-                    USER_ID: self.user1.id,
-                    FRIEND_USER_ID: self.user3.id,
                     FRIEND: {
                         USERNAME: self.user_data3[USERNAME],
                         DISPLAY_NAME: self.player_data3[DISPLAY_NAME],
@@ -165,8 +159,6 @@ class FriendsListViewTests(test.APITestCase):
             response.data[DATA],
             [
                 {
-                    USER_ID: self.user1.id,
-                    FRIEND_USER_ID: self.user3.id,
                     FRIEND: {
                         USERNAME: self.user_data3[USERNAME],
                         DISPLAY_NAME: self.player_data3[DISPLAY_NAME],

--- a/backend/pong/users/friends/views.py
+++ b/backend/pong/users/friends/views.py
@@ -81,7 +81,31 @@ logger = logging.getLogger(__name__)
             ],
         ),
         responses={
-            201: create_serializers.FriendshipCreateSerializer,
+            201: utils.OpenApiResponse(
+                description="Successfully added a new user to the authenticated user's friends list.",
+                response=list_serializers.FriendshipListSerializer(many=True),
+                examples=[
+                    utils.OpenApiExample(
+                        "Example 201 response",
+                        value={
+                            custom_response.STATUS: custom_response.Status.OK,
+                            custom_response.DATA: [
+                                {
+                                    constants.FriendshipFields.FRIEND: {
+                                        accounts_constants.UserFields.ID: 2,
+                                        accounts_constants.UserFields.USERNAME: "username2",
+                                        accounts_constants.PlayerFields.DISPLAY_NAME: "display_name2",
+                                        accounts_constants.PlayerFields.AVATAR: "/media/avatars/sample.png",
+                                        users_constants.UsersFields.IS_FRIEND: True,
+                                        # todo: is_blocked,is_online,win_match,lose_match追加
+                                    },
+                                },
+                                {"...", "..."},
+                            ],
+                        },
+                    ),
+                ],
+            ),
             400: utils.OpenApiResponse(
                 description="Invalid friend_user_id",
                 response={

--- a/backend/pong/users/friends/views.py
+++ b/backend/pong/users/friends/views.py
@@ -373,11 +373,11 @@ class FriendsViewSet(viewsets.ModelViewSet):
         self, user_id: int, friend_id: int
     ) -> destroy_serializers.FriendshipDestroySerializer:
         friendship_data: dict = {
-            constants.FriendshipFields.USER_ID: user_id,
-            constants.FriendshipFields.FRIEND_USER_ID: friend_id,
+            constants.FriendshipFields.FRIEND_USER_ID: friend_id
         }
         return destroy_serializers.FriendshipDestroySerializer(
-            data=friendship_data
+            data=friendship_data,
+            context={constants.FriendshipFields.USER_ID: user_id},
         )
 
     def _handle_destroy_validation_error(

--- a/backend/pong/users/friends/views.py
+++ b/backend/pong/users/friends/views.py
@@ -263,8 +263,7 @@ class FriendsViewSet(viewsets.ModelViewSet):
         self, user_id: int, friend_user_id: Optional[int]
     ) -> create_serializers.FriendshipCreateSerializer:
         friendship_data: dict = {
-            constants.FriendshipFields.USER_ID: user_id,
-            constants.FriendshipFields.FRIEND_USER_ID: friend_user_id,
+            constants.FriendshipFields.FRIEND_USER_ID: friend_user_id
         }
         return create_serializers.FriendshipCreateSerializer(
             data=friendship_data,

--- a/backend/pong/users/friends/views.py
+++ b/backend/pong/users/friends/views.py
@@ -35,9 +35,11 @@ logger = logging.getLogger(__name__)
                             custom_response.DATA: [
                                 {
                                     constants.FriendshipFields.FRIEND: {
+                                        accounts_constants.UserFields.ID: 2,
                                         accounts_constants.UserFields.USERNAME: "username2",
                                         accounts_constants.PlayerFields.DISPLAY_NAME: "display_name2",
                                         accounts_constants.PlayerFields.AVATAR: "/media/avatars/sample.png",
+                                        # todo: is_friend,is_blocked,is_online,win_match,lose_match追加
                                     },
                                 },
                                 {"...", "..."},

--- a/backend/pong/users/friends/views.py
+++ b/backend/pong/users/friends/views.py
@@ -267,7 +267,8 @@ class FriendsViewSet(viewsets.ModelViewSet):
             constants.FriendshipFields.FRIEND_USER_ID: friend_user_id,
         }
         return create_serializers.FriendshipCreateSerializer(
-            data=friendship_data
+            data=friendship_data,
+            context={constants.FriendshipFields.USER_ID: user_id},
         )
 
     def _handle_create_validation_error(

--- a/backend/pong/users/friends/views.py
+++ b/backend/pong/users/friends/views.py
@@ -34,8 +34,6 @@ logger = logging.getLogger(__name__)
                             custom_response.STATUS: custom_response.Status.OK,
                             custom_response.DATA: [
                                 {
-                                    constants.FriendshipFields.USER_ID: 1,
-                                    constants.FriendshipFields.FRIEND_USER_ID: 2,
                                     constants.FriendshipFields.FRIEND: {
                                         accounts_constants.UserFields.USERNAME: "username2",
                                         accounts_constants.PlayerFields.DISPLAY_NAME: "display_name2",

--- a/backend/pong/users/friends/views.py
+++ b/backend/pong/users/friends/views.py
@@ -39,7 +39,8 @@ logger = logging.getLogger(__name__)
                                         accounts_constants.UserFields.USERNAME: "username2",
                                         accounts_constants.PlayerFields.DISPLAY_NAME: "display_name2",
                                         accounts_constants.PlayerFields.AVATAR: "/media/avatars/sample.png",
-                                        # todo: is_friend,is_blocked,is_online,win_match,lose_match追加
+                                        users_constants.UsersFields.IS_FRIEND: True,
+                                        # todo: is_blocked,is_online,win_match,lose_match追加
                                     },
                                 },
                                 {"...", "..."},
@@ -234,7 +235,11 @@ class FriendsViewSet(viewsets.ModelViewSet):
         # 自分のフレンド一覧を取得
         friends: QuerySet[models.Friendship] = self.queryset.filter(user=user)
         list_serializer: list_serializers.FriendshipListSerializer = (
-            list_serializers.FriendshipListSerializer(friends, many=True)
+            list_serializers.FriendshipListSerializer(
+                friends,
+                many=True,
+                context={constants.FriendshipFields.USER_ID: user.id},
+            )
         )
         # todo: logger.info追加
         return custom_response.CustomResponse(

--- a/backend/pong/users/serializers.py
+++ b/backend/pong/users/serializers.py
@@ -12,6 +12,10 @@ class UsersSerializer(serializers.Serializer):
     """
     users app全体で共通のシリアライザ
     Playerとそれに紐づくUserから、返しても良い情報のみをまとめてシリアライズする
+
+    Usage:
+        - __init__時にkwargsにfieldsを渡すことで、返す情報を動的に変更可能
+        - is_friendを使用する際は、get_is_friend()で使用するためcontextにUSER_IDを渡す必要がある
     """
 
     id = serializers.IntegerField(source="user.id")


### PR DESCRIPTION
## タスクやディスカッションのリンク
<!-- - URLをここに貼る -->
- #318 

## やったこと
<!-- - このタスクでやったことはなにか？ -->
- `friends` app 内でレスポンスを返す以下の 2 つのエンドポイントについて、レスポンスの内容をユーザー一覧取得などと統一しました。`destroy view` はレスポンスを返さないが、他の serializer と形式を統一するのだけしました
  - `list view` : `/api/users/me/friends/`, `GET`
  - `create view` : `/api/users/me/friends/`, `POST`


具体的にはレスポンスの `data` の中身を以下のように変更しました
- `user_id`, `friend_user_id` は削除
- `friend` 内をユーザー取得のエンドポイントと統一するため、`id` と `is_friend`(必ず True) を追加
```
{
  user_id:
  friend_user_id:
    friend: {
      username:
      display_name:
      avatar:
    }
}
```
　↓ 以下に変更
```
{
  friend: {
    id:
    username:
    display_name:
    avatar:
    is_friend: True,
    # is_blocked なども順次追加
  }
}
```

## やらないこと
<!-- - このタスクでやらないことはなにか？（やらない場合いつやるのか？無ければ「なし」を記述） -->
- `is_blocked`, `is_online` などは実装でき次第追加します

## 動作確認
<!-- - どのような動作確認を行い、結果はどうだったのか？(適宜スクショ等添付) -->
- テスト確認と、
```sh
make exec-be
make test ARG=users.friends
```
- swagger-ui にて friend の 2 つのエンドポイントの extend_schema と実際のレスポンスを比較し、以下を確認
  - `user_id`, `friend_user_id` が返ってきていないこと
  - `friend` の中に `id`, `is_friend` が追加されていること
  - フレンド一覧取得と、フレンド追加なので、`is_friend` は必ず True になっていること

## 特にレビューをお願いしたい箇所
<!-- - 特にチェックをお願いしたいポイントを簡潔に記述する -->
- レスポンス形式の確認と `is_friend` の挙動確認

## その他
<!-- - 実装上の懸念点、注意点等あれば記載する -->
特になし

## 参考リンク
<!-- - 実装に際し参考にした、記事やサイトのリンクを記載する -->
特になし

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **新機能**
  - 友達作成および友達一覧のAPIレスポンスに、友達状態を示すフラグが追加され、ユーザーに現在の友達関係が明確に伝わるようになりました。
  - 友達削除機能が追加され、ユーザーは友達関係を簡単に削除できるようになりました。

- **リファクタリング**
  - 内部で使用されていたユーザー識別情報が非表示となり、レスポンスがシンプルかつ直感的な構造へ変更されました。必要な友達情報（ID、ユーザー名、表示名、アバターなど）が提供されます。

- **ドキュメント**
  - 友達追加成功時のレスポンス例と説明が強化され、APIの利用性が向上しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->