### PR TITLE
🌱 [blocks] `/api/users/me/blocks/{id}`, `DELETE` 実装 (ブロック解除)

### DIFF
--- a/backend/pong/users/blocks/serializers/destroy_serializers.py
+++ b/backend/pong/users/blocks/serializers/destroy_serializers.py
@@ -1,0 +1,37 @@
+from rest_framework import serializers
+
+from .. import constants, models
+from . import validators
+
+
+class BlockRelationshipDestroySerializer(serializers.ModelSerializer):
+    blocked_user_id = serializers.IntegerField(
+        source="blocked_user.id", min_value=1, write_only=True
+    )
+
+    class Meta:
+        model = models.BlockRelationship
+        fields = (constants.BlockRelationshipFields.BLOCKED_USER_ID,)
+
+    def validate(self, data: dict) -> dict:
+        """
+        is_valid()内で呼ばれるvalidate()のオーバーライド
+
+        Raises:
+            serializers.ValidationError
+              - ブロック解除したいユーザーをブロックしていない場合
+              - 自分自身をブロック解除しようとした場合
+              - ブロック解除したいユーザーが存在しない場合
+        """
+        user_id: int = self.context[constants.BlockRelationshipFields.USER_ID]
+        blocked_user_id: int = data[
+            constants.BlockRelationshipFields.BLOCKED_USER
+        ][constants.BlockRelationshipFields.ID]
+
+        # 自分自身をブロック解除しようとした場合にValidationErrorを発生させる
+        validators.invalid_same_user_validator(user_id, blocked_user_id)
+
+        # ブロック解除したいユーザーをブロックしていない場合にValidationErrorを発生させる
+        validators.not_block_validator(user_id, blocked_user_id)
+
+        return data

