### PR TITLE
⚡ [users] UsersSerializer に is_blocked 追加

### DIFF
--- a/backend/pong/accounts/views.py
+++ b/backend/pong/accounts/views.py
@@ -52,7 +52,8 @@ class AccountCreateView(views.APIView):
                                 constants.PlayerFields.DISPLAY_NAME: "default",
                                 constants.PlayerFields.AVATAR: "/media/avatars/sample.png",
                                 users_constants.UsersFields.IS_FRIEND: False,
-                                # todo: is_blocked,is_online,win_match,lose_match追加
+                                users_constants.UsersFields.IS_BLOCKED: False,
+                                # todo: is_online,win_match,lose_match追加
                             },
                         },
                     ),

--- a/backend/pong/users/blocks/serializers/create_serializers.py
+++ b/backend/pong/users/blocks/serializers/create_serializers.py
@@ -21,7 +21,8 @@ class BlockRelationshipCreateSerializer(serializers.ModelSerializer):
             accounts_constants.PlayerFields.DISPLAY_NAME,
             accounts_constants.PlayerFields.AVATAR,
             users_constants.UsersFields.IS_FRIEND,
-            # todo: is_blocked,is_online,win_match,lose_match追加
+            users_constants.UsersFields.IS_BLOCKED,
+            # todo: is_online,win_match,lose_match追加
         ),
     )
 

--- a/backend/pong/users/blocks/serializers/list_serializers.py
+++ b/backend/pong/users/blocks/serializers/list_serializers.py
@@ -17,7 +17,8 @@ class BlockRelationshipListSerializer(drf_serializers.ModelSerializer):
             accounts_constants.PlayerFields.DISPLAY_NAME,
             accounts_constants.PlayerFields.AVATAR,
             users_constants.UsersFields.IS_FRIEND,
-            # todo: is_blocked,is_online,win_match,lose_match追加
+            users_constants.UsersFields.IS_BLOCKED,
+            # todo: is_online,win_match,lose_match追加
         ),
     )
 

--- a/backend/pong/users/blocks/serializers/tests/test_create_serializers.py
+++ b/backend/pong/users/blocks/serializers/tests/test_create_serializers.py
@@ -18,6 +18,7 @@ USER: Final[str] = accounts_constants.PlayerFields.USER
 DISPLAY_NAME: Final[str] = accounts_constants.PlayerFields.DISPLAY_NAME
 AVATAR: Final[str] = accounts_constants.PlayerFields.AVATAR
 IS_FRIEND: Final[str] = users_constants.UsersFields.IS_FRIEND
+IS_BLOCKED: Final[str] = users_constants.UsersFields.IS_BLOCKED
 
 USER_ID: Final[str] = constants.BlockRelationshipFields.USER_ID
 BLOCKED_USER_ID: Final[str] = constants.BlockRelationshipFields.BLOCKED_USER_ID
@@ -89,7 +90,8 @@ class BlockRelationshipCreateSerializerTests(TestCase):
                     DISPLAY_NAME: self.player_data_2[DISPLAY_NAME],
                     AVATAR: "/media/avatars/sample.png",  # todo: デフォルト画像が変更になったら修正
                     IS_FRIEND: False,
-                    # todo: is_blocked,is_online,win_match,lose_match追加
+                    IS_BLOCKED: True,
+                    # todo: is_online,win_match,lose_match追加
                 },
             },
         )

--- a/backend/pong/users/blocks/serializers/tests/test_list_serializers.py
+++ b/backend/pong/users/blocks/serializers/tests/test_list_serializers.py
@@ -19,6 +19,7 @@ USER: Final[str] = accounts_constants.PlayerFields.USER
 DISPLAY_NAME: Final[str] = accounts_constants.PlayerFields.DISPLAY_NAME
 AVATAR: Final[str] = accounts_constants.PlayerFields.AVATAR
 IS_FRIEND: Final[str] = users_constants.UsersFields.IS_FRIEND
+IS_BLOCKED: Final[str] = users_constants.UsersFields.IS_BLOCKED
 
 USER_ID: Final[str] = constants.BlockRelationshipFields.USER_ID
 BLOCKED_USER: Final[str] = constants.BlockRelationshipFields.BLOCKED_USER
@@ -97,7 +98,8 @@ class BlockRelationshipListSerializerTests(TestCase):
                         DISPLAY_NAME: self.player_data_2[DISPLAY_NAME],
                         AVATAR: "/media/avatars/sample.png",  # todo: デフォルト画像が変更になったら修正
                         IS_FRIEND: False,
