### PR TITLE
⚡ [users, friends] handle_exception() をオーバーライドして CustomResponse の 500 を返す

### DIFF
--- a/backend/pong/users/friends/views.py
+++ b/backend/pong/users/friends/views.py
@@ -403,11 +403,7 @@ class FriendsViewSet(viewsets.ModelViewSet):
                 f"[500] Failed to create friendship\
                 (user_id={user_id},friend_user_id={friend_user_id}): {str(e)} from {errors}"
             )
-            return custom_response.CustomResponse(
-                code=[users_constants.Code.INTERNAL_ERROR],
-                errors={"detail": str(e)},
-                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            )
+            raise
 
     def create(self, request: request.Request) -> response.Response:
         """
@@ -445,11 +441,7 @@ class FriendsViewSet(viewsets.ModelViewSet):
                 f"[500] Failed to create friendship\
                 (user_id={user.id},friend_user_id={friend_user_id}): {str(e)}"
             )
-            return custom_response.CustomResponse(
-                code=[users_constants.Code.INTERNAL_ERROR],
-                errors={"detail": str(e)},
-                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            )
+            raise
 
     # --------------------------------------------------------------------------
     # DELETE method
@@ -489,11 +481,7 @@ class FriendsViewSet(viewsets.ModelViewSet):
                 f"[500] Failed to delete friendship\
                 (user_id={user_id},friend_user_id={friend_id}): {str(e)} from {errors}"
             )
-            return custom_response.CustomResponse(
-                code=[users_constants.Code.INTERNAL_ERROR],
-                errors={"detail": str(e)},
-                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            )
+            raise
 
     def destroy(
         self, request: request.Request, friend_id: int
@@ -533,8 +521,4 @@ class FriendsViewSet(viewsets.ModelViewSet):
                 f"[500] Failed to delete friendship\
                 (user_id={user.id},friend_user_id={friend_id}): {str(e)}"
             )
-            return custom_response.CustomResponse(
-                code=[users_constants.Code.INTERNAL_ERROR],
-                errors={"detail": str(e)},
-                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            )
+            raise

--- a/backend/pong/users/views/list.py
+++ b/backend/pong/users/views/list.py
@@ -1,3 +1,5 @@
+import logging
+
 from django.db.models.query import QuerySet
 from drf_spectacular import utils
 from rest_framework import (
@@ -16,6 +18,8 @@ from users.friends import constants as friends_constants
 
 from .. import constants, serializers
 
+logger = logging.getLogger(__name__)
+
 
 class UsersListView(views.APIView):
     """
@@ -32,9 +36,11 @@ class UsersListView(views.APIView):
         if isinstance(
             exc, (exceptions.NotAuthenticated, exceptions.AuthenticationFailed)
         ):
+            logger.error(f"[401] Authentication error: {str(exc)}")
             # 401はCustomResponseにせずそのまま返す
             return super().handle_exception(exc)
 
+        logger.error(f"[500] Internal server error: {str(exc)}")
         response: custom_response.CustomResponse = (
             custom_response.CustomResponse(
                 code=[constants.Code.INTERNAL_ERROR],
@@ -145,6 +151,7 @@ class UsersListView(views.APIView):
                 friends_constants.FriendshipFields.USER_ID: request.user.id
             },
         )
+        # todo: logger.info()追加
         return custom_response.CustomResponse(
             data=serializer.data, status=status.HTTP_200_OK
         )

