### PR TITLE
🌱 [blocks] `/api/users/me/blocks/`, `POST` 実装 (ブロック追加)

### DIFF
--- a/backend/pong/users/blocks/serializers/create_serializers.py
+++ b/backend/pong/users/blocks/serializers/create_serializers.py
@@ -1,0 +1,68 @@
+from rest_framework import serializers
+
+from accounts import constants as accounts_constants
+from users import constants as users_constants
+from users import serializers as users_serializers
+
+from .. import constants, models
+from . import validators
+
+
+class BlockRelationshipCreateSerializer(serializers.ModelSerializer):
+    blocked_user_id = serializers.IntegerField(
+        source="blocked_user.id", min_value=1, write_only=True
+    )
+    blocked_user = users_serializers.UsersSerializer(
+        source="blocked_user.player",
+        read_only=True,
+        fields=(  # emailは含めない
+            accounts_constants.UserFields.ID,
+            accounts_constants.UserFields.USERNAME,
+            accounts_constants.PlayerFields.DISPLAY_NAME,
+            accounts_constants.PlayerFields.AVATAR,
+            users_constants.UsersFields.IS_FRIEND,
+            # todo: is_blocked,is_online,win_match,lose_match追加
+        ),
+    )
+
+    class Meta:
+        model = models.BlockRelationship
+        fields = (
+            constants.BlockRelationshipFields.BLOCKED_USER_ID,
+            constants.BlockRelationshipFields.BLOCKED_USER,
+        )
+
+    def create(self, data: dict) -> models.BlockRelationship:
+        """
+        save()内で呼ばれるcreate()のオーバーライド
+        """
+        user_id: int = self.context[constants.BlockRelationshipFields.USER_ID]
+        blocked_user_id: int = data[
+            constants.BlockRelationshipFields.BLOCKED_USER
+        ][constants.BlockRelationshipFields.ID]
+        return models.BlockRelationship.objects.create(
+            user_id=user_id, blocked_user_id=blocked_user_id
+        )
+
+    def validate(self, data: dict) -> dict:
+        """
+        is_valid()内で呼ばれるvalidate()のオーバーライド
+
+        Raises:
+            serializers.ValidationError
+              - 自分自身をブロックしようとした場合
+              - ブロックしたいユーザーが存在しない場合
+              - ブロックしたいユーザーを既にブロックしている場合
+        """
+        user_id: int = self.context[constants.BlockRelationshipFields.USER_ID]
+        blocked_user_id: int = data[
+            constants.BlockRelationshipFields.BLOCKED_USER
+        ][constants.BlockRelationshipFields.ID]
+
+        # 自分自身をブロックしようとした場合にValidationErrorを発生させる
+        validators.invalid_same_user_validator(user_id, blocked_user_id)
+
+        # ブロックしたいユーザーを既にブロックしている場合にValidationErrorを発生させる
+        validators.already_block_validator(user_id, blocked_user_id)
+
+        return data