-                        # todo: is_blocked,is_online,win_match,lose_match追加
+                        IS_BLOCKED: True,
+                        # todo: is_online,win_match,lose_match追加
                     },
                 },
                 {
@@ -107,7 +109,8 @@ class BlockRelationshipListSerializerTests(TestCase):
                         DISPLAY_NAME: self.player_data_3[DISPLAY_NAME],
                         AVATAR: "/media/avatars/sample.png",  # todo: デフォルト画像が変更になったら修正
                         IS_FRIEND: False,
-                        # todo: is_blocked,is_online,win_match,lose_match追加
+                        IS_BLOCKED: True,
+                        # todo: is_online,win_match,lose_match追加
                     },
                 },
             ],

--- a/backend/pong/users/blocks/tests/integration/test_create_views.py
+++ b/backend/pong/users/blocks/tests/integration/test_create_views.py
@@ -20,6 +20,7 @@ USER: Final[str] = accounts_constants.PlayerFields.USER
 DISPLAY_NAME: Final[str] = accounts_constants.PlayerFields.DISPLAY_NAME
 AVATAR: Final[str] = accounts_constants.PlayerFields.AVATAR
 IS_FRIEND: Final[str] = users_constants.UsersFields.IS_FRIEND
+IS_BLOCKED: Final[str] = users_constants.UsersFields.IS_BLOCKED
 
 USER_ID: Final[str] = constants.BlockRelationshipFields.USER_ID
 BLOCKED_USER_ID: Final[str] = constants.BlockRelationshipFields.BLOCKED_USER_ID
@@ -108,7 +109,8 @@ class BlocksCreateViewTests(test.APITestCase):
                     DISPLAY_NAME: self.player_data2[DISPLAY_NAME],
                     AVATAR: "/media/avatars/sample.png",  # todo: デフォルト画像が変更になったら修正
                     IS_FRIEND: False,
-                    # todo: is_blocked,is_online,win_match,lose_match追加
+                    IS_BLOCKED: True,
+                    # todo: is_online,win_match,lose_match追加
                 },
             },
         )

--- a/backend/pong/users/blocks/tests/integration/test_list_views.py
+++ b/backend/pong/users/blocks/tests/integration/test_list_views.py
@@ -20,6 +20,7 @@ USER: Final[str] = accounts_constants.PlayerFields.USER
 DISPLAY_NAME: Final[str] = accounts_constants.PlayerFields.DISPLAY_NAME
 AVATAR: Final[str] = accounts_constants.PlayerFields.AVATAR
 IS_FRIEND: Final[str] = users_constants.UsersFields.IS_FRIEND
+IS_BLOCKED: Final[str] = users_constants.UsersFields.IS_BLOCKED
 
 BLOCKED_USER: Final[str] = constants.BlockRelationshipFields.BLOCKED_USER
 
@@ -142,7 +143,8 @@ class BlocksListViewTests(test.APITestCase):
                         DISPLAY_NAME: self.player_data2[DISPLAY_NAME],
                         AVATAR: "/media/avatars/sample.png",  # todo: デフォルト画像が変更になったら修正
                         IS_FRIEND: False,
-                        # todo: is_blocked,is_online,win_match,lose_match追加
+                        IS_BLOCKED: True,
+                        # todo: is_online,win_match,lose_match追加
                     },
                 },
                 {
@@ -152,7 +154,8 @@ class BlocksListViewTests(test.APITestCase):
                         DISPLAY_NAME: self.player_data3[DISPLAY_NAME],
                         AVATAR: "/media/avatars/sample.png",  # todo: デフォルト画像が変更になったら修正
                         IS_FRIEND: False,
-                        # todo: is_blocked,is_online,win_match,lose_match追加
+                        IS_BLOCKED: True,
+                        # todo: is_online,win_match,lose_match追加
                     },
                 },
             ],
@@ -178,7 +181,8 @@ class BlocksListViewTests(test.APITestCase):
                         DISPLAY_NAME: self.player_data3[DISPLAY_NAME],
                         AVATAR: "/media/avatars/sample.png",  # todo: デフォルト画像が変更になったら修正
                         IS_FRIEND: False,
-                        # todo: is_blocked,is_online,win_match,lose_match追加
+                        IS_BLOCKED: True,
+                        # todo: is_online,win_match,lose_match追加
                     },
                 },
             ],
@@ -204,7 +208,8 @@ class BlocksListViewTests(test.APITestCase):
                         DISPLAY_NAME: self.player_data2[DISPLAY_NAME],
                         AVATAR: "/media/avatars/sample.png",  # todo: デフォルト画像が変更になったら修正
                         IS_FRIEND: False,