--- a/backend/pong/users/blocks/serializers/tests/test_destroy_serializers.py
+++ b/backend/pong/users/blocks/serializers/tests/test_destroy_serializers.py
@@ -1,0 +1,168 @@
+from typing import Final
+
+from django.contrib.auth.models import User
+from django.test import TestCase
+
+from accounts import constants as accounts_constants
+from accounts.player import models as players_models
+from users import constants as users_constants
+
+from ... import constants, models
+from .. import destroy_serializers
+
+ID: Final[str] = accounts_constants.UserFields.ID
+USERNAME: Final[str] = accounts_constants.UserFields.USERNAME
+EMAIL: Final[str] = accounts_constants.UserFields.EMAIL
+PASSWORD: Final[str] = accounts_constants.UserFields.PASSWORD
+USER: Final[str] = accounts_constants.PlayerFields.USER
+DISPLAY_NAME: Final[str] = accounts_constants.PlayerFields.DISPLAY_NAME
+
+USER_ID: Final[str] = constants.BlockRelationshipFields.USER_ID
+BLOCKED_USER_ID: Final[str] = constants.BlockRelationshipFields.BLOCKED_USER_ID
+BLOCKED_USER: Final[str] = constants.BlockRelationshipFields.BLOCKED_USER
+
+CODE_INVALID: Final[str] = users_constants.Code.INVALID
+CODE_NOT_EXISTS: Final[str] = users_constants.Code.NOT_EXISTS
+CODE_INTERNAL_ERROR: Final[str] = users_constants.Code.INTERNAL_ERROR
+
+
+class BlockRelationshipDestroySerializerTests(TestCase):
+    def setUp(self) -> None:
+        """
+        TestCaseのsetUpメソッドのオーバーライド
+        """
+
+        def _create_user(user_data: dict, player_data: dict) -> User:
+            user: User = User.objects.create_user(**user_data)
+            player_data[USER] = user
+            players_models.Player.objects.create(**player_data)
+            return user
+
+        # 2人のuserを作成
+        self.user_data_1: dict = {
+            USERNAME: "testuser1",
+            EMAIL: "testuser1@example.com",
+            PASSWORD: "testpassword",
+        }
+        self.user_data_2: dict = {
+            USERNAME: "testuser2",
+            EMAIL: "testuser2@example.com",
+            PASSWORD: "testpassword",
+        }
+        self.player_data_1: dict = {
+            DISPLAY_NAME: "display_name1",
+        }
+        self.player_data_2: dict = {
+            DISPLAY_NAME: "display_name2",
+        }
+        self.user1: User = _create_user(self.user_data_1, self.player_data_1)
+        self.user2: User = _create_user(self.user_data_2, self.player_data_2)
+
+        # user1がuser2をブロック
+        self.block_relationship: models.BlockRelationship = (
+            models.BlockRelationship.objects.create(
+                user=self.user1, blocked_user=self.user2
+            )
+        )
+
+    def test_valid_block_relationship_destroy(self) -> None:
+        """
+        正常にブロック解除ができることを確認
+        """
+        block_relationship_data: dict = {BLOCKED_USER_ID: self.user2.id}
+        destroy_serializer: destroy_serializers.BlockRelationshipDestroySerializer = destroy_serializers.BlockRelationshipDestroySerializer(
+            data=block_relationship_data, context={USER_ID: self.user1.id}
+        )
+
+        # validate()確認
+        self.assertTrue(destroy_serializer.is_valid())
+        self.assertEqual(
+            destroy_serializer.validated_data,
+            {BLOCKED_USER: {ID: self.user2.id}},
+        )
+        # destroy()確認
+        block_relationship: models.BlockRelationship = (
+            models.BlockRelationship.objects.get(
+                user=self.user1, blocked_user=self.user2
+            )
+        )
+        block_relationship.delete()
+        self.assertFalse(
+            models.BlockRelationship.objects.filter(
+                user=self.user1, blocked_user=self.user2
+            ).exists()
+        )
+
+    def test_error_same_user(self) -> None:
+        """
+        自分自身をブロック解除しようとした場合にエラーが発生することを確認
+        """
+        # user1が自分自身をブロック解除しようとする
+        block_relationship_data: dict = {BLOCKED_USER_ID: self.user1.id}
+        destroy_serializer: destroy_serializers.BlockRelationshipDestroySerializer = destroy_serializers.BlockRelationshipDestroySerializer(
+            data=block_relationship_data, context={USER_ID: self.user1.id}
+        )
+
+        self.assertFalse(destroy_serializer.is_valid())
+        self.assertIn(BLOCKED_USER_ID, destroy_serializer.errors)
+        self.assertEqual(
+            destroy_serializer.errors[BLOCKED_USER_ID][0].code,
+            CODE_INTERNAL_ERROR,
+        )
+
+    def test_error_already_not_block(self) -> None:
+        """
+        ブロックしていないユーザーをブロック解除しようとした場合にエラーが発生することを確認
+        """
+        # user1がuser2をブロック解除する
+        self.block_relationship.delete()
+        # user1が再度user2をブロック解除しようとする
+        block_relationship_data: dict = {BLOCKED_USER_ID: self.user2.id}
+        destroy_serializer: destroy_serializers.BlockRelationshipDestroySerializer = destroy_serializers.BlockRelationshipDestroySerializer(
+            data=block_relationship_data, context={USER_ID: self.user1.id}
+        )
+
+        self.assertFalse(destroy_serializer.is_valid())
+        self.assertIn(BLOCKED_USER_ID, destroy_serializer.errors)
+        self.assertEqual(
+            destroy_serializer.errors[BLOCKED_USER_ID][0].code,
+            CODE_INVALID,
+        )
+
+    def test_error_not_exist_block_user(self) -> None:
+        """
+        存在しないユーザーをブロック解除しようとした場合にエラーが発生することを確認
+        """
+        # user1が、存在しないユーザーをブロック解除しようとする
+        block_relationship_data: dict = {
+            BLOCKED_USER_ID: 9999
+        }  # 存在しないユーザー
+        destroy_serializer: destroy_serializers.BlockRelationshipDestroySerializer = destroy_serializers.BlockRelationshipDestroySerializer(
+            data=block_relationship_data, context={USER_ID: self.user1.id}
+        )
+
+        self.assertFalse(destroy_serializer.is_valid())
+        self.assertIn(BLOCKED_USER_ID, destroy_serializer.errors)
+        self.assertEqual(
+            destroy_serializer.errors[BLOCKED_USER_ID][0].code,
+            CODE_NOT_EXISTS,
+        )
+
+    def test_error_not_player(self) -> None:
+        """
+        紐づくPlayerが存在しないユーザー(superuser含む)をブロック解除しようとした場合にエラーになることを確認
+        """
+        # user2に紐づくPlayer情報のみ削除
+        players_models.Player.objects.get(user=self.user2).delete()
+        # user1が、Player情報を持たないuser2をブロック解除しようとする
+        block_relationship_data: dict = {BLOCKED_USER_ID: self.user2.id}
+        destroy_serializer: destroy_serializers.BlockRelationshipDestroySerializer = destroy_serializers.BlockRelationshipDestroySerializer(
+            data=block_relationship_data, context={USER_ID: self.user1.id}
+        )
+
+        self.assertFalse(destroy_serializer.is_valid())
+        self.assertIn(BLOCKED_USER_ID, destroy_serializer.errors)
+        self.assertEqual(
+            destroy_serializer.errors[BLOCKED_USER_ID][0].code,
+            CODE_NOT_EXISTS,
+        )