--- a/backend/pong/users/blocks/serializers/tests/test_create_serializers.py
+++ b/backend/pong/users/blocks/serializers/tests/test_create_serializers.py
@@ -1,0 +1,179 @@
+from typing import Final
+
+from django.contrib.auth.models import User
+from django.test import TestCase
+
+from accounts import constants as accounts_constants
+from accounts.player import models as players_models
+from users import constants as users_constants
+
+from ... import constants, models
+from .. import create_serializers
+
+ID: Final[str] = accounts_constants.UserFields.ID
+USERNAME: Final[str] = accounts_constants.UserFields.USERNAME
+EMAIL: Final[str] = accounts_constants.UserFields.EMAIL
+PASSWORD: Final[str] = accounts_constants.UserFields.PASSWORD
+USER: Final[str] = accounts_constants.PlayerFields.USER
+DISPLAY_NAME: Final[str] = accounts_constants.PlayerFields.DISPLAY_NAME
+AVATAR: Final[str] = accounts_constants.PlayerFields.AVATAR
+IS_FRIEND: Final[str] = users_constants.UsersFields.IS_FRIEND
+
+USER_ID: Final[str] = constants.BlockRelationshipFields.USER_ID
+BLOCKED_USER_ID: Final[str] = constants.BlockRelationshipFields.BLOCKED_USER_ID
+BLOCKED_USER: Final[str] = constants.BlockRelationshipFields.BLOCKED_USER
+
+CODE_INVALID: Final[str] = users_constants.Code.INVALID
+CODE_NOT_EXISTS: Final[str] = users_constants.Code.NOT_EXISTS
+CODE_INTERNAL_ERROR: Final[str] = users_constants.Code.INTERNAL_ERROR
+
+
+class BlockRelationshipCreateSerializerTests(TestCase):
+    def setUp(self) -> None:
+        """
+        TestCaseのsetUpメソッドのオーバーライド
+        """
+
+        def _create_user(user_data: dict, player_data: dict) -> User:
+            user: User = User.objects.create_user(**user_data)
+            player_data[USER] = user
+            players_models.Player.objects.create(**player_data)
+            return user
+
+        # 2人のuserを作成
+        self.user_data_1: dict = {
+            USERNAME: "testuser1",
+            EMAIL: "testuser1@example.com",
+            PASSWORD: "testpassword",
+        }
+        self.user_data_2: dict = {
+            USERNAME: "testuser2",
+            EMAIL: "testuser2@example.com",
+            PASSWORD: "testpassword",
+        }
+        self.player_data_1: dict = {
+            DISPLAY_NAME: "display_name1",
+        }
+        self.player_data_2: dict = {
+            DISPLAY_NAME: "display_name2",
+        }
+        self.user1: User = _create_user(self.user_data_1, self.player_data_1)
+        self.user2: User = _create_user(self.user_data_2, self.player_data_2)
+
+    def test_valid_block_relationship_create(self) -> None:
+        """
+        正常にブロックできることを確認
+        """
+        # user1がuser2をブロックする
+        block_relationship_data: dict = {
+            BLOCKED_USER_ID: self.user2.id,
+        }
+        create_serializer: create_serializers.BlockRelationshipCreateSerializer = create_serializers.BlockRelationshipCreateSerializer(
+            data=block_relationship_data, context={USER_ID: self.user1.id}
+        )
+
+        # validate()確認
+        self.assertTrue(create_serializer.is_valid())
+        self.assertEqual(
+            create_serializer.validated_data,
+            {BLOCKED_USER: {ID: self.user2.id}},
+        )
+        # create()確認
+        create_serializer.save()
+        self.assertEqual(
+            create_serializer.data,
+            {
+                BLOCKED_USER: {
+                    ID: self.user2.id,
+                    USERNAME: self.user_data_2[USERNAME],
+                    DISPLAY_NAME: self.player_data_2[DISPLAY_NAME],
+                    AVATAR: "/media/avatars/sample.png",  # todo: デフォルト画像が変更になったら修正
+                    IS_FRIEND: False,
+                    # todo: is_blocked,is_online,win_match,lose_match追加
+                },
+            },
+        )
+
+    def test_error_same_user(self) -> None:
+        """
+        自分自身をブロックしようとした場合にエラーになることを確認
+        """
+        # user1が自分自身をブロックしようとする
+        block_relationship_data: dict = {
+            BLOCKED_USER_ID: self.user1.id,
+        }
+        create_serializer: create_serializers.BlockRelationshipCreateSerializer = create_serializers.BlockRelationshipCreateSerializer(
+            data=block_relationship_data, context={USER_ID: self.user1.id}
+        )
+
+        self.assertFalse(create_serializer.is_valid())
+        self.assertIn(BLOCKED_USER_ID, create_serializer.errors)
+        self.assertEqual(
+            create_serializer.errors[BLOCKED_USER_ID][0].code,
+            CODE_INTERNAL_ERROR,
+        )
+
+    def test_error_already_block(self) -> None:
+        """
+        既にブロックしているユーザーをブロックしようとした場合にエラーになることを確認
+        """
+        # user1がuser2をブロックする
+        models.BlockRelationship.objects.create(
+            user=self.user1, blocked_user=self.user2
+        )
+        # 再度、user1がuser2をブロックしようとする
+        block_relationship_data: dict = {
+            BLOCKED_USER_ID: self.user2.id,
+        }
+        create_serializer: create_serializers.BlockRelationshipCreateSerializer = create_serializers.BlockRelationshipCreateSerializer(
+            data=block_relationship_data, context={USER_ID: self.user1.id}
+        )
+
+        self.assertFalse(create_serializer.is_valid())
+        self.assertIn(BLOCKED_USER_ID, create_serializer.errors)
+        self.assertEqual(
+            create_serializer.errors[BLOCKED_USER_ID][0].code,
+            CODE_INVALID,
+        )
+
+    def test_not_exist_block_user(self) -> None:
+        """
+        存在しないユーザーをブロックしようとした場合にエラーになることを確認
+        """
+        # user1が存在しないユーザーをブロックしようとする
+        block_relationship_data: dict = {
+            BLOCKED_USER_ID: 9999,
+        }
+        create_serializer: create_serializers.BlockRelationshipCreateSerializer = create_serializers.BlockRelationshipCreateSerializer(
+            data=block_relationship_data, context={USER_ID: self.user1.id}
+        )
+
+        self.assertFalse(create_serializer.is_valid())
+        self.assertIn(BLOCKED_USER_ID, create_serializer.errors)
+        self.assertEqual(
+            create_serializer.errors[BLOCKED_USER_ID][0].code,
+            CODE_NOT_EXISTS,
+        )
+
+    # todo: requestから取得するblocked_user_idがNoneの場合のテストを追加(今は自動でcode="null"が返る)
+
+    def test_error_not_player(self) -> None:
+        """
+        紐づくPlayerが存在しないユーザー(superuser含む)をブロックしようとした場合にエラーになることを確認
+        """
+        # user2に紐づくPlayer情報のみ削除
+        players_models.Player.objects.get(user=self.user2).delete()
+        # user1が、Player情報を持たないuser2をブロックしようとする
+        block_relationship_data: dict = {
+            BLOCKED_USER_ID: self.user2.id,
+        }
+        create_serializer: create_serializers.BlockRelationshipCreateSerializer = create_serializers.BlockRelationshipCreateSerializer(
+            data=block_relationship_data, context={USER_ID: self.user1.id}
+        )
+
+        self.assertFalse(create_serializer.is_valid())
+        self.assertIn(BLOCKED_USER_ID, create_serializer.errors)
+        self.assertEqual(
+            create_serializer.errors[BLOCKED_USER_ID][0].code,
+            CODE_NOT_EXISTS,
+        )

