### PR TITLE
⚡ [accounts] password の validator を追加

### DIFF
--- a/backend/pong/accounts/tests/test_accounts.py
+++ b/backend/pong/accounts/tests/test_accounts.py
@@ -138,6 +138,14 @@ class AccountsTests(test.APITestCase):
             ("よく使われてるパスワードの場合2", "pass1234"),
             ("よく使われてるパスワードの場合3", "computer"),
             # ("usernameとの類似度が高い場合", "testuser"), # todo: なぜかエラーにならない
+            (
+                "使用可能文字列以外が含まれる場合(英数字以外)",
+                "あいうえおかきく",
+            ),
+            (
+                "使用可能文字列以外が含まれる場合(記号の-_以外)",
+                "invalid@password!",
+            ),
         ]
     )
     def test_create_account_with_invalid_password(

--- a/backend/pong/accounts/tests/test_accounts.py
+++ b/backend/pong/accounts/tests/test_accounts.py
@@ -127,3 +127,42 @@ class AccountsTests(test.APITestCase):
         # DBにUser,Playerが作成されていないことを確認
         self.assertEqual(models.User.objects.count(), 0)
         self.assertEqual(models.Player.objects.count(), 0)
+
+    @parameterized.parameterized.expand(
+        [
+            ("空文字列の場合", ""),
+            ("7文字以下の場合", "mb7asb2"),
+            ("51文字以上の場合", "a" * 51),
+            ("数字のみの場合", "97251037"),
+            ("よく使われてるパスワードの場合1", "password"),
+            ("よく使われてるパスワードの場合2", "pass1234"),
+            ("よく使われてるパスワードの場合3", "computer"),
+            # ("usernameとの類似度が高い場合", "testuser"), # todo: なぜかエラーにならない
+        ]
+    )
+    def test_create_account_with_invalid_password(
+        self, testcase_name: str, invalid_password: str
+    ) -> None:
+        """
+        不正なpasswordの形式でアカウントを作成するテスト
+        status 400 が返されることを確認
+        errorsにpasswordが含まれることを確認
+        """
+        account_data: dict = {
+            USER: {
+                EMAIL: "valid@example.com",
+                PASSWORD: invalid_password,  # 不正なpassword形式
+            }
+        }
+        response: drf_response.Response = self.client.post(
+            self.url, account_data, format="json"
+        )
+        response_error: dict = response.data[ERRORS]
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn(PASSWORD, response_error)
+        # todo: codeを返すようになったらresponse.data[CODE]も確認
+
+        # DBにUser,Playerが作成されていないことを確認
+        self.assertEqual(models.User.objects.count(), 0)
+        self.assertEqual(models.Player.objects.count(), 0)

--- a/backend/pong/accounts/user/serializers.py
+++ b/backend/pong/accounts/user/serializers.py
@@ -1,4 +1,5 @@
 from django.contrib.auth.models import User
+from django.contrib.auth.password_validation import validate_password
 from rest_framework import serializers, validators
 
 from .. import constants
@@ -20,6 +21,13 @@ class UserSerializer(serializers.ModelSerializer):
             validators.UniqueValidator(queryset=User.objects.all()),
         ]
     )
+    # validate_password: 4つのvalidatorでチェックされる
+    # https://docs.djangoproject.com/ja/5.1/topics/auth/passwords/#included-validators
+    password = serializers.CharField(
+        write_only=True,
+        max_length=50,
+        validators=[validate_password],
+    )
 
     class Meta:
         model = User
@@ -29,9 +37,6 @@ class UserSerializer(serializers.ModelSerializer):
             constants.UserFields.EMAIL,
             constants.UserFields.PASSWORD,
         )
-        extra_kwargs = {
-            constants.UserFields.PASSWORD: {"write_only": True},
-        }
 
     # PlayerSerializerのuser_serializer.save()の内部で呼ばれる
     def create(self, validated_data: dict) -> User:

--- a/backend/pong/accounts/user/serializers.py
+++ b/backend/pong/accounts/user/serializers.py
@@ -1,5 +1,6 @@
 from django.contrib.auth.models import User
 from django.contrib.auth.password_validation import validate_password
+from django.core.validators import RegexValidator
 from rest_framework import serializers, validators
 
 from .. import constants
@@ -26,7 +27,14 @@ class UserSerializer(serializers.ModelSerializer):
     password = serializers.CharField(
         write_only=True,
         max_length=50,
-        validators=[validate_password],
+        validators=[
+            validate_password,
+            # 使用可能文字列を指定: 英子文字・英大文字・数字・記号(-_)
+            RegexValidator(
+                regex=r"^[a-zA-Z0-9-_]+$",
+                message="Must contain only alphanumeric characters or some symbols(-_)",
+            ),
+        ],
     )
 
     class Meta:

--- a/backend/pong/accounts/user/tests/test_user_serializer.py
+++ b/backend/pong/accounts/user/tests/test_user_serializer.py
@@ -214,3 +214,29 @@ class UserSerializerTests(TestCase):
 
         self.assertFalse(serializer_2.is_valid())
         self.assertIn(EMAIL, serializer_2.errors)
