### PR TITLE
⚡ [accounts] レスポンスに code を返すように

### DIFF
--- a/backend/pong/accounts/admin.py
+++ b/backend/pong/accounts/admin.py
@@ -38,6 +38,7 @@ class AccountAdmin(ModelAdmin):
     # Playerに紐づくUserの情報をadminサイトで表示する為にはメソッド名をそのまま指定
     # メソッド名はアンダースコアがスペースに変換されてカラム名として扱われる
     list_display: tuple = (
+        constants.PlayerFields.ID,
         "user_id",
         "username",
         constants.PlayerFields.DISPLAY_NAME,

--- a/backend/pong/accounts/constants.py
+++ b/backend/pong/accounts/constants.py
@@ -1,5 +1,7 @@
 import dataclasses
 
+from pong.custom_response import custom_response
+
 
 @dataclasses.dataclass(frozen=True)
 class UserFields:
@@ -23,3 +25,4 @@ class PlayerFields:
 class Code:
     INVALID_EMAIL: str = "invalid_email"
     INVALID_PASSWORD: str = "invalid_password"
+    INTERNAL_ERROR: str = custom_response.Code.INTERNAL_ERROR

--- a/backend/pong/accounts/constants.py
+++ b/backend/pong/accounts/constants.py
@@ -17,3 +17,9 @@ class PlayerFields:
     AVATAR: str = "avatar"
     CREATED_AT: str = "created_at"
     UPDATED_AT: str = "updated_at"
+
+
+@dataclasses.dataclass(frozen=True)
+class Code:
+    INVALID_EMAIL: str = "invalid_email"
+    INVALID_PASSWORD: str = "invalid_password"

--- a/backend/pong/accounts/constants.py
+++ b/backend/pong/accounts/constants.py
@@ -11,6 +11,7 @@ class UserFields:
 
 @dataclasses.dataclass(frozen=True)
 class PlayerFields:
+    ID: str = "id"
     USER: str = "user"
     DISPLAY_NAME: str = "display_name"
     AVATAR: str = "avatar"

--- a/backend/pong/accounts/constants.py
+++ b/backend/pong/accounts/constants.py
@@ -23,6 +23,7 @@ class PlayerFields:
 
 @dataclasses.dataclass(frozen=True)
 class Code:
+    ALREADY_EXISTS: str = "already_exists"
     INVALID_EMAIL: str = "invalid_email"
     INVALID_PASSWORD: str = "invalid_password"
     INTERNAL_ERROR: str = custom_response.Code.INTERNAL_ERROR

--- a/backend/pong/accounts/create_account/create_account.py
+++ b/backend/pong/accounts/create_account/create_account.py
@@ -121,6 +121,9 @@ def create_account(
 
     Returns:
         CreateAccountResult: 作成されたUserのシリアライズ後のデータのResult
+          - ok: User,Playerの作成に成功した場合
+          - error: PlayerSerializerでは実装上のミス以外にValidationErrorは発生しないため、
+                   errorが返る場合は実装上のミスまたはDatabaseErrorとしていい
     """
     # UserSerializerが引数として正しくない場合にassertを発生させる
     _assert_user_serializer(user_serializer)

--- a/backend/pong/accounts/player/serializers.py
+++ b/backend/pong/accounts/player/serializers.py
@@ -43,10 +43,4 @@ class PlayerSerializer(serializers.ModelSerializer):
             constants.PlayerFields.USER,
             constants.PlayerFields.DISPLAY_NAME,
             constants.PlayerFields.AVATAR,
-            constants.PlayerFields.CREATED_AT,
-            constants.PlayerFields.UPDATED_AT,
         )
-        extra_kwargs = {
-            constants.PlayerFields.CREATED_AT: {"read_only": True},
-            constants.PlayerFields.UPDATED_AT: {"read_only": True},
-        }

--- a/backend/pong/accounts/tests/test_accounts.py
+++ b/backend/pong/accounts/tests/test_accounts.py
@@ -15,7 +15,11 @@ EMAIL: Final[str] = constants.UserFields.EMAIL
 PASSWORD: Final[str] = constants.UserFields.PASSWORD
 
 DATA: Final[str] = custom_response.DATA
+CODE: Final[str] = custom_response.CODE
 ERRORS: Final[str] = custom_response.ERRORS
+
+CODE_INVALID_EMAIL: Final[str] = constants.Code.INVALID_EMAIL
+CODE_INVALID_PASSWORD: Final[str] = constants.Code.INVALID_PASSWORD
 
 
 # todo: 認証付きのテスト追加？
@@ -105,6 +109,7 @@ class AccountsTests(test.APITestCase):
             self.url, account_data, format="json"
         )
         response_error: dict = response.data[ERRORS]
+        code: list[str] = response.data[CODE]
 
         # responseの内容を確認
         # response.data == {
@@ -117,7 +122,7 @@ class AccountsTests(test.APITestCase):
         # }
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIn(EMAIL, response_error)
-        # todo: codeを返すようになったらresponse.data[CODE]も確認
+        self.assertIn(CODE_INVALID_EMAIL, code)
 
         # DBにUser,Playerが作成されていないことを確認
         self.assertEqual(models.User.objects.count(), 0)
@@ -159,10 +164,11 @@ class AccountsTests(test.APITestCase):
             self.url, account_data, format="json"
         )
         response_error: dict = response.data[ERRORS]
+        code: list[str] = response.data[CODE]
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIn(PASSWORD, response_error)
-        # todo: codeを返すようになったらresponse.data[CODE]も確認
+        self.assertIn(CODE_INVALID_PASSWORD, code)
 
         # DBにUser,Playerが作成されていないことを確認
         self.assertEqual(models.User.objects.count(), 0)

--- a/backend/pong/accounts/tests/test_accounts.py
+++ b/backend/pong/accounts/tests/test_accounts.py
@@ -13,7 +13,6 @@ from ..player import models
 USERNAME: Final[str] = constants.UserFields.USERNAME
 EMAIL: Final[str] = constants.UserFields.EMAIL
 PASSWORD: Final[str] = constants.UserFields.PASSWORD
-USER: Final[str] = constants.PlayerFields.USER
 
 DATA: Final[str] = custom_response.DATA
 ERRORS: Final[str] = custom_response.ERRORS
@@ -36,11 +35,10 @@ class AccountsTests(test.APITestCase):
         有効なデータでアカウントを作成するテスト
         status 201, username, email が返されることを確認
         """
-        user_data: dict = {
+        account_data: dict = {
             EMAIL: "testuser@example.com",
             PASSWORD: "testpassword12345",
         }
-        account_data: dict = {USER: user_data}
         response: drf_response.Response = self.client.post(
             self.url, account_data, format="json"
         )
@@ -54,7 +52,7 @@ class AccountsTests(test.APITestCase):
 
         # responseの内容を確認
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        self.assertEqual(response_user[EMAIL], user_data[EMAIL])
+        self.assertEqual(response_user[EMAIL], account_data[EMAIL])
         # passwordは返されない
         self.assertNotIn(PASSWORD, response_user)
 
@@ -64,7 +62,7 @@ class AccountsTests(test.APITestCase):
 
         # emailからplayerを取得できる/例外がraiseされないことを確認
         player: models.Player = models.Player.objects.get(
-            user__email=user_data[EMAIL]
+            user__email=account_data[EMAIL]
         )
         # playerから取得したランダム文字列usernameのUserが実際にDBに存在するか確認
         self.assertTrue(
@@ -100,10 +98,8 @@ class AccountsTests(test.APITestCase):
         errorsにemailが含まれることを確認
         """
         account_data: dict = {
-            USER: {
-                EMAIL: invalid_email,  # 不正なemail形式
-                PASSWORD: "testpassword12345",
-            }
+            EMAIL: invalid_email,  # 不正なemail形式
+            PASSWORD: "testpassword12345",
         }
         response: drf_response.Response = self.client.post(
             self.url, account_data, format="json"
@@ -156,10 +152,8 @@ class AccountsTests(test.APITestCase):
         errorsにpasswordが含まれることを確認
         """
         account_data: dict = {
-            USER: {
-                EMAIL: "valid@example.com",
-                PASSWORD: invalid_password,  # 不正なpassword形式
-            }
+            EMAIL: "valid@example.com",
+            PASSWORD: invalid_password,  # 不正なpassword形式
         }
         response: drf_response.Response = self.client.post(
             self.url, account_data, format="json"

--- a/backend/pong/accounts/tests/test_accounts.py
+++ b/backend/pong/accounts/tests/test_accounts.py
@@ -50,7 +50,7 @@ class AccountsTests(test.APITestCase):
         #         "user": {...}
         #     },
         # }
-        response_user: dict = response.data[DATA][USER]
+        response_user: dict = response.data[DATA]
 
         # responseの内容を確認
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)

--- a/backend/pong/accounts/tests/test_accounts.py
+++ b/backend/pong/accounts/tests/test_accounts.py
@@ -22,7 +22,6 @@ CODE_INVALID_EMAIL: Final[str] = constants.Code.INVALID_EMAIL
 CODE_INVALID_PASSWORD: Final[str] = constants.Code.INVALID_PASSWORD
 
 
-# todo: 認証付きのテスト追加？
 class AccountsTests(test.APITestCase):
     def setUp(self) -> None:
         """

--- a/backend/pong/accounts/tests/test_accounts.py
+++ b/backend/pong/accounts/tests/test_accounts.py
@@ -34,7 +34,7 @@ class AccountsTests(test.APITestCase):
     # -------------------------------------------------------------------------
     # 正常ケース
     # -------------------------------------------------------------------------
-    def test_create_account_with_valid_data(self) -> None:
+    def test_200_create_account_with_valid_data(self) -> None:
         """
         有効なデータでアカウントを作成するテスト
         status 201, username, email が返されることを確認
@@ -93,7 +93,7 @@ class AccountsTests(test.APITestCase):
             ),
         ]
     )
-    def test_create_account_with_invalid_email(
+    def test_400_create_account_with_invalid_email(
         self, testcase_name: str, invalid_email: str
     ) -> None:
         """
@@ -148,7 +148,7 @@ class AccountsTests(test.APITestCase):
             ),
         ]
     )
-    def test_create_account_with_invalid_password(
+    def test_400_create_account_with_invalid_password(
         self, testcase_name: str, invalid_password: str
     ) -> None:
         """

--- a/backend/pong/accounts/tests/test_accounts.py
+++ b/backend/pong/accounts/tests/test_accounts.py
@@ -36,12 +36,11 @@ class AccountsTests(test.APITestCase):
         有効なデータでアカウントを作成するテスト
         status 201, username, email が返されることを確認
         """
-        account_data: dict = {
-            USER: {
-                EMAIL: "testuser@example.com",
-                PASSWORD: "testpassword12345",
-            }
+        user_data: dict = {
+            EMAIL: "testuser@example.com",
+            PASSWORD: "testpassword12345",
         }
+        account_data: dict = {USER: user_data}
         response: drf_response.Response = self.client.post(
             self.url, account_data, format="json"
         )
@@ -55,7 +54,7 @@ class AccountsTests(test.APITestCase):
 
         # responseの内容を確認
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        self.assertEqual(response_user[EMAIL], "testuser@example.com")
+        self.assertEqual(response_user[EMAIL], user_data[EMAIL])
         # passwordは返されない
         self.assertNotIn(PASSWORD, response_user)
 
@@ -65,7 +64,7 @@ class AccountsTests(test.APITestCase):
 
         # emailからplayerを取得できる/例外がraiseされないことを確認
         player: models.Player = models.Player.objects.get(
-            user__email="testuser@example.com"
+            user__email=user_data[EMAIL]
         )
         # playerから取得したランダム文字列usernameのUserが実際にDBに存在するか確認
         self.assertTrue(

--- a/backend/pong/accounts/tests/test_accounts.py
+++ b/backend/pong/accounts/tests/test_accounts.py
@@ -173,3 +173,25 @@ class AccountsTests(test.APITestCase):
         # DBにUser,Playerが作成されていないことを確認
         self.assertEqual(models.User.objects.count(), 0)
         self.assertEqual(models.Player.objects.count(), 0)
+
+    def test_400_invalid_email_and_invalid_password(self) -> None:
+        """
+        不正なemailと不正なpasswordの形式でアカウントを作成するテスト
+        status 400 が返されることを確認
+        errorsにemailとpasswordが含まれることを確認
+        """
+        account_data: dict = {
+            EMAIL: "invalid_email",
+            PASSWORD: "invalid_password!!",
+        }
+        response: drf_response.Response = self.client.post(
+            self.url, account_data, format="json"
+        )
+        response_error: dict = response.data[ERRORS]
+        code: list[str] = response.data[CODE]
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn(EMAIL, response_error)
+        self.assertIn(PASSWORD, response_error)
+        self.assertIn(CODE_INVALID_EMAIL, code)
+        self.assertIn(CODE_INVALID_PASSWORD, code)

--- a/backend/pong/accounts/user/tests/test_user_serializer.py
+++ b/backend/pong/accounts/user/tests/test_user_serializer.py
@@ -280,3 +280,17 @@ class UserSerializerTests(TestCase):
 
         self.assertFalse(serializer.is_valid())
         self.assertIn(PASSWORD, serializer.errors)
+
+    def test_error_invalid_email_and_invalid_password(self) -> None:
+        """
+        emailとpasswordの両方が不正な場合に両方エラーになることを確認する
+        """
+        self.user_data[EMAIL] = "invalid_email"
+        self.user_data[PASSWORD] = "invalid_password!!"
+        serializer: serializers.UserSerializer = serializers.UserSerializer(
+            data=self.user_data
+        )
+
+        self.assertFalse(serializer.is_valid())
+        self.assertIn(EMAIL, serializer.errors)
+        self.assertIn(PASSWORD, serializer.errors)

--- a/backend/pong/accounts/views.py
+++ b/backend/pong/accounts/views.py
@@ -30,10 +30,8 @@ class AccountCreateView(views.APIView):
                 utils.OpenApiExample(
                     "Example request",
                     value={
-                        constants.PlayerFields.USER: {
-                            constants.UserFields.EMAIL: "user@example.com",
-                            constants.UserFields.PASSWORD: "password",
-                        }
+                        constants.UserFields.EMAIL: "user@example.com",
+                        constants.UserFields.PASSWORD: "passwordpassword",
                     },
                 ),
             ],
@@ -96,12 +94,12 @@ class AccountCreateView(views.APIView):
             user_data[constants.UserFields.USERNAME] = (
                 create_account.get_unique_random_username()
             )
+            # user_dataの中に必須fieldが存在しない場合は、UserSerializerでエラーになる
             return user_serializers.UserSerializer(data=user_data)
 
         # サインアップ専用のUserSerializerを作成
-        user_serializer: user_serializers.UserSerializer = _create_user_serializer(
-            # popしたいfieldが存在しない場合は空dictを渡し、UserSerializerでエラーになる
-            request.data.pop(constants.PlayerFields.USER, {})
+        user_serializer: user_serializers.UserSerializer = (
+            _create_user_serializer(request.data)
         )
         if not user_serializer.is_valid():
             return custom_response.CustomResponse(

--- a/backend/pong/accounts/views.py
+++ b/backend/pong/accounts/views.py
@@ -59,14 +59,24 @@ class AccountCreateView(views.APIView):
                 ],
             ),
             400: utils.OpenApiResponse(
+                description="Invalid Request (複数例あり)",
                 response={
                     "type": "object",
                     "properties": {
                         custom_response.STATUS: {"type": ["string"]},
-                        custom_response.ERRORS: {"type": ["dict"]},
+                        custom_response.CODE: {"type": ["list"]},
                     },
                 },
                 examples=[
+                    utils.OpenApiExample(
+                        "Example 400 response - already_exists",
+                        value={
+                            custom_response.STATUS: custom_response.Status.ERROR,
+                            custom_response.CODE: [
+                                constants.Code.ALREADY_EXISTS
+                            ],
+                        },
+                    ),
                     utils.OpenApiExample(
                         "Example 400 response - invalid_email",
                         value={

--- a/backend/pong/accounts/views.py
+++ b/backend/pong/accounts/views.py
@@ -4,6 +4,7 @@ from drf_spectacular import utils
 from rest_framework import permissions, request, response, status, views
 
 from pong.custom_response import custom_response
+from users import constants as users_constants
 
 from . import constants
 from .create_account import create_account
@@ -46,11 +47,13 @@ class AccountCreateView(views.APIView):
                         value={
                             "status": "ok",
                             "data": {
-                                constants.PlayerFields.USER: {
-                                    constants.UserFields.ID: 1,
-                                    constants.UserFields.USERNAME: "username",
-                                    constants.UserFields.EMAIL: "user@example.com",
-                                },
+                                constants.UserFields.ID: 2,
+                                constants.UserFields.USERNAME: "username",
+                                constants.UserFields.EMAIL: "user@example.com",
+                                constants.PlayerFields.DISPLAY_NAME: "default",
+                                constants.PlayerFields.AVATAR: "/media/avatars/sample.png",
+                                users_constants.UsersFields.IS_FRIEND: False,
+                                # todo: is_blocked,is_online,win_match,lose_match追加
                             },
                         },
                     ),
@@ -121,6 +124,6 @@ class AccountCreateView(views.APIView):
 
         user_serializer_data: dict = create_account_result.unwrap()
         return custom_response.CustomResponse(
-            data={constants.PlayerFields.USER: user_serializer_data},
+            data=user_serializer_data,
             status=status.HTTP_201_CREATED,
         )

--- a/backend/pong/accounts/views.py
+++ b/backend/pong/accounts/views.py
@@ -86,6 +86,8 @@ class AccountCreateView(views.APIView):
                     ),
                 ],
             ),
+            # todo: 詳細のschemaが必要であれば追加する
+            500: utils.OpenApiResponse(description="Internal server error"),
         },
     )
     # todo: try-exceptを書いて予期せぬエラー(実装上のミスを含む)の場合に500を返す
@@ -123,10 +125,11 @@ class AccountCreateView(views.APIView):
             )
 
         def _handle_unexpected_error(errors: dict) -> response.Response:
-            # todo: エラーの種類によって返すcodeを変える
+            # 実装上のミスor予期せぬエラーのみ
             return custom_response.CustomResponse(
+                code=[constants.Code.INTERNAL_ERROR],
                 errors=errors,
-                status=status.HTTP_400_BAD_REQUEST,
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )
 
         # サインアップ専用のUserSerializerを作成

--- a/backend/pong/accounts/views.py
+++ b/backend/pong/accounts/views.py
@@ -111,7 +111,12 @@ class AccountCreateView(views.APIView):
             code: list[str] = []
             # emailのエラーがあればcodeに追加
             if constants.UserFields.EMAIL in errors:
-                code.append(constants.Code.INVALID_EMAIL)
+                email_code: str = errors[constants.UserFields.EMAIL][0].code
+                if email_code == "unique":
+                    code.append(constants.Code.ALREADY_EXISTS)
+                else:
+                    # 既にアカウント登録済み以外は全てINVALID_EMAIL
+                    code.append(constants.Code.INVALID_EMAIL)
             # passwordのエラーがあればcodeに追加
             if constants.UserFields.PASSWORD in errors:
                 code.append(constants.Code.INVALID_PASSWORD)

--- a/backend/pong/accounts/views.py
+++ b/backend/pong/accounts/views.py
@@ -1,6 +1,4 @@
 from drf_spectacular import utils
-
-# todo: IsAuthenticatedが追加されたらAllowAnyは不要かも
 from rest_framework import permissions, request, response, status, views
 
 from pong.custom_response import custom_response
@@ -20,7 +18,6 @@ class AccountCreateView(views.APIView):
     serializer_class: type[player_serializers.PlayerSerializer] = (
         player_serializers.PlayerSerializer
     )
-    # todo: 認証機能を実装したら多分IsAuthenticatedに変更
     permission_classes = (permissions.AllowAny,)
 
     @utils.extend_schema(

--- a/backend/pong/accounts/views.py
+++ b/backend/pong/accounts/views.py
@@ -43,8 +43,8 @@ class AccountCreateView(views.APIView):
                     utils.OpenApiExample(
                         "Example 201 response",
                         value={
-                            "status": "ok",
-                            "data": {
+                            custom_response.STATUS: custom_response.Status.OK,
+                            custom_response.DATA: {
                                 constants.UserFields.ID: 2,
                                 constants.UserFields.USERNAME: "username",
                                 constants.UserFields.EMAIL: "user@example.com",
@@ -61,16 +61,18 @@ class AccountCreateView(views.APIView):
                 response={
                     "type": "object",
                     "properties": {
-                        "status": {"type": ["string"]},
-                        "errors": {"type": ["dict"]},
+                        custom_response.STATUS: {"type": ["string"]},
+                        custom_response.ERRORS: {"type": ["dict"]},
                     },
                 },
                 examples=[
                     utils.OpenApiExample(
                         "Example 400 response",
                         value={
-                            "status": "error",
-                            "errors": {"field": ["error messages"]},
+                            custom_response.STATUS: custom_response.Status.ERROR,
+                            custom_response.ERRORS: {
+                                "field": ["error messages"]
+                            },
                         },
                     ),
                 ],

--- a/backend/pong/accounts/views.py
+++ b/backend/pong/accounts/views.py
@@ -67,12 +67,21 @@ class AccountCreateView(views.APIView):
                 },
                 examples=[
                     utils.OpenApiExample(
-                        "Example 400 response",
+                        "Example 400 response - invalid_email",
                         value={
                             custom_response.STATUS: custom_response.Status.ERROR,
-                            custom_response.ERRORS: {
-                                "field": ["error messages"]
-                            },
+                            custom_response.CODE: [
+                                constants.Code.INVALID_EMAIL
+                            ],
+                        },
+                    ),
+                    utils.OpenApiExample(
+                        "Example 400 response - invalid_password",
+                        value={
+                            custom_response.STATUS: custom_response.Status.ERROR,
+                            custom_response.CODE: [
+                                constants.Code.INVALID_PASSWORD
+                            ],
                         },
                     ),
                 ],
@@ -100,8 +109,15 @@ class AccountCreateView(views.APIView):
             return user_serializers.UserSerializer(data=user_data)
 
         def _handle_validation_error(errors: dict) -> response.Response:
-            # todo: エラーの種類によって返すcodeを変える
+            code: list[str] = []
+            # emailのエラーがあればcodeに追加
+            if constants.UserFields.EMAIL in errors:
+                code.append(constants.Code.INVALID_EMAIL)
+            # passwordのエラーがあればcodeに追加
+            if constants.UserFields.PASSWORD in errors:
+                code.append(constants.Code.INVALID_PASSWORD)
             return custom_response.CustomResponse(
+                code=code,
                 errors=errors,
                 status=status.HTTP_400_BAD_REQUEST,
             )


### PR DESCRIPTION
## タスクやディスカッションのリンク
<!-- - URLをここに貼る -->
- #335 

## やったこと
<!-- - このタスクでやったことはなにか？ -->
- `/api/accounts/,` `POST` メソッドについて、参考リンクの Notion の code のルールに記載の以下 3 つの code をレスポンスに含めて返すようにしました
  - already_exists
  - invalid_email
  - invalid_password
- 他は accounts app 内のリファクタ・extend_schema・テスト追加などです

## やらないこと
<!-- - このタスクでやらないことはなにか？（やらない場合いつやるのか？無ければ「なし」を記述） -->
- アカウント新規作成時のレスポンスも、他のユーザー取得系のレスポンスと同じフィールドを返したいことから、accounts app 内の `create_account()` が、users app の `UsersSerializer` を呼んでいるという構成になっていて良くなさそうなので改善したいのですが、取りあえず動くことを優先して後回しにしました

## 動作確認
<!-- - どのような動作確認を行い、結果はどうだったのか？(適宜スクショ等添付) -->
- テスト確認と
```sh
make exec-be
make test ARG=accounts
```
- swagger-ui にて `/api/accounts/`, `POST` の
  - extend_schema とレスポンスが合っているか確認
  - エラー時のレスポンスの code が、以下のパターンで返ってくることを確認
    - `[already_exists]` -> 既に登録済み email
    - `[invalid_email]` -> email の形式が不正
    - `[invalid_password]`  -> password の形式が不正
    - `[invalid_email, invalid_password]` -> email の形式が不正かつ password の形式が不正

## 特にレビューをお願いしたい箇所
<!-- - 特にチェックをお願いしたいポイントを簡潔に記述する -->
- 主に入力値を色々変更してレスポンスが期待した extend_schema のようになっていること

## その他
<!-- - 実装上の懸念点、注意点等あれば記載する -->
特になし

## 参考リンク
<!-- - 実装に際し参考にした、記事やサイトのリンクを記載する -->
- Notion code : https://www.notion.so/440370c7d06c497abfda19ac0fbc95e7?pvs=4#4815f4d34f1a4f8295d2a35d4f7d642c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **新機能**
  - 管理画面でプレイヤーのIDが表示され、情報の把握が容易になりました。
  - アカウント作成時のレスポンスが改善され、ユーザー情報の提供とエラー処理が統一されました。

- **バグ修正**
  - エラーハンドリングが強化され、アカウント作成プロセスがより堅牢になりました。

- **テスト**
  - 入力検証とエラーハンドリングに関するテストが強化され、より堅牢な動作が保証されるようになりました。
  - ユーザーシリアライザーのエラーハンドリングに関するテストが追加されました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->