--- a/backend/pong/users/blocks/serializers/validators.py
+++ b/backend/pong/users/blocks/serializers/validators.py
@@ -76,3 +76,24 @@ def already_block_validator(user_id: int, block_user_id: int) -> None:
             },
             code=users_constants.Code.INVALID,
         )
+
+
+def not_block_validator(user_id: int, block_user_id: int) -> None:
+    """
+    user_idがblock_user_idをブロックしていない場合に例外を発生させる
+    destroyのserializerのvalidate()で呼ばれる想定
+
+    Args:
+        user_id: リクエストを送信したユーザーのID
+        block_user_id: ブロック解除対象のユーザーのID
+
+    Raises:
+        serializers.ValidationError: ブロック解除したいユーザーをブロックしていない場合
+    """
+    if not _is_block_relationship_exists(user_id, block_user_id):
+        raise serializers.ValidationError(
+            {
+                constants.BlockRelationshipFields.BLOCKED_USER_ID: "The user is not blocked."
+            },
+            code=users_constants.Code.INVALID,
+        )

--- a/backend/pong/users/blocks/tests/integration/test_destroy_views.py
+++ b/backend/pong/users/blocks/tests/integration/test_destroy_views.py
@@ -1,0 +1,187 @@
+from typing import Final
+
+from django.contrib.auth.models import User
+from django.urls import reverse
+from rest_framework import response as drf_response
+from rest_framework import status, test
+
+from accounts import constants as accounts_constants
+from accounts.player import models as players_models
+from pong.custom_response import custom_response
+from users import constants as users_constants
+
+from ... import models
+
+USERNAME: Final[str] = accounts_constants.UserFields.USERNAME
+EMAIL: Final[str] = accounts_constants.UserFields.EMAIL
+PASSWORD: Final[str] = accounts_constants.UserFields.PASSWORD
+USER: Final[str] = accounts_constants.PlayerFields.USER
+DISPLAY_NAME: Final[str] = accounts_constants.PlayerFields.DISPLAY_NAME
+
+DATA: Final[str] = custom_response.DATA
+CODE: Final[str] = custom_response.CODE
+
+CODE_INVALID: Final[str] = users_constants.Code.INVALID
+CODE_NOT_EXISTS: Final[str] = users_constants.Code.NOT_EXISTS
+CODE_INTERNAL_ERROR: Final[str] = users_constants.Code.INTERNAL_ERROR
+
+
+class BlocksDestroyViewTests(test.APITestCase):
+    def setUp(self) -> None:
+        """
+        APITestCaseのsetUpメソッドのオーバーライド
+        """
+
+        def _create_user_and_related_player(
+            user_data: dict, player_data: dict
+        ) -> tuple[User, players_models.Player]:
+            user: User = User.objects.create_user(**user_data)
+            player_data[USER] = user
+            player: players_models.Player = (
+                players_models.Player.objects.create(**player_data)
+            )
+            return user, player
+
+        # 2人のuserを作成
+        self.user_data1: dict = {
+            USERNAME: "testuser1",
+            EMAIL: "testuser1@example.com",
+            PASSWORD: "password",
+        }
+        self.user_data2: dict = {
+            USERNAME: "testuser2",
+            EMAIL: "testuser2@example.com",
+            PASSWORD: "password",
+        }
+        self.player_data1: dict = {
+            DISPLAY_NAME: "display_name1",
+        }
+        self.player_data2: dict = {
+            DISPLAY_NAME: "display_name2",
+        }
+        self.user1, self.player1 = _create_user_and_related_player(
+            self.user_data1, self.player_data1
+        )
+        self.user2, self.player2 = _create_user_and_related_player(
+            self.user_data2, self.player_data2
+        )
+
+        # user1が、user2をブロックする
+        self.block_relationship: models.BlockRelationship = (
+            models.BlockRelationship.objects.create(
+                user=self.user1, blocked_user=self.user2
+            )
+        )
+
+        # user1がtokenを取得してログイン
+        # todo: 自作jwtができたらnamespaceを変更
+        token_url: str = reverse("simple_jwt:token_obtain_pair")
+        token_response: drf_response.Response = self.client.post(
+            token_url,
+            {
+                USERNAME: self.user_data1[USERNAME],
+                PASSWORD: self.user_data1[PASSWORD],
+            },
+            format="json",
+        )
+        self.client.credentials(
+            HTTP_AUTHORIZATION="Bearer " + token_response.data["access"]
+        )
+
+    def _create_url(self, blocked_user_id: int) -> str:
+        # /api/*/{id}/ の形の場合はdetail
+        return reverse(
+            "users:blocks:blocks-detail",
+            kwargs={"blocked_user_id": blocked_user_id},
+        )
+
+    def test_204_delete_block(self) -> None:
+        """
+        正常にブロック解除をできることを確認
+        """
+        response: drf_response.Response = self.client.delete(
+            self._create_url(self.user2.id)
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertEqual(response.data[DATA], {})
+        self.assertFalse(
+            models.BlockRelationship.objects.filter(
+                user=self.user1, blocked_user=self.user2
+            ).exists()
+        )
+
+    def test_401_unauthenticated_user(self) -> None:
+        """
+        認証されていないユーザーがブロック解除しようとするとエラーになることを確認
+        """
+        # user1の認証情報をクリア
+        self.client.credentials()
+        # ログインしていないuser1がuser2をブロック解除しようとする
+        response: drf_response.Response = self.client.delete(
+            self._create_url(self.user2.id)
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        # DRFのpermission_classesによりエラーが返るため、自作のResponse formatではない
+        # todo: permissions_classesを変更して自作Responseを返せる場合、併せてresponse.data[CODE]を見るように変更する
+        self.assertEqual(response.data["detail"].code, "not_authenticated")
+
+    def test_404_delete_not_block(self) -> None:
+        """
+        ブロックしていないユーザーをブロック解除しようとするとエラーになることを確認
+        """
+        # user1がuser2をブロック解除する
+        self.block_relationship.delete()
+        # 再度user1がuser2をブロック解除しようとする
+        response: drf_response.Response = self.client.delete(
+            self._create_url(self.user2.id)
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(response.data[CODE][0], CODE_INVALID)
+        self.assertFalse(
+            models.BlockRelationship.objects.filter(
+                user=self.user1, blocked_user=self.user2
+            ).exists()
+        )
+
+    def test_404_delete_same_user(self) -> None:
+        """
+        自分自身をブロック解除しようとするとエラーになることを確認
+        """
+        # user1が自分自身をブロック解除
+        response: drf_response.Response = self.client.delete(
+            self._create_url(self.user1.id)
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(response.data[CODE][0], CODE_INTERNAL_ERROR)
+
+    def test_404_delete_not_exist_user(self) -> None:
+        """
+        存在しないユーザーをブロック解除しようとするとエラーになることを確認
+        """
+        # 存在しないユーザーをブロック解除
+        response: drf_response.Response = self.client.delete(
+            self._create_url(9999)
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(response.data[CODE][0], CODE_NOT_EXISTS)
+
+    def test_404_not_player(self) -> None:
+        """
+        紐づくPlayerが存在しないユーザー(superuser含む)をブロック解除しようとした場合にエラーになることを確認
+        """
+        # user2に紐づくPlayer情報のみ削除
+        players_models.Player.objects.get(user=self.user2).delete()
+        # user1が、Player情報を持たないuser2をブロック解除しようとする
+        response: drf_response.Response = self.client.delete(
+            self._create_url(self.user2.id)
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(
+            response.data[CODE][0], users_constants.Code.NOT_EXISTS
+        )


### PR DESCRIPTION
## タスクやディスカッションのリンク
<!-- - URLをここに貼る -->
- #354 
- blocks 流れ : #228 

## やったこと
<!-- - このタスクでやったことはなにか？ -->
フレンドと全く同じなので、mtg で話したように DELETE メソッド関連をまとめて PR を出しているため多くなってしまっています
- 特定の人をブロック解除する、 `/api/users/me/blocks/{id}`, `DELETE` のエンドポイント実装を追加しました
  - destroy() 専用の `serializer` 追加
  - serializer の unit test 追加
  - `destroy()` の view 追加
  - view の integration test 追加

## やらないこと
<!-- - このタスクでやらないことはなにか？（やらない場合いつやるのか？無ければ「なし」を記述） -->
特になし

## 動作確認
<!-- - どのような動作確認を行い、結果はどうだったのか？(適宜スクショ等添付) -->
swagger-ui にて
- `204` : ブロックしているユーザーのブロックを解除し、204 が返ること
- ブロック一覧取得をするとブロック解除したユーザーは含まれないこと
- `401` : ログインしていない場合
- `404`,code=`not_exists` : 存在しないユーザーをブロック解除しようとした場合
- `404`, code=`invalid` : ブロックしていないユーザーをブロック解除しようとした場合
- `404`, code=`Internal_error` : ログインユーザー自身をブロック解除しようとした場合


## 特にレビューをお願いしたい箇所
<!-- - 特にチェックをお願いしたいポイントを簡潔に記述する -->
動作確認のみで大丈夫かと思います

## その他
<!-- - 実装上の懸念点、注意点等あれば記載する -->
ブロック関連はこれで終わりです！

## 参考リンク
<!-- - 実装に際し参考にした、記事やサイトのリンクを記載する -->
Notion, code rule : https://www.notion.so/440370c7d06c497abfda19ac0fbc95e7?pvs=4#fa89571981fe4c699966725e69e01cbb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - ユーザーがブロック解除を実施できるようになり、ブロックリストから対象ユーザーを削除する新しいエンドポイントを追加しました。自己解除や無効な解除リクエストに対するバリデーションも強化されています。

- **テスト**
  - ブロック解除機能とエラーハンドリングの正確な動作を確認するため、統合テストとユニットテストを実装しました。 

<!-- end of auto-generated comment: release notes by coderabbit.ai -->