### PR TITLE
🐛 [friends] Player が存在しないユーザー(superuser 含む)をフレンド追加・削除できてしまう問題修正

### DIFF
--- a/backend/pong/users/friends/serializers/validators.py
+++ b/backend/pong/users/friends/serializers/validators.py
@@ -1,6 +1,6 @@
-from django.contrib.auth.models import User
 from rest_framework import serializers
 
+from accounts.player import models as players_models
 from users import constants as users_constants
 
 from .. import constants, models
@@ -16,7 +16,7 @@ def invalid_same_user_validator(user_id: int, friend_user_id: int) -> None:
         friend_user_id: フレンド追加対象・削除対象のユーザーのID
 
     Raises:
-        serializers.ValidationError: フレンドとして追加したいユーザーが自分自身の場合
+        serializers.ValidationError: フレンドとして追加・削除したいユーザーが自分自身の場合
     """
     if user_id == friend_user_id:
         raise serializers.ValidationError(
@@ -41,8 +41,10 @@ def _is_friendship_exists(user_id: int, friend_user_id: int) -> bool:
     Raises:
         serializers.ValidationError: フレンドに追加したいidがDBに存在せず、フレンドかどうかの判定ができない場合
     """
-    # フレンドに追加したいidがDBに存在しない場合はエラー
-    if not User.objects.filter(id=friend_user_id).exists():
+    # フレンドに追加したいidのPlayerがDBに存在しない場合はエラー
+    if not players_models.Player.objects.filter(
+        user_id=friend_user_id
+    ).exists():
         raise serializers.ValidationError(
             {
                 constants.FriendshipFields.FRIEND_USER_ID: "The user does not exist."

--- a/backend/pong/users/friends/tests/integration/test_destroy_views.py
+++ b/backend/pong/users/friends/tests/integration/test_destroy_views.py
@@ -166,3 +166,19 @@ class FriendsListViewTests(test.APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
         self.assertEqual(response.data[CODE][0], CODE_NOT_EXISTS)
+
+    def test_404_not_player(self) -> None:
+        """
+        紐づくPlayerが存在しないユーザー(superuser含む)をフレンドから削除しようとした場合にエラーになることを確認
+        """
+        # user2に紐づくPlayer情報のみ削除
+        players_models.Player.objects.get(user=self.user2).delete()
+        # user1が、Player情報を持たないuser2をフレンドから削除しようとする
+        response: drf_response.Response = self.client.delete(
+            self._create_url(self.user2.id)
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(
+            response.data[CODE][0], users_constants.Code.NOT_EXISTS
+        )

--- a/backend/pong/users/friends/tests/integration/test_list_views.py
+++ b/backend/pong/users/friends/tests/integration/test_list_views.py
@@ -180,6 +180,32 @@ class FriendsListViewTests(test.APITestCase):
             ],
         )
 
+    def test_200_exists_non_player(self) -> None:
+        """
+        紐づくPlayerが存在しないユーザー(superuser含む)はフレンド一覧に含まれないことを確認
+        """
+        # user3をフレンドから削除はせず、紐づくPlayer情報のみ削除
+        players_models.Player.objects.get(user=self.user3).delete()
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        # user2のみフレンド一覧に表示される
+        self.assertEqual(
+            response.data[DATA],
+            [
+                {
+                    FRIEND: {
+                        ID: self.user2.id,
+                        USERNAME: self.user_data2[USERNAME],
+                        DISPLAY_NAME: self.player_data2[DISPLAY_NAME],
+                        AVATAR: "/media/avatars/sample.png",  # todo: デフォルト画像が変更になったら修正
+                        IS_FRIEND: True,
+                        # todo: is_blocked,is_online,win_match,lose_match追加
+                    },
+                },
+            ],
+        )
+
     def test_401_unauthenticated_user(self) -> None:
         """
         認証されていないユーザーがフレンド一覧を取得しようとするとエラーになることを確認

--- a/backend/pong/users/friends/views.py
+++ b/backend/pong/users/friends/views.py
@@ -3,6 +3,7 @@ from typing import Optional
 
 from django.contrib.auth.models import AnonymousUser, User
 from django.db import transaction
+from django.db.models import Q
 from django.db.models.query import QuerySet
 from drf_spectacular import utils
 from rest_framework import permissions, request, response, status, viewsets
@@ -232,7 +233,9 @@ logger = logging.getLogger(__name__)
 )
 # todo: 各メソッドにtry-exceptを書いて予期せぬエラー(実装上のミスを含む)の場合に500を返す
 class FriendsViewSet(viewsets.ModelViewSet):
-    queryset = models.Friendship.objects.all().select_related("user", "friend")
+    queryset = models.Friendship.objects.filter(
+        Q(friend__player__isnull=False)
+    ).select_related("user", "friend")
     permission_classes = (permissions.IsAuthenticated,)
 
     # URLから取得するID名

--- a/backend/pong/users/friends/views.py
+++ b/backend/pong/users/friends/views.py
@@ -108,7 +108,7 @@ logger = logging.getLogger(__name__)
                 ],
             ),
             400: utils.OpenApiResponse(
-                description="Invalid friend_user_id",
+                description="Invalid friend_user_id (複数例あり)",
                 response={
                     "type": "object",
                     "properties": {
@@ -188,7 +188,7 @@ logger = logging.getLogger(__name__)
                 ],
             ),
             404: utils.OpenApiResponse(
-                description="Invalid friend_user_id",
+                description="Invalid friend_user_id (複数例あり)",
                 response={
                     "type": "object",
                     "properties": {


### PR DESCRIPTION
## タスクやディスカッションのリンク
<!-- - URLをここに貼る -->
- #321 

## やったこと
<!-- - このタスクでやったことはなにか？ -->
- superuser の `user.id` はゲームユーザーには知られないはずですが、リクエストを送ればフレンド追加できてしまっていたので、そもそも存在を知られないように変更しました
- 具体的には、フレンド追加の際に `User` のクエリセットから検索していたのを、`Player` のクエリセットからから検索するようにしました

これにより、ゲームに必須な `Player` が存在する User のみフレンドに追加できるようになりました
superuser でも紐づく `Player` がもしあればゲーム参加者としてフレンドに追加できて良いと思い、`is_superuser` を見るという処理にはしませんでした

また念のため、フレンド削除の際も `Player` クエリセットから検索するようにし、フレンド一覧取得の際も紐づく `Player` がいる場合のみ取得するようにしました


## やらないこと
<!-- - このタスクでやらないことはなにか？（やらない場合いつやるのか？無ければ「なし」を記述） -->
上記以外

## 動作確認
<!-- - どのような動作確認を行い、結果はどうだったのか？(適宜スクショ等添付) -->
- テスト確認
- swagger-ui にて、
  - superuser の user.id をフレンド追加してみる -> `400` と code=`not_exists` が返ることを確認
  - admin サイトで直に superuser とフレンドにさせる( Friendship を追加)
  -> フレンド一覧取得をし、superuser のみ含まれないことを確認
  -> supseruser をフレンド削除 -> `404` と code="not_exists` が返り削除できないことを確認 

## 特にレビューをお願いしたい箇所
<!-- - 特にチェックをお願いしたいポイントを簡潔に記述する -->
superuser を特別視するのではなく、紐づく `Player` の有無で判定している点について大丈夫そうかどうか

## その他
<!-- - 実装上の懸念点、注意点等あれば記載する -->
特になし

## 参考リンク
<!-- - 実装に際し参考にした、記事やサイトのリンクを記載する -->
特になし

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - フレンドリストの表示条件を改善し、有効な友達のみがリストに反映されるようになりました。

- **バグ修正**
  - フレンドの追加・削除処理において、対象ユーザーが有効な状態でない場合に適切なエラーが返されるよう改善しました。

- **テスト**
  - フレンド追加・削除時に、関連するプレイヤーが存在しない場合のエラーハンドリングを強化するテストを追加しました。
  - フレンドリスト取得時に、プレイヤーが存在しないユーザーがリストに含まれないことを確認するテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->