-                        # todo: is_blocked,is_online,win_match,lose_match追加
+                        IS_BLOCKED: True,
+                        # todo: is_online,win_match,lose_match追加
                     },
                 },
             ],

--- a/backend/pong/users/blocks/views.py
+++ b/backend/pong/users/blocks/views.py
@@ -50,7 +50,8 @@ logger = logging.getLogger(__name__)
                                         accounts_constants.PlayerFields.DISPLAY_NAME: "display_name2",
                                         accounts_constants.PlayerFields.AVATAR: "/media/avatars/sample.png",
                                         users_constants.UsersFields.IS_FRIEND: False,
-                                        # todo: is_blocked,is_online,win_match,lose_match追加
+                                        users_constants.UsersFields.IS_BLOCKED: True,
+                                        # todo: is_online,win_match,lose_match追加
                                     },
                                 },
                                 {"...", "..."},

--- a/backend/pong/users/blocks/views.py
+++ b/backend/pong/users/blocks/views.py
@@ -127,7 +127,8 @@ logger = logging.getLogger(__name__)
                                     accounts_constants.PlayerFields.DISPLAY_NAME: "display_name2",
                                     accounts_constants.PlayerFields.AVATAR: "/media/avatars/sample.png",
                                     users_constants.UsersFields.IS_FRIEND: False,
-                                    # todo: is_blocked,is_online,win_match,lose_match追加
+                                    users_constants.UsersFields.IS_BLOCKED: True,
+                                    # todo: is_online,win_match,lose_match追加
                                 },
                             },
                         },

--- a/backend/pong/users/constants.py
+++ b/backend/pong/users/constants.py
@@ -14,4 +14,5 @@ class Code:
 @dataclasses.dataclass(frozen=True)
 class UsersFields:
     IS_FRIEND: Final[str] = "is_friend"
-    # todo: is_blocked,is_online,win_match,lose_match追加
+    IS_BLOCKED: Final[str] = "is_blocked"
+    # todo: is_online,win_match,lose_match追加

--- a/backend/pong/users/friends/serializers/create_serializers.py
+++ b/backend/pong/users/friends/serializers/create_serializers.py
@@ -21,7 +21,8 @@ class FriendshipCreateSerializer(serializers.ModelSerializer):
             accounts_constants.PlayerFields.DISPLAY_NAME,
             accounts_constants.PlayerFields.AVATAR,
             users_constants.UsersFields.IS_FRIEND,
-            # todo: is_blocked,is_online,win_match,lose_match追加
+            users_constants.UsersFields.IS_BLOCKED,
+            # todo: is_online,win_match,lose_match追加
         ),
     )
 

--- a/backend/pong/users/friends/serializers/list_serializers.py
+++ b/backend/pong/users/friends/serializers/list_serializers.py
@@ -17,7 +17,8 @@ class FriendshipListSerializer(drf_serializers.ModelSerializer):
             accounts_constants.PlayerFields.DISPLAY_NAME,
             accounts_constants.PlayerFields.AVATAR,
             users_constants.UsersFields.IS_FRIEND,
-            # todo: is_blocked,is_online,win_match,lose_match追加
+            users_constants.UsersFields.IS_BLOCKED,
+            # todo: is_online,win_match,lose_match追加
         ),
     )
 

--- a/backend/pong/users/friends/serializers/tests/test_create_serializers.py
+++ b/backend/pong/users/friends/serializers/tests/test_create_serializers.py
@@ -18,6 +18,7 @@ USER: Final[str] = accounts_constants.PlayerFields.USER
 DISPLAY_NAME: Final[str] = accounts_constants.PlayerFields.DISPLAY_NAME
 AVATAR: Final[str] = accounts_constants.PlayerFields.AVATAR
 IS_FRIEND: Final[str] = users_constants.UsersFields.IS_FRIEND
+IS_BLOCKED: Final[str] = users_constants.UsersFields.IS_BLOCKED
 
 USER_ID: Final[str] = constants.FriendshipFields.USER_ID
 FRIEND_USER_ID: Final[str] = constants.FriendshipFields.FRIEND_USER_ID
@@ -90,7 +91,8 @@ class FriendshipCreateSerializerTests(TestCase):
                     DISPLAY_NAME: self.player_data_2[DISPLAY_NAME],
                     AVATAR: "/media/avatars/sample.png",  # todo: デフォルト画像が変更になったら修正
                     IS_FRIEND: True,