--- a/backend/pong/users/blocks/serializers/validators.py
+++ b/backend/pong/users/blocks/serializers/validators.py
@@ -1,0 +1,78 @@
+from rest_framework import serializers
+
+from accounts.player import models as players_models
+from users import constants as users_constants
+
+from .. import constants, models
+
+
+def invalid_same_user_validator(user_id: int, block_user_id: int) -> None:
+    """
+    BlockRelationshipに渡すblock_user_idが自分自身である場合に例外を発生させる
+    create,destroyのserializerのvalidate()で呼ばれる想定
+
+    Args:
+        user_id: リクエストを送信したユーザーのID
+        block_user_id: ブロック追加対象・削除対象のユーザーのID
+
+    Raises:
+        serializers.ValidationError: ブロック追加・削除したいユーザーが自分自身の場合
+    """
+    if user_id == block_user_id:
+        raise serializers.ValidationError(
+            {
+                constants.BlockRelationshipFields.BLOCKED_USER_ID: "The blocked_user_id cannot be the same as user_id."
+            },
+            code=users_constants.Code.INTERNAL_ERROR,
+        )
+
+
+def _is_block_relationship_exists(user_id: int, block_user_id: int) -> bool:
+    """
+    user_idがblock_user_idをブロック済みであるかどうかを返す
+
+    Args:
+        user_id: リクエストを送信したユーザーのID
+        block_user_id: ブロック追加対象・削除対象のユーザーのID
+
+    Returns:
+        bool: user_idがblock_user_idを既にブロックしていればTrue、そうでなければFalse
+
+    Raises:
+        serializers.ValidationError: ブロックしたいidがDBに存在せず、ブロック済みかどうかの判定ができない場合
+    """
+    # ブロックに追加したいidのPlayerがDBに存在しない場合はエラー
+    if not players_models.Player.objects.filter(
+        user_id=block_user_id
+    ).exists():
+        raise serializers.ValidationError(
+            {
+                constants.BlockRelationshipFields.BLOCKED_USER_ID: "The user does not exist."
+            },
+            code=users_constants.Code.NOT_EXISTS,
+        )
+    # ブロック済みであるかどうか
+    return models.BlockRelationship.objects.filter(
+        user_id=user_id, blocked_user_id=block_user_id
+    ).exists()
+
+
+def already_block_validator(user_id: int, block_user_id: int) -> None:
+    """
+    user_idがblock_user_idをブロック済みである場合に例外を発生させる
+    createのserializerのvalidate()で呼ばれる想定
+
+    Args:
+        user_id: リクエストを送信したユーザーのID
+        block_user_id: ブロック対象のユーザーのID
+
+    Raises:
+        serializers.ValidationError: ブロックしたいユーザーがブロック済みである場合
+    """
+    if _is_block_relationship_exists(user_id, block_user_id):
+        raise serializers.ValidationError(
+            {
+                constants.BlockRelationshipFields.BLOCKED_USER_ID: "The user is already blocked."
+            },
+            code=users_constants.Code.INVALID,
+        )

