### PR TITLE
⚡ [users] 認証付きにしていなかったエンドポイントを IsAuthenticated に変更

### DIFF
--- a/backend/pong/users/views/list.py
+++ b/backend/pong/users/views/list.py
@@ -21,8 +21,7 @@ class UsersListView(views.APIView):
     ユーザープロフィールの一覧を取得するビュー
     """
 
-    # todo: IsAuthenticatedに変更する。extend_schemaにも401を追加する
-    permission_classes = (permissions.AllowAny,)
+    permission_classes = (permissions.IsAuthenticated,)
 
     @utils.extend_schema(
         operation_id="get_users_list",
@@ -55,6 +54,22 @@ class UsersListView(views.APIView):
                                 },
                                 {"...", "..."},
                             ],
+                        },
+                    ),
+                ],
+            ),
+            # todo: 現在Djangoが自動で返している。CustomResponseが使えたら併せて変更する
+            401: utils.OpenApiResponse(
+                description="Not authenticated",
+                response={
+                    "type": "object",
+                    "properties": {"detail": {"type": "string"}},
+                },
+                examples=[
+                    utils.OpenApiExample(
+                        "Example 401 response",
+                        value={
+                            "detail": "Authentication credentials were not provided."
                         },
                     ),
                 ],

--- a/backend/pong/users/views/list.py
+++ b/backend/pong/users/views/list.py
@@ -40,7 +40,7 @@ class UsersListView(views.APIView):
                                     accounts_constants.UserFields.ID: 2,
                                     accounts_constants.UserFields.USERNAME: "username1",
                                     accounts_constants.PlayerFields.DISPLAY_NAME: "display_name1",
-                                    accounts_constants.PlayerFields.AVATAR: "avatars/sample1.png",
+                                    accounts_constants.PlayerFields.AVATAR: "/media/avatars/sample1.png",
                                     constants.UsersFields.IS_FRIEND: False,
                                     # todo: is_blocked,is_online,win_match,lose_match追加
                                 },
@@ -48,7 +48,7 @@ class UsersListView(views.APIView):
                                     accounts_constants.UserFields.ID: 3,
                                     accounts_constants.UserFields.USERNAME: "username2",
                                     accounts_constants.PlayerFields.DISPLAY_NAME: "display_name2",
-                                    accounts_constants.PlayerFields.AVATAR: "avatars/sample2.png",
+                                    accounts_constants.PlayerFields.AVATAR: "/media/avatars/sample2.png",
                                     constants.UsersFields.IS_FRIEND: False,
                                     # todo: is_blocked,is_online,win_match,lose_match追加
                                 },

--- a/backend/pong/users/views/me.py
+++ b/backend/pong/users/views/me.py
@@ -43,7 +43,7 @@ class UsersMeView(views.APIView):
                                 accounts_constants.UserFields.USERNAME: "username1",
                                 accounts_constants.UserFields.EMAIL: "username1@example.com",
                                 accounts_constants.PlayerFields.DISPLAY_NAME: "display_name1",
-                                accounts_constants.PlayerFields.AVATAR: "avatars/sample.png",
+                                accounts_constants.PlayerFields.AVATAR: "/media/avatars/sample.png",
                                 constants.UsersFields.IS_FRIEND: False,
                                 # todo: is_blocked,is_online,win_match,lose_match追加
                             },
@@ -128,7 +128,7 @@ class UsersMeView(views.APIView):
                                 accounts_constants.UserFields.USERNAME: "username1",
                                 accounts_constants.UserFields.EMAIL: "username1@example.com",
                                 accounts_constants.PlayerFields.DISPLAY_NAME: "display_name1",
-                                accounts_constants.PlayerFields.AVATAR: "avatars/sample.png",
+                                accounts_constants.PlayerFields.AVATAR: "/media/avatars/sample.png",
                                 constants.UsersFields.IS_FRIEND: False,
                                 # todo: is_blocked,is_online,win_match,lose_match追加
                             },

--- a/backend/pong/users/views/retrieve.py
+++ b/backend/pong/users/views/retrieve.py
@@ -43,7 +43,7 @@ class UsersRetrieveView(views.APIView):
                                 accounts_constants.UserFields.ID: 2,
                                 accounts_constants.UserFields.USERNAME: "username1",
                                 accounts_constants.PlayerFields.DISPLAY_NAME: "display_name1",
-                                accounts_constants.PlayerFields.AVATAR: "avatars/sample.png",
+                                accounts_constants.PlayerFields.AVATAR: "/media/avatars/sample.png",
                                 constants.UsersFields.IS_FRIEND: True,
                                 # todo: is_blocked,is_online,win_match,lose_match追加
                             },

--- a/backend/pong/users/views/retrieve.py
+++ b/backend/pong/users/views/retrieve.py
@@ -25,8 +25,7 @@ class UsersRetrieveView(views.APIView):
     特定のuser_idのユーザープロフィールを取得するビュー
     """
 
-    # todo: IsAuthenticatedに変更する。extend_schemaにも401を追加する
-    permission_classes = (permissions.AllowAny,)
+    permission_classes = (permissions.IsAuthenticated,)
 
     @utils.extend_schema(
         operation_id="get_users_retrieve",
@@ -48,6 +47,22 @@ class UsersRetrieveView(views.APIView):
                                 constants.UsersFields.IS_FRIEND: True,
                                 # todo: is_blocked,is_online,win_match,lose_match追加
                             },
+                        },
+                    ),
+                ],
+            ),
+            # todo: 現在Djangoが自動で返している。CustomResponseが使えたら併せて変更する
+            401: utils.OpenApiResponse(
+                description="Not authenticated",
+                response={
+                    "type": "object",
+                    "properties": {"detail": {"type": "string"}},
+                },
+                examples=[
+                    utils.OpenApiExample(
+                        "Example 401 response",
+                        value={
+                            "detail": "Authentication credentials were not provided."
                         },
                     ),
                 ],


### PR DESCRIPTION
## タスクやディスカッションのリンク
<!-- - URLをここに貼る -->
- #343 

## やったこと
<!-- - このタスクでやったことはなにか？ -->
- 以下のエンドポイント 2 つの permission を認証付き `IsAuthenticated` にしました
  - `/api/users/`, `GET`
  - `/api/users/{id}/`, `GET`

## やらないこと
<!-- - このタスクでやらないことはなにか？（やらない場合いつやるのか？無ければ「なし」を記述） -->
上記以外

## 動作確認
<!-- - どのような動作確認を行い、結果はどうだったのか？(適宜スクショ等添付) -->
- テスト確認と
```sh
make test ARG=users
```
- swagger-ui にて 2 つのエンドポイントにリクエストを送って確認
  - 認証無しでリクエストを送ると 401 が返ること
  - 認証ありでリクエストを送ると extend_schema と同じ形式でユーザー情報を取得できること

## 特にレビューをお願いしたい箇所
<!-- - 特にチェックをお願いしたいポイントを簡潔に記述する -->
動作確認に書いてあること

## その他
<!-- - 実装上の懸念点、注意点等あれば記載する -->
特になし

## 参考リンク
<!-- - 実装に際し参考にした、記事やサイトのリンクを記載する -->
特になし

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - API エンドポイントが認証必須となり、認証されていない場合は 401 Unauthorized のエラーが返されるようになりました。
  - ユーザープロフィールのアバター画像URLが絶対パス（例: /media/avatars/…）に統一され、表示が改善されました。
- **ドキュメント**
  - 未認証リクエスト時のエラーレスポンス仕様が API ドキュメンテーションに反映されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->