-                    # todo: is_blocked,is_online,win_match,lose_match追加
+                    IS_BLOCKED: False,
+                    # todo: is_online,win_match,lose_match追加
                 },
             },
         )

--- a/backend/pong/users/friends/serializers/tests/test_list_serializers.py
+++ b/backend/pong/users/friends/serializers/tests/test_list_serializers.py
@@ -19,6 +19,7 @@ USER: Final[str] = accounts_constants.PlayerFields.USER
 DISPLAY_NAME: Final[str] = accounts_constants.PlayerFields.DISPLAY_NAME
 AVATAR: Final[str] = accounts_constants.PlayerFields.AVATAR
 IS_FRIEND: Final[str] = users_constants.UsersFields.IS_FRIEND
+IS_BLOCKED: Final[str] = users_constants.UsersFields.IS_BLOCKED
 
 USER_ID: Final[str] = constants.FriendshipFields.USER_ID
 FRIEND: Final[str] = constants.FriendshipFields.FRIEND
@@ -93,7 +94,8 @@ class FriendshipListSerializerTests(TestCase):
                         DISPLAY_NAME: self.player_data_2[DISPLAY_NAME],
                         AVATAR: "/media/avatars/sample.png",  # todo: デフォルト画像が変更になったら修正
                         IS_FRIEND: True,
-                        # todo: is_blocked,is_online,win_match,lose_match追加
+                        IS_BLOCKED: False,
+                        # todo: is_online,win_match,lose_match追加
                     },
                 },
                 {
@@ -103,7 +105,8 @@ class FriendshipListSerializerTests(TestCase):
                         DISPLAY_NAME: self.player_data_3[DISPLAY_NAME],
                         AVATAR: "/media/avatars/sample.png",  # todo: デフォルト画像が変更になったら修正
                         IS_FRIEND: True,
-                        # todo: is_blocked,is_online,win_match,lose_match追加
+                        IS_BLOCKED: False,
+                        # todo: is_online,win_match,lose_match追加
                     },
                 },
             ],

--- a/backend/pong/users/friends/tests/integration/test_create_views.py
+++ b/backend/pong/users/friends/tests/integration/test_create_views.py
@@ -20,6 +20,7 @@ USER: Final[str] = accounts_constants.PlayerFields.USER
 DISPLAY_NAME: Final[str] = accounts_constants.PlayerFields.DISPLAY_NAME
 AVATAR: Final[str] = accounts_constants.PlayerFields.AVATAR
 IS_FRIEND: Final[str] = users_constants.UsersFields.IS_FRIEND
+IS_BLOCKED: Final[str] = users_constants.UsersFields.IS_BLOCKED
 
 USER_ID: Final[str] = constants.FriendshipFields.USER_ID
 FRIEND_USER_ID: Final[str] = constants.FriendshipFields.FRIEND_USER_ID
@@ -108,7 +109,8 @@ class FriendsCreateViewTests(test.APITestCase):
                     DISPLAY_NAME: self.player_data2[DISPLAY_NAME],
                     AVATAR: "/media/avatars/sample.png",  # todo: デフォルト画像が変更になったら修正
                     IS_FRIEND: True,
-                    # todo: is_blocked,is_online,win_match,lose_match追加
+                    IS_BLOCKED: False,
+                    # todo: is_online,win_match,lose_match追加
                 },
             },
         )

--- a/backend/pong/users/friends/tests/integration/test_list_views.py
+++ b/backend/pong/users/friends/tests/integration/test_list_views.py
@@ -20,6 +20,7 @@ USER: Final[str] = accounts_constants.PlayerFields.USER
 DISPLAY_NAME: Final[str] = accounts_constants.PlayerFields.DISPLAY_NAME
 AVATAR: Final[str] = accounts_constants.PlayerFields.AVATAR
 IS_FRIEND: Final[str] = users_constants.UsersFields.IS_FRIEND
+IS_BLOCKED: Final[str] = users_constants.UsersFields.IS_BLOCKED
 
 FRIEND: Final[str] = constants.FriendshipFields.FRIEND
 
@@ -138,7 +139,8 @@ class FriendsListViewTests(test.APITestCase):
                         DISPLAY_NAME: self.player_data2[DISPLAY_NAME],
                         AVATAR: "/media/avatars/sample.png",  # todo: デフォルト画像が変更になったら修正
                         IS_FRIEND: True,