--- a/backend/pong/users/blocks/tests/integration/test_create_views.py
+++ b/backend/pong/users/blocks/tests/integration/test_create_views.py
@@ -1,0 +1,224 @@
+from typing import Final
+
+from django.contrib.auth.models import User
+from django.urls import reverse
+from rest_framework import response as drf_response
+from rest_framework import status, test
+
+from accounts import constants as accounts_constants
+from accounts.player import models as players_models
+from pong.custom_response import custom_response
+from users import constants as users_constants
+
+from ... import constants, models
+
+ID: Final[str] = accounts_constants.UserFields.ID
+USERNAME: Final[str] = accounts_constants.UserFields.USERNAME
+EMAIL: Final[str] = accounts_constants.UserFields.EMAIL
+PASSWORD: Final[str] = accounts_constants.UserFields.PASSWORD
+USER: Final[str] = accounts_constants.PlayerFields.USER
+DISPLAY_NAME: Final[str] = accounts_constants.PlayerFields.DISPLAY_NAME
+AVATAR: Final[str] = accounts_constants.PlayerFields.AVATAR
+IS_FRIEND: Final[str] = users_constants.UsersFields.IS_FRIEND
+
+USER_ID: Final[str] = constants.BlockRelationshipFields.USER_ID
+BLOCKED_USER_ID: Final[str] = constants.BlockRelationshipFields.BLOCKED_USER_ID
+BLOCKED_USER: Final[str] = constants.BlockRelationshipFields.BLOCKED_USER
+
+DATA: Final[str] = custom_response.DATA
+CODE: Final[str] = custom_response.CODE
+
+
+class BlocksCreateViewTests(test.APITestCase):
+    def setUp(self) -> None:
+        """
+        APITestCaseのsetUpメソッドのオーバーライド
+        """
+        # POSTもlistで取得するらしい
+        self.url: str = reverse("users:blocks:blocks-list")
+
+        def _create_user_and_related_player(
+            user_data: dict, player_data: dict
+        ) -> tuple[User, players_models.Player]:
+            user: User = User.objects.create_user(**user_data)
+            player_data[USER] = user
+            player: players_models.Player = (
+                players_models.Player.objects.create(**player_data)
+            )
+            return user, player
+
+        # 2人のuserを作成
+        self.user_data1: dict = {
+            USERNAME: "testuser1",
+            EMAIL: "testuser1@example.com",
+            PASSWORD: "password",
+        }
+        self.user_data2: dict = {
+            USERNAME: "testuser2",
+            EMAIL: "testuser2@example.com",
+            PASSWORD: "password",
+        }
+        self.player_data1: dict = {
+            DISPLAY_NAME: "display_name1",
+        }
+        self.player_data2: dict = {
+            DISPLAY_NAME: "display_name2",
+        }
+        self.user1, self.player1 = _create_user_and_related_player(
+            self.user_data1, self.player_data1
+        )
+        self.user2, self.player2 = _create_user_and_related_player(
+            self.user_data2, self.player_data2
+        )
+
+        # user1がtokenを取得してログイン
+        # todo: 自作jwtができたらnamespaceを変更
+        token_url: str = reverse("simple_jwt:token_obtain_pair")
+        token_response: drf_response.Response = self.client.post(
+            token_url,
+            {
+                USERNAME: self.user_data1[USERNAME],
+                PASSWORD: self.user_data1[PASSWORD],
+            },
+            format="json",
+        )
+        self.client.credentials(
+            HTTP_AUTHORIZATION="Bearer " + token_response.data["access"]
+        )
+
+    def test_201_valid_block_relationship_create(self) -> None:
+        """
+        正常にブロックできることを確認
+        """
+        # user1がuser2をブロックする
+        block_relationship_data: dict = {
+            BLOCKED_USER_ID: self.user2.id,
+        }
+        response: drf_response.Response = self.client.post(
+            self.url, block_relationship_data, format="json"
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(
+            response.data[DATA],
+            {
+                BLOCKED_USER: {
+                    ID: self.user2.id,
+                    USERNAME: self.user_data2[USERNAME],
+                    DISPLAY_NAME: self.player_data2[DISPLAY_NAME],
+                    AVATAR: "/media/avatars/sample.png",  # todo: デフォルト画像が変更になったら修正
+                    IS_FRIEND: False,
+                    # todo: is_blocked,is_online,win_match,lose_match追加
+                },
+            },
+        )
+        self.assertTrue(
+            models.BlockRelationship.objects.filter(
+                user=self.user1, blocked_user=self.user2
+            ).exists()
+        )
+
+    def test_400_invalid_same_user(self) -> None:
+        """
+        自分自身をブロックしようとした場合にエラーでcode=internal_errorが返ることを確認
+        """
+        # user1が自分自身をブロックしようとする
+        block_relationship_data: dict = {
+            BLOCKED_USER_ID: self.user1.id,
+        }
+        response: drf_response.Response = self.client.post(
+            self.url, block_relationship_data, format="json"
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(
+            response.data[CODE][0], users_constants.Code.INTERNAL_ERROR
+        )
+        self.assertFalse(
+            models.BlockRelationship.objects.filter(user=self.user1).exists()
+        )
+
+    def test_400_already_block(self) -> None:
+        """
+        既にブロックしているユーザーをブロックしようとした場合に
+        エラーでcode=invalidが返ることを確認
+        """
+        # user1がuser2をブロックする
+        models.BlockRelationship.objects.create(
+            user=self.user1, blocked_user=self.user2
+        )
+        # 再度、user1がuser2をブロックしようとする
+        block_relationship_data: dict = {
+            BLOCKED_USER_ID: self.user2.id,
+        }
+        response: drf_response.Response = self.client.post(
+            self.url, block_relationship_data, format="json"
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data[CODE][0], users_constants.Code.INVALID)
+        self.assertTrue(
+            models.BlockRelationship.objects.filter(user=self.user1).exists()
+        )
+
+    def test_400_not_exist_block_user(self) -> None:
+        """
+        存在しないユーザーをブロックしようとした場合にエラーcode=not_existsが返ることを確認
+        """
+        # user1が存在しないユーザーをブロックしようとする
+        block_relationship_data: dict = {
+            BLOCKED_USER_ID: 9999,
+        }
+        response: drf_response.Response = self.client.post(
+            self.url, block_relationship_data, format="json"
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(
+            response.data[CODE][0], users_constants.Code.NOT_EXISTS
+        )
+        self.assertFalse(
+            models.BlockRelationship.objects.filter(user=self.user1).exists()
+        )
+
+    def test_400_not_player(self) -> None:
+        """
+        紐づくPlayerが存在しないユーザー(superuser含む)をブロックしようとした場合に
+        エラーでcode=not_existsが返ることを確認
+        """
+        # user2に紐づくPlayer情報のみ削除
+        players_models.Player.objects.get(user=self.user2).delete()
+        # user1が、Player情報を持たないuser2をブロックしようとする
+        block_relationship_data: dict = {
+            BLOCKED_USER_ID: self.user2.id,
+        }
+        response: drf_response.Response = self.client.post(
+            self.url, block_relationship_data, format="json"
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(
+            response.data[CODE][0], users_constants.Code.NOT_EXISTS
+        )
+        self.assertFalse(
+            models.BlockRelationship.objects.filter(user=self.user1).exists()
+        )
+
+    def test_401_unauthenticated_user(self) -> None:
+        """
+        認証されていないユーザーがブロックしようとするとエラーになることを確認
+        """
+        # 認証情報をクリア
+        self.client.credentials()
+
+        block_relationship_data: dict = {
+            BLOCKED_USER_ID: self.user2.id,
+        }
+        response: drf_response.Response = self.client.post(
+            self.url, block_relationship_data, format="json"
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        # DRFのpermission_classesによりエラーが返るため、自作のResponse formatではない
+        # todo: permissions_classesを変更して自作Responseを返せる場合、併せてresponse.data[CODE]を見るように変更する
+        self.assertEqual(response.data["detail"].code, "not_authenticated")


### PR DESCRIPTION
## タスクやディスカッションのリンク
<!-- - URLをここに貼る -->
- #353 
- blocks 流れ : #228 

## やったこと
<!-- - このタスクでやったことはなにか？ -->
フレンドと全く同じなので、mtg で話したように POST メソッド関連をまとめて PR を出しているため多くなってしまっています
- 特定の人をブロックに追加する、 `/api/users/me/blocks/`, `POST` のエンドポイント実装を追加しました
  - create() 専用の `serializer` 追加
  - serializer の unit test 追加
  - `create()` の view 追加
  - view の integration test 追加

## やらないこと
<!-- - このタスクでやらないことはなにか？（やらない場合いつやるのか？無ければ「なし」を記述） -->
DELETE メソッドは別 PR

## 動作確認
<!-- - どのような動作確認を行い、結果はどうだったのか？(適宜スクショ等添付) -->
swagger-ui にて
- `201` : 存在するユーザーをブロックに追加し、201 が返ること
- ブロック一覧取得をするとブロック追加したユーザーが含まれること
- `400`, code=`not_exists` : 存在しないユーザーをブロックしようとした場合
- `400`, code=`invalid` : 既にブロック済みのユーザーを再度ブロックしようとした場合
- `400`, code=`Internal_error` : ログインユーザー自身をブロックしようとした場合
- `401` : ログインしていない場合


## 特にレビューをお願いしたい箇所
<!-- - 特にチェックをお願いしたいポイントを簡潔に記述する -->
動作確認のみで大丈夫かと思います

## その他
<!-- - 実装上の懸念点、注意点等あれば記載する -->
特になし

## 参考リンク
<!-- - 実装に際し参考にした、記事やサイトのリンクを記載する -->
Notion, code rule : https://www.notion.so/440370c7d06c497abfda19ac0fbc95e7?pvs=4#fa89571981fe4c699966725e69e01cbb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- ユーザー同士のブロック操作が強化され、自己ブロック、既にブロック済み、存在しないユーザー、無効なアカウントに対する操作時に適切なエラーメッセージが表示されるようになりました。安全な処理と直感的なフィードバックが実現され、ユーザー体験が向上しています。

- **Tests**
	- 各種シナリオを網羅する自動テストが導入され、機能の堅牢性と品質が一層保証されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->