### PR TITLE
⚡ [accounts] email の validator のテスト追加

### DIFF
--- a/backend/pong/accounts/user/serializers.py
+++ b/backend/pong/accounts/user/serializers.py
@@ -11,10 +11,14 @@ class UserSerializer(serializers.ModelSerializer):
     """
 
     # EmailField: デフォルトがrequired=True, allow_blank=False
-    # todo: max_length、min_lengthの設定
+    # EmailValidator: EmailFieldがデフォルトで使用しているバリデーター
+    #   - emailの形式チェック
+    #   - max_length=320
     email = serializers.EmailField(
-        # UniqueValidator: emailをユニークにする
-        validators=[validators.UniqueValidator(queryset=User.objects.all())],
+        validators=[
+            # emailをユニークにする
+            validators.UniqueValidator(queryset=User.objects.all()),
+        ]
     )
 
     class Meta:


### PR DESCRIPTION
## タスクやディスカッションのリンク
<!-- - URLをここに貼る -->
- #306 
- accounts の流れ : #110 

## やったこと
<!-- - このタスクでやったことはなにか？ -->
email の validator に関するテストを追加しました
email 用の validator を使用するか自作するかする必要があると思っていたのですが、Django の `EmailField` を使用しているだけでデフォルトで `EmailValidator` が適用されていたので、その確認のテストのみの追加です

## やらないこと
<!-- - このタスクでやらないことはなにか？（やらない場合いつやるのか？無ければ「なし」を記述） -->
上記以外

## 動作確認
<!-- - どのような動作確認を行い、結果はどうだったのか？(適宜スクショ等添付) -->
- テスト確認
```sh
make exec-ve
make test ARG=accounts
```
- swagger-ui にて email 形式が間違っている新規アカウント登録をしようとすると `400` で `errors` に `email` が含まれていることを確認 ( accounts はまだ `code` を返せていないので `code` は空です )

## 特にレビューをお願いしたい箇所
<!-- - 特にチェックをお願いしたいポイントを簡潔に記述する -->
テストが十分かどうか

## その他
<!-- - 実装上の懸念点、注意点等あれば記載する -->
特になし

## 参考リンク
<!-- - 実装に際し参考にした、記事やサイトのリンクを記載する -->
- Django, EmailField : https://docs.djangoproject.com/ja/5.1/ref/models/fields/#emailfield
- Django, EmailValidator : https://docs.djangoproject.com/ja/5.1/ref/validators/#emailvalidator

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

このリリースでは、無効なメールアドレスに対するエラーハンドリングの信頼性向上と、メール検証に関する内部説明の明確化を実施しました。これにより、エラーメッセージの精度が改善され、全体のシステムの堅牢性が向上しています。

- **Tests**
  - 複数の無効なメールアドレス入力ケースを1つのテストで網羅し、エラーチェックの精度を向上しました。
- **Documentation**
  - メール検証の説明文をより分かりやすく改善しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->