--- a/backend/pong/users/views/list.py
+++ b/backend/pong/users/views/list.py
@@ -1,6 +1,7 @@
 from django.db.models.query import QuerySet
 from drf_spectacular import utils
 from rest_framework import (
+    exceptions,
     permissions,
     request,
     response,
@@ -22,6 +23,26 @@ class UsersListView(views.APIView):
     """
 
     permission_classes = (permissions.IsAuthenticated,)
+
+    def handle_exception(self, exc: Exception) -> response.Response:
+        """
+        APIViewのhandle_exception()をオーバーライド
+        viewでtry-exceptしていない例外をカスタムレスポンスに変換して返す
+        """
+        if isinstance(
+            exc, (exceptions.NotAuthenticated, exceptions.AuthenticationFailed)
+        ):
+            # 401はCustomResponseにせずそのまま返す
+            return super().handle_exception(exc)
+
+        response: custom_response.CustomResponse = (
+            custom_response.CustomResponse(
+                code=[constants.Code.INTERNAL_ERROR],
+                errors={"detail": str(exc)},
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            )
+        )
+        return response
 
     @utils.extend_schema(
         operation_id="get_users_list",
@@ -74,11 +95,29 @@ class UsersListView(views.APIView):
                     ),
                 ],
             ),
-            # todo: 詳細のschemaが必要であれば追加する
-            500: utils.OpenApiResponse(description="Internal server error"),
+            500: utils.OpenApiResponse(
+                description="Internal server error",
+                response={
+                    "type": "object",
+                    "properties": {
+                        custom_response.STATUS: {"type": "string"},
+                        custom_response.CODE: {"type": "list"},
+                    },
+                },
+                examples=[
+                    utils.OpenApiExample(
+                        "Example 500 response",
+                        value={
+                            custom_response.STATUS: custom_response.Status.ERROR,
+                            custom_response.CODE: [
+                                constants.Code.INTERNAL_ERROR
+                            ],
+                        },
+                    ),
+                ],
+            ),
         },
     )
-    # todo: try-exceptで全体を囲って500を返す？
     def get(self, request: request.Request) -> response.Response:
         """
         ユーザープロフィール一覧を取得するGETメソッド

--- a/backend/pong/users/views/me.py
+++ b/backend/pong/users/views/me.py
@@ -184,7 +184,7 @@ class UsersMeView(views.APIView):
                     "type": "object",
                     "properties": {
                         custom_response.STATUS: {"type": "string"},
-                        custom_response.ERRORS: {"type": "dict"},
+                        custom_response.CODE: {"type": "list"},
                     },
                 },
                 examples=[

--- a/backend/pong/users/views/retrieve.py
+++ b/backend/pong/users/views/retrieve.py
@@ -96,7 +96,7 @@ class UsersRetrieveView(views.APIView):
                     "type": "object",
                     "properties": {
                         custom_response.STATUS: {"type": "string"},
-                        custom_response.ERRORS: {"type": "list"},
+                        custom_response.CODE: {"type": "list"},
                     },
                 },
                 examples=[

--- a/backend/pong/users/views/retrieve.py
+++ b/backend/pong/users/views/retrieve.py
@@ -3,6 +3,7 @@ import logging
 from django.core.exceptions import ObjectDoesNotExist
 from drf_spectacular import utils
 from rest_framework import (
+    exceptions,
     permissions,
     request,
     response,
@@ -26,6 +27,28 @@ class UsersRetrieveView(views.APIView):
     """
 
     permission_classes = (permissions.IsAuthenticated,)
+
+    def handle_exception(self, exc: Exception) -> response.Response:
+        """
+        APIViewのhandle_exception()をオーバーライド
+        viewでtry-exceptしていない例外をカスタムレスポンスに変換して返す
+        """
+        if isinstance(
+            exc, (exceptions.NotAuthenticated, exceptions.AuthenticationFailed)
+        ):
+            logger.error(f"[401] Authentication error: {str(exc)}")
+            # 401はCustomResponseにせずそのまま返す
+            return super().handle_exception(exc)
+
+        logger.error(f"[500] Internal server error: {str(exc)}")
+        response: custom_response.CustomResponse = (
+            custom_response.CustomResponse(
+                code=[constants.Code.INTERNAL_ERROR],
+                errors={"detail": str(exc)},
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            )
+        )
+        return response
 
     @utils.extend_schema(
         operation_id="get_users_retrieve",
@@ -88,8 +111,27 @@ class UsersRetrieveView(views.APIView):
                     ),
                 ],
             ),
-            # todo: 詳細のschemaが必要であれば追加する
-            500: utils.OpenApiResponse(description="Internal server error"),
+            500: utils.OpenApiResponse(
+                description="Internal server error",
+                response={
+                    "type": "object",
+                    "properties": {
+                        custom_response.STATUS: {"type": "string"},
+                        custom_response.CODE: {"type": "list"},
+                    },
+                },
+                examples=[
+                    utils.OpenApiExample(
+                        "Example 500 response",
+                        value={
+                            custom_response.STATUS: custom_response.Status.ERROR,
+                            custom_response.CODE: [
+                                constants.Code.INTERNAL_ERROR
+                            ],
+                        },
+                    ),
+                ],
+            ),
         },
     )
     def get(self, request: request.Request, user_id: int) -> response.Response:
@@ -119,6 +161,7 @@ class UsersRetrieveView(views.APIView):
                     friends_constants.FriendshipFields.USER_ID: request.user.id
                 },
             )
+            # todo: logger.info()追加
             return custom_response.CustomResponse(
                 data=users_serializer.data,
                 status=status.HTTP_200_OK,
@@ -130,12 +173,4 @@ class UsersRetrieveView(views.APIView):
                 code=[constants.Code.INTERNAL_ERROR],
                 errors={"user_id": "The user does not exist."},
                 status=status.HTTP_404_NOT_FOUND,
-            )
-        except Exception as e:
-            # MultipleObjectsReturnedなどの場合
-            logger.error(f"[500] Internal server error: {str(e)}")
-            return custom_response.CustomResponse(
-                code=[constants.Code.INTERNAL_ERROR],
-                errors={"detail": str(e)},
-                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )


### PR DESCRIPTION
## タスクやディスカッションのリンク
<!-- - URLをここに貼る -->
- #349 

## やったこと
<!-- - このタスクでやったことはなにか？ -->
ちょっと多くなってしまったのですが、同じ処理なので `users`, `friends` まとめてしてしまいました

以下のエンドポイントについて、`500` を `handle_exception()` をオーバーライドすることでまとめて `CustomResponse()` で返すようにしました
- `users` 全て
  - `/api/users/`, `GET` (list)
  - `/api/users/{id}`, `GET` (retrieve)
  - `/api/users/me/`, `GET` (me)
  - `/api/users/me/`, `PATCH` (me)
- `friends` 全て
  - `/api/users/me/friends/`, `GET` (list)
  - `/api/users/me/friends/`, `POST` (create)
  - `/api/users/me/friends/{id}`, `DELETE` (destroy)
- extend_schema・logger 追加


## やらないこと
<!-- - このタスクでやらないことはなにか？（やらない場合いつやるのか？無ければ「なし」を記述） -->
特になし


## 動作確認
<!-- - どのような動作確認を行い、結果はどうだったのか？(適宜スクショ等添付) -->
view の中で適当に `raise Exception("error message")` などを追加していただいて、実際にリクエストを送ると、`CustomResponse` で 500 と raise されたエラーメッセージが返ることを確認できると思います

## 特にレビューをお願いしたい箇所
<!-- - 特にチェックをお願いしたいポイントを簡潔に記述する -->
気になった点あればなんでも

## その他
<!-- - 実装上の懸念点、注意点等あれば記載する -->
- `handle_exception()` の中で先に `401` を処理している理由は、テストをしている中で以下の場合に `handle_exception()` の中に認証系のエラーが入ってきたからです
  - `pong/users/tests/integration/test_list.py`
    - `test_get_401_unauthenticated_user()` -> `handle_exception()` には入らず、恐らく認証クラスで自動で `401`・`"not_authenticated"` が返る
    - `test_401_no_users_exist()` -> `handle_exception()` の中に入ってきて `"authentication_failed"` がエラーに入っていた

## 参考リンク
<!-- - 実装に際し参考にした、記事やサイトのリンクを記載する -->
特になし

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **リファクタ**
	- API全体でエラーハンドリングを統一し、エラー応答に詳細なエラーコード情報を追加しました。
	- 未認証アクセス時の対応が明確になり、認証エラーと内部サーバーエラーの処理が一元化されました。
	- 各エンドポイントのログ記録が強化され、問題解析が容易になっています。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->