-                        # todo: is_blocked,is_online,win_match,lose_match追加
+                        IS_BLOCKED: False,
+                        # todo: is_online,win_match,lose_match追加
                     },
                 },
                 {
@@ -148,7 +150,8 @@ class FriendsListViewTests(test.APITestCase):
                         DISPLAY_NAME: self.player_data3[DISPLAY_NAME],
                         AVATAR: "/media/avatars/sample.png",  # todo: デフォルト画像が変更になったら修正
                         IS_FRIEND: True,
-                        # todo: is_blocked,is_online,win_match,lose_match追加
+                        IS_BLOCKED: False,
+                        # todo: is_online,win_match,lose_match追加
                     },
                 },
             ],
@@ -174,7 +177,8 @@ class FriendsListViewTests(test.APITestCase):
                         DISPLAY_NAME: self.player_data3[DISPLAY_NAME],
                         AVATAR: "/media/avatars/sample.png",  # todo: デフォルト画像が変更になったら修正
                         IS_FRIEND: True,
-                        # todo: is_blocked,is_online,win_match,lose_match追加
+                        IS_BLOCKED: False,
+                        # todo: is_online,win_match,lose_match追加
                     },
                 },
             ],
@@ -200,7 +204,8 @@ class FriendsListViewTests(test.APITestCase):
                         DISPLAY_NAME: self.player_data2[DISPLAY_NAME],
                         AVATAR: "/media/avatars/sample.png",  # todo: デフォルト画像が変更になったら修正
                         IS_FRIEND: True,
-                        # todo: is_blocked,is_online,win_match,lose_match追加
+                        IS_BLOCKED: False,
+                        # todo: is_online,win_match,lose_match追加
                     },
                 },
             ],

--- a/backend/pong/users/friends/views.py
+++ b/backend/pong/users/friends/views.py
@@ -48,7 +48,8 @@ logger = logging.getLogger(__name__)
                                         accounts_constants.PlayerFields.DISPLAY_NAME: "display_name2",
                                         accounts_constants.PlayerFields.AVATAR: "/media/avatars/sample.png",
                                         users_constants.UsersFields.IS_FRIEND: True,
-                                        # todo: is_blocked,is_online,win_match,lose_match追加
+                                        users_constants.UsersFields.IS_BLOCKED: False,
+                                        # todo: is_online,win_match,lose_match追加
                                     },
                                 },
                                 {"...", "..."},

--- a/backend/pong/users/friends/views.py
+++ b/backend/pong/users/friends/views.py
@@ -123,7 +123,8 @@ logger = logging.getLogger(__name__)
                                     accounts_constants.PlayerFields.DISPLAY_NAME: "display_name2",
                                     accounts_constants.PlayerFields.AVATAR: "/media/avatars/sample.png",
                                     users_constants.UsersFields.IS_FRIEND: True,
-                                    # todo: is_blocked,is_online,win_match,lose_match追加
+                                    users_constants.UsersFields.IS_BLOCKED: False,
+                                    # todo: is_online,win_match,lose_match追加
                                 },
                             },
                         },

--- a/backend/pong/users/serializers.py
+++ b/backend/pong/users/serializers.py
@@ -3,7 +3,8 @@ from rest_framework import serializers
 from accounts import constants as accounts_constants
 from accounts.player import models as player_models
 from accounts.player import serializers as player_serializers
-from users.friends import constants, models
+from users.friends import constants as friends_constants
+from users.friends import models as friends_models
 
 from . import constants as users_constants
 
