### PR TITLE
Feature frontend global user session

### DIFF
--- a/frontend/pong/js/bootstrap/utilities/spacing.js
+++ b/frontend/pong/js/bootstrap/utilities/spacing.js
@@ -8,6 +8,10 @@ const setMargin = (element, size = 2) => {
   return setClassNames(element, `m-${size}`);
 };
 
+const setMarginLeft = (element, size = 2) => {
+  return setClassNames(element, `ms-${size}`);
+};
+
 const setGap = (element, size = 3) => {
   return setClassNames(element, `gap-${size}`);
 };
@@ -15,5 +19,6 @@ const setGap = (element, size = 3) => {
 export const BootstrapSpacing = {
   setPadding,
   setMargin,
+  setMarginLeft,
   setGap,
 };

--- a/frontend/pong/js/bootstrap/utilities/spacing.js
+++ b/frontend/pong/js/bootstrap/utilities/spacing.js
@@ -1,15 +1,15 @@
 import { setClassNames } from "../../utils/elements/setClassNames";
 
-const setPadding = (element) => {
-  return setClassNames(element, "p-2");
+const setPadding = (element, size = 2) => {
+  return setClassNames(element, `p-${size}`);
 };
 
-const setMargin = (element) => {
-  return setClassNames(element, "m-2");
+const setMargin = (element, size = 2) => {
+  return setClassNames(element, `m-${size}`);
 };
 
-const setGap = (element) => {
-  return setClassNames(element, "gap-3");
+const setGap = (element, size = 3) => {
+  return setClassNames(element, `gap-${size}`);
 };
 
 export const BootstrapSpacing = {

--- a/frontend/pong/js/components/auth/SignInButton.js
+++ b/frontend/pong/js/components/auth/SignInButton.js
@@ -1,0 +1,33 @@
+import { StyledButton } from "../../core/StyledButton";
+import { getUserSession } from "../../session";
+
+export class SignInButton extends StyledButton {
+  constructor(state = {}, attributes = {}) {
+    super(
+      { textContent: "サインイン", ...state },
+      { type: "button", ...attributes },
+    );
+  }
+
+  _setStyle() {
+    this.setOutlinePrimary();
+    this.setSmall();
+  }
+
+  _onConnect() {
+    this._attachEventListener("click", (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+
+      // TODO: DELETE: 一時的な対処なので確認が必要
+      const mockUser = {
+        id: 1,
+        username: "user",
+        email: "username1@example.com",
+        displayName: "mock",
+        avatar: "https://placehold.co/30",
+      };
+      getUserSession().signIn(mockUser, {});
+    });
+  }
+}

--- a/frontend/pong/js/components/auth/SignOutButton.js
+++ b/frontend/pong/js/components/auth/SignOutButton.js
@@ -1,0 +1,24 @@
+import { StyledButton } from "../../core/StyledButton";
+import { getUserSession } from "../../session";
+
+export class SignOutButton extends StyledButton {
+  constructor(state = {}, attributes = {}) {
+    super(
+      { textContent: "サインアウト", ...state },
+      { type: "button", ...attributes },
+    );
+  }
+
+  _setStyle() {
+    this.setOutlineSecondary();
+    this.setSmall();
+  }
+
+  _onConnect() {
+    this._attachEventListener("click", (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      getUserSession().signOut();
+    });
+  }
+}

--- a/frontend/pong/js/components/index.js
+++ b/frontend/pong/js/components/index.js
@@ -1,4 +1,6 @@
 import { LoginContainer } from "./auth/LoginContainer";
+import { SignInButton } from "./auth/SignInButton";
+import { SignOutButton } from "./auth/SignOutButton";
 import { ChatBuddyListContainer } from "./chat/ChatBuddyListContainer";
 import { ChatDmContainer } from "./chat/ChatDmContainer";
 import { ChatGlobal } from "./chat/ChatGlobal";
@@ -20,6 +22,7 @@ import { UserListContainer } from "./user/UserListContainer";
 import { UserListItem } from "./user/UserListItem";
 import { UserProfile } from "./user/UserProfile";
 import { UserProfileContainer } from "./user/UserProfileContainer";
+import { UserProfileHeader } from "./user/UserProfileHeader";
 import { ErrorContainer } from "./utils/ErrorContainer";
 import { EventDispatchingButton } from "./utils/EventDispatchingButton";
 import { LinkButton } from "./utils/LinkButton";
@@ -35,6 +38,8 @@ import { TournamentsView } from "./views/TournamentsView";
 import { UsersView } from "./views/UsersView";
 
 customElements.define("login-container", LoginContainer, {});
+customElements.define("sign-in-button", SignInButton, {});
+customElements.define("sign-out-button", SignOutButton, {});
 customElements.define(
   "chat-buddy-list-container",
   ChatBuddyListContainer,
@@ -80,6 +85,7 @@ customElements.define(
   UserProfileContainer,
   {},
 );
+customElements.define("user-profile-header", UserProfileHeader, {});
 customElements.define("error-container", ErrorContainer, {});
 customElements.define(
   "event-dispatching-button",

--- a/frontend/pong/js/components/user/UserProfileHeader.js
+++ b/frontend/pong/js/components/user/UserProfileHeader.js
@@ -1,0 +1,51 @@
+import { BootstrapDisplay } from "../../bootstrap/utilities/display";
+import { BootstrapSpacing } from "../../bootstrap/utilities/spacing";
+import { Component } from "../../core/Component";
+import { getUserSession } from "../../session";
+import { createNameplate } from "../../utils/elements/div/createNameplate";
+import { SignInButton } from "../auth/SignInButton";
+import { SignOutButton } from "../auth/SignOutButton";
+
+export class UserProfileHeader extends Component {
+  #userDataObserver;
+
+  constructor(state = {}) {
+    super(state);
+    this.#userDataObserver = (myInfoData) => {
+      const { isSignedIn, id, username, displayName, avatar } =
+        myInfoData;
+
+      const user = isSignedIn
+        ? { id, username, displayName, avatar }
+        : null;
+
+      this._updateState({ user });
+    };
+  }
+
+  _setStyle() {
+    BootstrapDisplay.setFlex(this);
+  }
+
+  _onConnect() {
+    getUserSession().myInfoManager.attach(this.#userDataObserver);
+  }
+
+  _onDisconnect() {
+    getUserSession().myInfoManager.detach(this.#userDataObserver);
+  }
+
+  _render() {
+    const { user } = this._getState();
+    if (!user) {
+      this.append(new SignInButton());
+      return;
+    }
+
+    const nameplate = createNameplate(user, "4vh");
+    const signOutButton = new SignOutButton();
+    BootstrapSpacing.setMarginLeft(signOutButton, 3);
+
+    this.append(nameplate, signOutButton);
+  }
+}

--- a/frontend/pong/js/main.js
+++ b/frontend/pong/js/main.js
@@ -2,9 +2,12 @@ import "./components";
 import { ChatGlobal } from "./components/chat/ChatGlobal";
 import { PongEvents } from "./constants/PongEvents";
 import { appRouter } from "./routers/appRouter";
+import { initUserSession } from "./session";
 import { initWebSocket } from "./websocket";
 
 function main() {
+  initUserSession();
+
   const appLocal = document.getElementById("app-local");
   const router = appRouter(appLocal);
   const updateWindowPath = () => {

--- a/frontend/pong/js/session/DataManager.js
+++ b/frontend/pong/js/session/DataManager.js
@@ -1,0 +1,43 @@
+export class DataManager {
+  #data;
+  #observers;
+
+  constructor(data = {}) {
+    this.#data = data;
+    this.#observers = new Set();
+  }
+
+  init(data = {}) {
+    this.#data = data;
+    this.#notifyAll();
+  }
+
+  updateData(newData) {
+    if (!newData) return;
+    Object.assign(this.#data, newData);
+    this.#notifyAll();
+  }
+
+  attach(observer) {
+    const isAttachable = (observer) =>
+      observer instanceof Function && !this.#observers.has(observer);
+    if (!isAttachable(observer)) return;
+
+    this.#observers.add(observer);
+  }
+
+  detach(observer) {
+    if (!this.#observers.has(observer)) return;
+    this.#observers.delete(observer);
+  }
+
+  #notify(observer) {
+    observer(this.#data);
+  }
+
+  #notifyAll() {
+    for (const observer of this.#observers) {
+      this.#notify(observer);
+    }
+  }
+}

--- a/frontend/pong/js/session/UserSession.js
+++ b/frontend/pong/js/session/UserSession.js
@@ -1,0 +1,26 @@
+import { DataManager } from "./DataManager";
+
+export class UserSession {
+  #myInfoManager;
+
+  constructor() {
+    this.#myInfoManager = new DataManager();
+    this.init();
+  }
+
+  signIn(userData) {
+    this.#myInfoManager.updateData({ ...userData, isSignedIn: true });
+  }
+
+  signOut() {
+    this.init();
+  }
+
+  init() {
+    this.#myInfoManager.init({ isSignedIn: false });
+  }
+
+  get myInfoManager() {
+    return this.#myInfoManager;
+  }
+}

--- a/frontend/pong/js/session/index.js
+++ b/frontend/pong/js/session/index.js
@@ -1,0 +1,14 @@
+import { UserSession } from "./UserSession";
+
+let globalUserSession = null;
+
+const initUserSession = () => {
+  if (globalUserSession !== null) return;
+  globalUserSession = new UserSession();
+};
+
+const getUserSession = () => {
+  return globalUserSession;
+};
+
+export { initUserSession, getUserSession };

--- a/frontend/pong/js/utils/elements/nav/createDefaultNavbar.js
+++ b/frontend/pong/js/utils/elements/nav/createDefaultNavbar.js
@@ -1,5 +1,6 @@
 import { BootstrapNavbar } from "../../../bootstrap/components/navbar";
 import { BootstrapContainers } from "../../../bootstrap/layout/containers";
+import { UserProfileHeader } from "../../../components/user/UserProfileHeader";
 import { createBrandAnchor } from "../anchor/createBrandAnchor";
 import { createElement } from "../createElement";
 import { createNavbarNavList } from "./createNavbarNavList";
@@ -12,12 +13,13 @@ export const createDefaultNavbar = (links) => {
   BootstrapNavbar.setNavbarBrand(brand);
 
   const navListWrapper = createElement("div");
-  navListWrapper.appendChild(navList);
+  navListWrapper.append(navList);
+
+  const profileHeader = new UserProfileHeader();
 
   const containerFluid = createElement("div");
   BootstrapContainers.setFluid(containerFluid);
-  containerFluid.appendChild(brand);
-  containerFluid.appendChild(navListWrapper);
+  containerFluid.append(brand, navListWrapper, profileHeader);
 
   const navbar = createElement("nav");
   BootstrapNavbar.setNavbarExpand(navbar);


### PR DESCRIPTION
## タスクやディスカッションのリンク
なし

## やったこと
- ユーザー情報管理のクラス作成
- ユーザーのアバター、名前表示を仮の [サインイン]、[サインアウト] とともにホームに表示

## やらないこと
- サインインは仮のものにしています。実際の認証はまだ行っていません。
- チャットやウェブソケットの方もともに管理予定で、今回は含めていません。

## 動作確認
- `cd frontend/pong && npm install && npm run dev`
- 右上の仮のボタン [サインイン] を押してモックユーザーの名前などが表示されることを確認
- 同じ場所に表示される [サインアウト] を押して、元に戻ることを確認

## 特にレビューをお願いしたい箇所
今回はフロントの認証管理をどうするかをチームで決めて、その一歩を作成しています。主に手法的な部分を確認いただければと思います。

## その他
特になし

## 参考リンク
特になし
