### PR TITLE
🐛 [friends] フレンドの extend_schema, test 微修正

### DIFF
--- a/backend/pong/users/friends/serializers/tests/test_destroy_serializer.py
+++ b/backend/pong/users/friends/serializers/tests/test_destroy_serializer.py
@@ -26,7 +26,7 @@ CODE_NOT_EXISTS: Final[str] = users_constants.Code.NOT_EXISTS
 CODE_INTERNAL_ERROR: Final[str] = users_constants.Code.INTERNAL_ERROR
 
 
-class FriendshipCreateSerializerTests(TestCase):
+class FriendshipDestroySerializerTests(TestCase):
     def setUp(self) -> None:
         """
         TestCaseのsetUpメソッドのオーバーライド

--- a/backend/pong/users/friends/tests/integration/test_create_views.py
+++ b/backend/pong/users/friends/tests/integration/test_create_views.py
@@ -205,12 +205,15 @@ class FriendsCreateViewTests(test.APITestCase):
 
     def test_401_unauthenticated_user(self) -> None:
         """
-        認証されていないユーザーがフレンド一覧を取得しようとするとエラーになることを確認
+        認証されていないユーザーがフレンド追加しようとするとエラーになることを確認
         """
         # 認証情報をクリア
         self.client.credentials()
+        friendship_data: dict = {
+            FRIEND_USER_ID: self.user2.id,
+        }
         response: drf_response.Response = self.client.post(
-            self.url, format="json"
+            self.url, friendship_data, format="json"
         )
 
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)

--- a/backend/pong/users/friends/tests/integration/test_destroy_views.py
+++ b/backend/pong/users/friends/tests/integration/test_destroy_views.py
@@ -26,7 +26,7 @@ CODE_NOT_EXISTS: Final[str] = users_constants.Code.NOT_EXISTS
 CODE_INTERNAL_ERROR: Final[str] = users_constants.Code.INTERNAL_ERROR
 
 
-class FriendsListViewTests(test.APITestCase):
+class FriendsDestroyViewTests(test.APITestCase):
     def setUp(self) -> None:
         """
         APITestCaseのsetUpメソッドのオーバーライド

--- a/backend/pong/users/friends/views.py
+++ b/backend/pong/users/friends/views.py
@@ -115,19 +115,16 @@ logger = logging.getLogger(__name__)
                         "Example 201 response",
                         value={
                             custom_response.STATUS: custom_response.Status.OK,
-                            custom_response.DATA: [
-                                {
-                                    constants.FriendshipFields.FRIEND: {
-                                        accounts_constants.UserFields.ID: 2,
-                                        accounts_constants.UserFields.USERNAME: "username2",
-                                        accounts_constants.PlayerFields.DISPLAY_NAME: "display_name2",
-                                        accounts_constants.PlayerFields.AVATAR: "/media/avatars/sample.png",
-                                        users_constants.UsersFields.IS_FRIEND: True,
-                                        # todo: is_blocked,is_online,win_match,lose_match追加
-                                    },
+                            custom_response.DATA: {
+                                constants.FriendshipFields.FRIEND: {
+                                    accounts_constants.UserFields.ID: 2,
+                                    accounts_constants.UserFields.USERNAME: "username2",
+                                    accounts_constants.PlayerFields.DISPLAY_NAME: "display_name2",
+                                    accounts_constants.PlayerFields.AVATAR: "/media/avatars/sample.png",
+                                    users_constants.UsersFields.IS_FRIEND: True,
+                                    # todo: is_blocked,is_online,win_match,lose_match追加
                                 },
-                                {"...", "..."},
-                            ],
+                            },
                         },
                     ),
                 ],

--- a/backend/pong/users/friends/views.py
+++ b/backend/pong/users/friends/views.py
@@ -109,7 +109,7 @@ logger = logging.getLogger(__name__)
         responses={
             201: utils.OpenApiResponse(
                 description="Successfully added a new user to the authenticated user's friends list.",
-                response=list_serializers.FriendshipListSerializer(many=True),
+                response=create_serializers.FriendshipCreateSerializer,
                 examples=[
                     utils.OpenApiExample(
                         "Example 201 response",


### PR DESCRIPTION
## タスクやディスカッションのリンク
<!-- - URLをここに貼る -->
- #367 

## やったこと
<!-- - このタスクでやったことはなにか？ -->
friends app 内の extend_schema とテストの細かいミスの修正をしました

## やらないこと
<!-- - このタスクでやらないことはなにか？（やらない場合いつやるのか？無ければ「なし」を記述） -->
上記以外

## 動作確認
<!-- - どのような動作確認を行い、結果はどうだったのか？(適宜スクショ等添付) -->
特に動作に影響がない部分のみです
swagger-ui にて、修正した `/api/users/me/friends/`, `POST` の 201 レスポンスの examples がリストではなく 1 つのデータになっていることの確認のみで大丈夫かと思います

## 特にレビューをお願いしたい箇所
<!-- - 特にチェックをお願いしたいポイントを簡潔に記述する -->
上記動作確認

## その他
<!-- - 実装上の懸念点、注意点等あれば記載する -->
特になし

## 参考リンク
<!-- - 実装に際し参考にした、記事やサイトのリンクを記載する -->
特になし

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - フレンド追加時の応答が、これまでの複数オブジェクト形式から単一オブジェクト形式に変更され、結果がよりシンプルに表示されるようになりました。
  - フレンド削除時のエラーメッセージが改善され、不正な削除操作（自身の削除や存在しないフレンドの指定など）に対して、より明確なフィードバックが提供されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->