@@ -69,11 +70,13 @@ class UsersSerializer(serializers.Serializer):
         """
         if not hasattr(self, "_friendships_cache"):
             # ログインユーザーのフレンド全員をsetでキャッシュしておく
-            user_id: int = self.context[constants.FriendshipFields.USER_ID]
+            user_id: int = self.context[
+                friends_constants.FriendshipFields.USER_ID
+            ]
             self._friendships_cache: set[int] = set(
-                models.Friendship.objects.filter(user_id=user_id).values_list(
-                    "friend_id", flat=True
-                )
+                friends_models.Friendship.objects.filter(
+                    user_id=user_id
+                ).values_list("friend_id", flat=True)
             )
         return player.user.id in self._friendships_cache
 

--- a/backend/pong/users/serializers.py
+++ b/backend/pong/users/serializers.py
@@ -3,6 +3,8 @@ from rest_framework import serializers
 from accounts import constants as accounts_constants
 from accounts.player import models as player_models
 from accounts.player import serializers as player_serializers
+from users.blocks import constants as blocks_constants
+from users.blocks import models as blocks_models
 from users.friends import constants as friends_constants
 from users.friends import models as friends_models
 
@@ -29,9 +31,10 @@ class UsersSerializer(serializers.Serializer):
     avatar = player_serializers.PlayerSerializer().fields[
         accounts_constants.PlayerFields.AVATAR
     ]
-    # get_is_friend()の返り値が格納される
+    # `get_{field名}()`の返り値が格納される
     is_friend = serializers.SerializerMethodField()
-    # todo: is_blocked,is_online,win_match,lose_match追加
+    is_blocked = serializers.SerializerMethodField()
+    # todo: is_online,win_match,lose_match追加
 
     class Meta:
         model = player_models.Player
@@ -42,7 +45,8 @@ class UsersSerializer(serializers.Serializer):
             accounts_constants.PlayerFields.DISPLAY_NAME,
             accounts_constants.PlayerFields.AVATAR,
             users_constants.UsersFields.IS_FRIEND,
-            # todo: is_blocked,is_online,win_match,lose_match追加
+            users_constants.UsersFields.IS_BLOCKED,
+            # todo: is_online,win_match,lose_match追加
         )
 
     # args,kwargsは型ヒントが複雑かつそのままsuper()に渡したいためignoreで対処
@@ -79,6 +83,28 @@ class UsersSerializer(serializers.Serializer):
                 ).values_list("friend_id", flat=True)
             )
         return player.user.id in self._friendships_cache
+
+    def get_is_blocked(self, player: player_models.Player) -> bool:
+        """
+        playerがログインユーザーにブロックされているかどうかを取得する
+
+        Args:
+            player: Playerインスタンス
+
+        Returns:
+            bool: ログインユーザーにブロックされていればTrue、そうでなければFalse
+        """
+        if not hasattr(self, "_blocked_relationships_cache"):
+            # ログインユーザーにブロックされているユーザー全員をsetでキャッシュしておく
+            user_id: int = self.context[
+                blocks_constants.BlockRelationshipFields.USER_ID
+            ]
+            self._blocked_relationships_cache: set[int] = set(
+                blocks_models.BlockRelationship.objects.filter(
+                    user_id=user_id
+                ).values_list("blocked_user_id", flat=True)
+            )
+        return player.user.id in self._blocked_relationships_cache
 
     def update(
         self, player: player_models.Player, validated_data: dict

--- a/backend/pong/users/tests/integration/test_list.py
+++ b/backend/pong/users/tests/integration/test_list.py
@@ -19,6 +19,7 @@ USER: Final[str] = accounts_constants.PlayerFields.USER
 DISPLAY_NAME: Final[str] = accounts_constants.PlayerFields.DISPLAY_NAME
 AVATAR: Final[str] = accounts_constants.PlayerFields.AVATAR
 IS_FRIEND: Final[str] = constants.UsersFields.IS_FRIEND
+IS_BLOCKED: Final[str] = constants.UsersFields.IS_BLOCKED
 
 DATA: Final[str] = custom_response.DATA
 
@@ -106,7 +107,8 @@ class UsersListViewTests(test.APITestCase):
                     DISPLAY_NAME: self.player_data1[DISPLAY_NAME],
                     AVATAR: self.player1.avatar.url,
                     IS_FRIEND: False,
-                    # todo: is_blocked,is_online,win_match,lose_match追加
+                    IS_BLOCKED: False,
+                    # todo: is_online,win_match,lose_match追加
                 },
                 {
                     ID: self.user2.id,
@@ -114,7 +116,8 @@ class UsersListViewTests(test.APITestCase):
                     DISPLAY_NAME: self.player_data2[DISPLAY_NAME],
                     AVATAR: self.player2.avatar.url,
                     IS_FRIEND: False,
-                    # todo: is_blocked,is_online,win_match,lose_match追加
+                    IS_BLOCKED: False,
+                    # todo: is_online,win_match,lose_match追加
                 },
             ],
         )

--- a/backend/pong/users/tests/integration/test_me.py
+++ b/backend/pong/users/tests/integration/test_me.py
@@ -20,6 +20,7 @@ USER: Final[str] = accounts_constants.PlayerFields.USER
 DISPLAY_NAME: Final[str] = accounts_constants.PlayerFields.DISPLAY_NAME
 AVATAR: Final[str] = accounts_constants.PlayerFields.AVATAR
 IS_FRIEND: Final[str] = constants.UsersFields.IS_FRIEND
+IS_BLOCKED: Final[str] = constants.UsersFields.IS_BLOCKED
 
 DATA: Final[str] = custom_response.DATA
 CODE: Final[str] = custom_response.CODE
@@ -91,7 +92,8 @@ class UsersMeViewTests(test.APITestCase):
                 DISPLAY_NAME: self.player_data[DISPLAY_NAME],
                 AVATAR: self.player.avatar.url,
                 IS_FRIEND: False,
-                # todo: is_blocked,is_online,win_match,lose_match追加
+                IS_BLOCKED: False,
+                # todo: is_online,win_match,lose_match追加
             },
         )
 

--- a/backend/pong/users/tests/integration/test_retrieve.py
+++ b/backend/pong/users/tests/integration/test_retrieve.py
@@ -19,6 +19,7 @@ USER: Final[str] = accounts_constants.PlayerFields.USER
 DISPLAY_NAME: Final[str] = accounts_constants.PlayerFields.DISPLAY_NAME
 AVATAR: Final[str] = accounts_constants.PlayerFields.AVATAR
 IS_FRIEND: Final[str] = constants.UsersFields.IS_FRIEND
+IS_BLOCKED: Final[str] = constants.UsersFields.IS_BLOCKED
 
 DATA: Final[str] = custom_response.DATA
 CODE: Final[str] = custom_response.CODE
@@ -115,6 +116,8 @@ class UsersRetrieveViewTests(test.APITestCase):
                     DISPLAY_NAME: player_data[DISPLAY_NAME],
                     AVATAR: user.player.avatar.url,
                     IS_FRIEND: False,
+                    IS_BLOCKED: False,
+                    # todo: is_online,win_match,lose_match追加
                 },
             )
 

--- a/backend/pong/users/tests/unit/test_users_serializer.py
+++ b/backend/pong/users/tests/unit/test_users_serializer.py
@@ -19,6 +19,7 @@ USER: Final[str] = accounts_constants.PlayerFields.USER
 DISPLAY_NAME: Final[str] = accounts_constants.PlayerFields.DISPLAY_NAME
 AVATAR: Final[str] = accounts_constants.PlayerFields.AVATAR
 IS_FRIEND: Final[str] = constants.UsersFields.IS_FRIEND
+IS_BLOCKED: Final[str] = constants.UsersFields.IS_BLOCKED
 
 USER_ID: Final[str] = friends_constants.FriendshipFields.USER_ID
 
@@ -84,7 +85,8 @@ class UsersSerializerTests(TestCase):
                     DISPLAY_NAME: self.player_data_1[DISPLAY_NAME],
                     AVATAR: self.player_1.avatar.url,
                     IS_FRIEND: False,
-                    # todo: is_blocked,is_online,win_match,lose_match追加
+                    IS_BLOCKED: False,
+                    # todo: is_online,win_match,lose_match追加
                 },
                 {
                     ID: self.user_2.id,
@@ -93,7 +95,8 @@ class UsersSerializerTests(TestCase):
                     DISPLAY_NAME: self.player_data_2[DISPLAY_NAME],
                     AVATAR: self.player_2.avatar.url,
                     IS_FRIEND: False,
-                    # todo: is_blocked,is_online,win_match,lose_match追加
+                    IS_BLOCKED: False,
+                    # todo: is_online,win_match,lose_match追加
                 },
             ],
         )

--- a/backend/pong/users/views/list.py
+++ b/backend/pong/users/views/list.py
@@ -85,7 +85,8 @@ class UsersListView(views.APIView):
                                     accounts_constants.PlayerFields.DISPLAY_NAME: "display_name1",
                                     accounts_constants.PlayerFields.AVATAR: "/media/avatars/sample1.png",
                                     constants.UsersFields.IS_FRIEND: False,
-                                    # todo: is_blocked,is_online,win_match,lose_match追加
+                                    constants.UsersFields.IS_BLOCKED: False,
+                                    # todo: is_online,win_match,lose_match追加
                                 },
                                 {
                                     accounts_constants.UserFields.ID: 3,
@@ -93,7 +94,8 @@ class UsersListView(views.APIView):
                                     accounts_constants.PlayerFields.DISPLAY_NAME: "display_name2",
                                     accounts_constants.PlayerFields.AVATAR: "/media/avatars/sample2.png",
                                     constants.UsersFields.IS_FRIEND: False,
-                                    # todo: is_blocked,is_online,win_match,lose_match追加
+                                    constants.UsersFields.IS_BLOCKED: False,
+                                    # todo: is_online,win_match,lose_match追加
                                 },
                                 {"...", "..."},
                             ],
@@ -164,7 +166,8 @@ class UsersListView(views.APIView):
                 accounts_constants.PlayerFields.DISPLAY_NAME,
                 accounts_constants.PlayerFields.AVATAR,
                 constants.UsersFields.IS_FRIEND,
-                # todo: is_blocked,is_online,win_match,lose_match追加
+                constants.UsersFields.IS_BLOCKED,
+                # todo: is_online,win_match,lose_match追加
             ),
             context={friends_constants.FriendshipFields.USER_ID: user.id},
         )

--- a/backend/pong/users/views/me.py
+++ b/backend/pong/users/views/me.py
@@ -84,7 +84,8 @@ class UsersMeView(views.APIView):
                                 accounts_constants.PlayerFields.DISPLAY_NAME: "display_name1",
                                 accounts_constants.PlayerFields.AVATAR: "/media/avatars/sample.png",
                                 constants.UsersFields.IS_FRIEND: False,
-                                # todo: is_blocked,is_online,win_match,lose_match追加
+                                constants.UsersFields.IS_BLOCKED: False,
+                                # todo: is_online,win_match,lose_match追加
                             },
                         },
                     ),
@@ -178,7 +179,8 @@ class UsersMeView(views.APIView):
                                 accounts_constants.PlayerFields.DISPLAY_NAME: "display_name1",
                                 accounts_constants.PlayerFields.AVATAR: "/media/avatars/sample.png",
                                 constants.UsersFields.IS_FRIEND: False,
-                                # todo: is_blocked,is_online,win_match,lose_match追加
+                                constants.UsersFields.IS_BLOCKED: False,
+                                # todo: is_online,win_match,lose_match追加
                             },
                         },
                     ),

--- a/backend/pong/users/views/retrieve.py
+++ b/backend/pong/users/views/retrieve.py
@@ -84,7 +84,8 @@ class UsersRetrieveView(views.APIView):
                                 accounts_constants.PlayerFields.DISPLAY_NAME: "display_name1",
                                 accounts_constants.PlayerFields.AVATAR: "/media/avatars/sample.png",
                                 constants.UsersFields.IS_FRIEND: True,
-                                # todo: is_blocked,is_online,win_match,lose_match追加
+                                constants.UsersFields.IS_BLOCKED: False,
+                                # todo: is_online,win_match,lose_match追加
                             },
                         },
                     ),
@@ -183,7 +184,8 @@ class UsersRetrieveView(views.APIView):
                     accounts_constants.PlayerFields.DISPLAY_NAME,
                     accounts_constants.PlayerFields.AVATAR,
                     constants.UsersFields.IS_FRIEND,
-                    # todo: is_blocked,is_online,win_match,lose_match追加
+                    constants.UsersFields.IS_BLOCKED,
+                    # todo: is_online,win_match,lose_match追加
                 ),
                 context={friends_constants.FriendshipFields.USER_ID: user.id},
             )


### PR DESCRIPTION
## タスクやディスカッションのリンク
<!-- - URLをここに貼る -->
- #370 

## やったこと
<!-- - このタスクでやったことはなにか？ -->
- 以下の app 内のユーザープロフィールを返すエンドポイントのレスポンスに、ログインユーザーにブロックされているかどうかを表す `is_blocked` を追加しました
  - accounts, POST
  - users の DELETE 以外 8 個
![image](https://github.com/user-attachments/assets/0d0e83c5-857d-42de-ba61-bc5b9197b2ed)

- `is_friend`, `is_blocked` の簡単な unit test も追加


## やらないこと
<!-- - このタスクでやらないことはなにか？（やらない場合いつやるのか？無ければ「なし」を記述） -->
上記以外

## 動作確認
<!-- - どのような動作確認を行い、結果はどうだったのか？(適宜スクショ等添付) -->
- swagger-ui にて以下を確認
  - extend_schema に `is_blocked` が追加されていること
  - 実際のレスポンスにも `is_blocked` が含まれていること

## 特にレビューをお願いしたい箇所
<!-- - 特にチェックをお願いしたいポイントを簡潔に記述する -->
動作確認
確認するエンドポイントが多くてすみませんが、よろしくお願いします

## その他
<!-- - 実装上の懸念点、注意点等あれば記載する -->
特になし

## 参考リンク
<!-- - 実装に際し参考にした、記事やサイトのリンクを記載する -->
特になし

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - ユーザー情報や関係性を扱う各画面に、ブロック状態を示す新しいフィールドが追加されました。これにより、アカウント作成、ブロック・フレンドリスト、およびユーザープロファイルで、ユーザーがブロックされているかどうかが明確に表示され、情報の透明性が向上しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->