+
+    @parameterized.parameterized.expand(
+        [
+            # 空文字列はtest_error_empty_password()で確認済み
+            ("7文字以下の場合", "mb7asb2"),
+            ("51文字以上の場合", "a" * 51),
+            ("数字のみの場合", "97251037"),
+            ("よく使われてるパスワードの場合1", "password"),
+            ("よく使われてるパスワードの場合2", "pass1234"),
+            ("よく使われてるパスワードの場合3", "computer"),
+            # ("usernameとの類似度が高い場合", "testuser"), # todo: なぜかエラーにならない
+        ]
+    )
+    def test_error_invalid_password(
+        self, testcase_name: str, invalid_password: str
+    ) -> None:
+        """
+        パスワードが不正な場合にエラーになることを確認する
+        """
+        self.user_data[PASSWORD] = invalid_password
+        serializer: serializers.UserSerializer = serializers.UserSerializer(
+            data=self.user_data
+        )
+
+        self.assertFalse(serializer.is_valid())
+        self.assertIn(PASSWORD, serializer.errors)

--- a/backend/pong/accounts/user/tests/test_user_serializer.py
+++ b/backend/pong/accounts/user/tests/test_user_serializer.py
@@ -225,6 +225,14 @@ class UserSerializerTests(TestCase):
             ("よく使われてるパスワードの場合2", "pass1234"),
             ("よく使われてるパスワードの場合3", "computer"),
             # ("usernameとの類似度が高い場合", "testuser"), # todo: なぜかエラーにならない
+            (
+                "使用可能文字列以外が含まれる場合(英数字以外)",
+                "あいうえおかきく",
+            ),
+            (
+                "使用可能文字列以外が含まれる場合(記号の-_以外)",
+                "invalid@password!",
+            ),
         ]
     )
     def test_error_invalid_password(

--- a/backend/pong/accounts/user/tests/test_user_serializer.py
+++ b/backend/pong/accounts/user/tests/test_user_serializer.py
@@ -59,6 +59,38 @@ class UserSerializerTests(TestCase):
         # hash化されているので元のパスワードとは異なる
         self.assertNotEqual(user.password, self.user_data[PASSWORD])
 
+    @parameterized.parameterized.expand(
+        [
+            ("8文字の場合", "-g3wicPg"),
+            ("50文字の場合", "z" * 50),
+            ("英子文字のみ", "abcdefghijklmnopqrstuvwxyz"),
+            ("英大文字のみ", "ABCDEFGHIJKLMNOPQRSTUVWXYZ"),
+            ("記号(-_)のみ", "-_-_-_-_"),
+            ("有名なパスワード以外", "uncommon"),
+            ("数字以外が含まれる1", "12x34567"),
+        ]
+    )
+    def test_create_user_with_valid_password(
+        self, testcase_name: str, valid_password: str
+    ) -> None:
+        """
+        正常なパスワードでUserを作成できることを確認する
+          - 8文字以上・50文字以下
+          - 英子文字・英大文字・数字・記号(-_)のみ
+          - 有名なパスワード以外
+          - 数字以外が含まれる
+        """
+        user_data: dict = {
+            USERNAME: "testuser2",
+            EMAIL: "testuser2@example.com",
+            PASSWORD: valid_password,
+        }
+        serializer: serializers.UserSerializer = serializers.UserSerializer(
+            data=user_data
+        )
+
+        self.assertTrue(serializer.is_valid())
+
     # -------------------------------------------------------------------------
     # エラーケース
     # -------------------------------------------------------------------------


### PR DESCRIPTION
## タスクやディスカッションのリンク
<!-- - URLをここに貼る -->
- #307 
- accounts の流れ : #110 

## やったこと
<!-- - このタスクでやったことはなにか？ -->
- ユーザー新規作成時の password の validator を追加しました
  [Notion の password の仕様](https://www.notion.so/Account-Login-cbac270cdf0848408dd81377fb2d761c?pvs=4#fc4c842b6f93421084a3bd5c847d9895) に記載の以下以外をエラーにするバリデーションです
  - 8 文字以上
  - 50 文字以下
  - 使用可能文字列：英小文字・英大文字・数字・記号 (`-`, `_`)
  - 全て数字、ではない
  - 有名なパスワードではない
  - usename との類似度が低い -> やらないことに記載


## やらないこと
<!-- - このタスクでやらないことはなにか？（やらない場合いつやるのか？無ければ「なし」を記述） -->
- username との類似度が高い場合も `validate_password` が自動でエラーにしてくれるはずなのですが、password を username と全く一緒にしてもエラーにしてくれず、原因がすぐには分からなかったため、一旦放置しています
優先度低めなので、余裕がなければこのままな気がします…
- レスポンスに `code` を含めるのは別 PR でします

## 動作確認
<!-- - どのような動作確認を行い、結果はどうだったのか？(適宜スクショ等添付) -->
- テスト確認と、
```sh
make exec-be
make test ARG=accounts
```
- swagger-ui にて実際に `/api/accounts`, `POST` にパスワードを色々変えて新規アカウント登録をしてみる
  - ルールに合っていないパスワードの場合は 400 が返り、user が作成されていないことを確認

## 特にレビューをお願いしたい箇所
<!-- - 特にチェックをお願いしたいポイントを簡潔に記述する -->
テストケースで追加した方が良いものがあれば知りたいです

## その他
<!-- - 実装上の懸念点、注意点等あれば記載する -->
特になし

## 参考リンク
<!-- - 実装に際し参考にした、記事やサイトのリンクを記載する -->
Notion, password ルール : https://www.notion.so/Account-Login-cbac270cdf0848408dd81377fb2d761c#fc4c842b6f93421084a3bd5c847d9895

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新機能**
  - アカウント作成時のパスワードセキュリティと入力検証が強化され、無効なメールアドレスやパスワードでの登録を防ぐよう改善しました。

- **テスト**
  - 無効なパスワードに対する新しいテストケースを追加し、適切なエラーメッセージが返されることを検証しています。
  - 有効なパスワードに対する検証も強化され、条件を満たすパスワードが正しく認識されることを確認しています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->