### PR TITLE
⚡ ユーザー認証のハンドリング

### DIFF
--- a/frontend/pong/js/api/participations/getParticipations.js
+++ b/frontend/pong/js/api/participations/getParticipations.js
@@ -1,6 +1,6 @@
 import { Endpoints } from "../../constants/Endpoints";
 import { isNullOrValidId } from "../../utils/isNullOrValidId";
-import { fetchData } from "../utils/fetchData";
+import { fetchAuthenticatedData } from "../utils/fetchAuthenticatedData";
 import { convertParticipationData } from "./convertParticipationData";
 
 export async function getParticipations(
@@ -21,7 +21,8 @@ export async function getParticipations(
     );
   if (userId) participationUrl.searchParams.append("user-id", userId);
 
-  const { data, error } = await fetchData(participationUrl);
+  const { data, error } =
+    await fetchAuthenticatedData(participationUrl);
 
   const participations = error
     ? []

--- a/frontend/pong/js/api/users/convertMyInfoData.js
+++ b/frontend/pong/js/api/users/convertMyInfoData.js
@@ -1,0 +1,11 @@
+export const convertMyInfoData = (userData) => {
+  const { id, username, email, display_name, avatar } = userData;
+
+  return {
+    id,
+    username,
+    email,
+    displayName: display_name,
+    avatar,
+  };
+};

--- a/frontend/pong/js/api/users/getFriends.js
+++ b/frontend/pong/js/api/users/getFriends.js
@@ -1,10 +1,12 @@
 import { Endpoints } from "../../constants/Endpoints";
-import { fetchData } from "../utils/fetchData";
+import { fetchAuthenticatedData } from "../utils/fetchAuthenticatedData";
 import { convertFriendData } from "./convertFriendData";
 
 export async function getFriends() {
   // TODO: 認証つきのものに変更
-  const { data, error } = await fetchData(Endpoints.FRIENDS.href);
+  const { data, error } = await fetchAuthenticatedData(
+    Endpoints.FRIENDS.href,
+  );
 
   const users = error ? [] : data.map(convertFriendData);
   return { users, error };

--- a/frontend/pong/js/api/users/getMyInfo.js
+++ b/frontend/pong/js/api/users/getMyInfo.js
@@ -1,0 +1,12 @@
+import { Endpoints } from "../../constants/Endpoints";
+import { fetchAuthenticatedData } from "../utils/fetchAuthenticatedData";
+import { convertMyInfoData } from "./convertMyInfoData";
+
+export async function getMyInfo() {
+  const { data, error } = await fetchAuthenticatedData(
+    Endpoints.USERS.me().href,
+  );
+
+  const myInfo = error ? null : convertMyInfoData(data);
+  return { myInfo, error };
+}

--- a/frontend/pong/js/api/users/getUser.js
+++ b/frontend/pong/js/api/users/getUser.js
@@ -1,6 +1,6 @@
 import { Endpoints } from "../../constants/Endpoints";
 import { isValidId } from "../../utils/isValidId";
-import { fetchData } from "../utils/fetchData";
+import { fetchAuthenticatedData } from "../utils/fetchAuthenticatedData";
 import { convertUserData } from "./convertUserData";
 
 export async function getUser(userId) {
@@ -11,7 +11,7 @@ export async function getUser(userId) {
     };
   }
 
-  const { data, error } = await fetchData(
+  const { data, error } = await fetchAuthenticatedData(
     Endpoints.USERS.withId(userId).href,
   );
 

--- a/frontend/pong/js/api/users/getUsers.js
+++ b/frontend/pong/js/api/users/getUsers.js
@@ -1,9 +1,9 @@
 import { Endpoints } from "../../constants/Endpoints";
-import { fetchData } from "../utils/fetchData";
+import { fetchAuthenticatedData } from "../utils/fetchAuthenticatedData";
 import { convertUserData } from "./convertUserData";
 
 export async function getUsers() {
-  const { data, error } = await fetchData(
+  const { data, error } = await fetchAuthenticatedData(
     Endpoints.USERS.default.href,
   );
 

--- a/frontend/pong/js/api/utils/fetchAuthenticatedData.js
+++ b/frontend/pong/js/api/utils/fetchAuthenticatedData.js
@@ -1,0 +1,58 @@
+import { Endpoints } from "../../constants/Endpoints";
+import { UserSessionManager } from "../../session/UserSessionManager";
+import { fetchData } from "./fetchData";
+
+export const fetchAuthenticatedData = async (
+  url,
+  options = {},
+  isRetry = false,
+) => {
+  const result = {
+    data: null,
+    error: null,
+  };
+
+  const accessToken =
+    UserSessionManager.getInstance().getAccessToken();
+
+  try {
+    const headers = new Headers(options.headers ?? {});
+    headers.append("Authorization", `Bearer ${accessToken}`);
+
+    const res = await fetch(url, { ...options, headers });
+
+    if (res.status === 401 && !isRetry)
+      return retryWithRefreshToken(url, options);
+
+    const { status, data } = await res.json();
+    if (status !== "ok") throw new Error("STATUS: NOT OK");
+    result.data = data;
+  } catch (error) {
+    result.error = error;
+  }
+  return result;
+};
+
+const retryWithRefreshToken = async (url, options = {}) => {
+  const refreshToken =
+    UserSessionManager.getInstance().getRefreshToken();
+
+  try {
+    const {
+      data: { access },
+      error,
+    } = await fetchData(Endpoints.REFRESH_TOKEN.href, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ refreshToken }),
+    });
+    if (error) throw new Error("Refresh: NOT OK");
+
+    UserSessionManager.getInstance().setAccessToken(access);
+  } catch (error) {
+    return { data: null, error };
+  }
+  return fetchAuthenticatedData(url, options, true);
+};

--- a/frontend/pong/js/api/utils/fetchAuthenticatedData.js
+++ b/frontend/pong/js/api/utils/fetchAuthenticatedData.js
@@ -38,18 +38,19 @@ const retryWithRefreshToken = async (url, options = {}) => {
     UserSessionManager.getInstance().getRefreshToken();
 
   try {
-    const {
-      data: { access },
-      error,
-    } = await fetchData(Endpoints.REFRESH_TOKEN.href, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
+    const { data, error } = await fetchData(
+      Endpoints.REFRESH_TOKEN.href,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ refresh: refreshToken }),
       },
-      body: JSON.stringify({ refreshToken }),
-    });
+    );
     if (error) throw new Error("Refresh: NOT OK");
 
+    const { access } = data;
     UserSessionManager.getInstance().setAccessToken(access);
   } catch (error) {
     return { data: null, error };

--- a/frontend/pong/js/api/utils/fetchData.js
+++ b/frontend/pong/js/api/utils/fetchData.js
@@ -1,11 +1,11 @@
-export const fetchData = async (url) => {
+export const fetchData = async (url, options = {}) => {
   const result = {
     data: null,
     error: null,
   };
 
   try {
-    const res = await fetch(url);
+    const res = await fetch(url, options);
     const { status, data } = await res.json();
     if (status !== "ok") throw new Error("STATUS: NOT OK");
     result.data = data;

--- a/frontend/pong/js/components/auth/LoginContainer.js
+++ b/frontend/pong/js/components/auth/LoginContainer.js
@@ -1,7 +1,9 @@
 import { Endpoints } from "../../constants/Endpoints";
+import { Paths } from "../../constants/Paths";
 import { FrontendMessage } from "../../constants/message/FrontendMessage";
 import { Component } from "../../core/Component";
 import { MessageEnums } from "../../enums/MessageEnums";
+import { UserSessionManager } from "../../session/UserSessionManager";
 
 export class LoginContainer extends Component {
   #container;
@@ -93,9 +95,9 @@ export class LoginContainer extends Component {
             password: password,
           }),
         });
-        const res = await response.json();
+        const { status, data: tokens } = await response.json();
 
-        if (res.status !== "ok") {
+        if (status !== "ok") {
           this.#form.reset();
           this.#loginError.textContent =
             FrontendMessage.Auth[MessageEnums.AuthCode.LOGIN_ERROR];
@@ -103,10 +105,11 @@ export class LoginContainer extends Component {
           throw new Error(response.code);
         }
         this.#loginError.style.display = "none"; //エラーメッセージをデフォルトの非表示にする
-        // access tokenとrefresh tokenの管理を行う
-        // TODO delete
-        // console.log("AccessToken:", res.data.access);
-        // console.log("RefreshToken:", res.data.refresh);
+
+        const isVerified =
+          await UserSessionManager.getInstance().signIn(tokens);
+        if (isVerified)
+          UserSessionManager.getInstance().redirect(Paths.HOME);
       } catch (error) {
         console.error("ログインエラー:", error);
       }

--- a/frontend/pong/js/components/auth/SignInButton.js
+++ b/frontend/pong/js/components/auth/SignInButton.js
@@ -1,5 +1,6 @@
+import { Paths } from "../../constants/Paths";
+import { PongEvents } from "../../constants/PongEvents";
 import { StyledButton } from "../../core/StyledButton";
-import { UserSessionManager } from "../../session/UserSessionManager";
 
 export class SignInButton extends StyledButton {
   constructor(state = {}, attributes = {}) {
@@ -17,17 +18,10 @@ export class SignInButton extends StyledButton {
   _onConnect() {
     this._attachEventListener("click", (event) => {
       event.preventDefault();
-      event.stopPropagation();
 
-      // TODO: DELETE: 一時的な対処なので確認が必要
-      const mockUser = {
-        id: 1,
-        username: "user",
-        email: "username1@example.com",
-        displayName: "mock",
-        avatar: "https://placehold.co/30",
-      };
-      UserSessionManager.signIn(mockUser, {});
+      this.dispatchEvent(
+        PongEvents.UPDATE_ROUTER.create(Paths.LOGIN),
+      );
     });
   }
 }

--- a/frontend/pong/js/components/auth/SignOutButton.js
+++ b/frontend/pong/js/components/auth/SignOutButton.js
@@ -17,8 +17,7 @@ export class SignOutButton extends StyledButton {
   _onConnect() {
     this._attachEventListener("click", (event) => {
       event.preventDefault();
-      event.stopPropagation();
-      UserSessionManager.signOut();
+      UserSessionManager.getInstance().signOut();
     });
   }
 }

--- a/frontend/pong/js/components/tournament/TournamentEntrance.js
+++ b/frontend/pong/js/components/tournament/TournamentEntrance.js
@@ -118,7 +118,7 @@ export class TournamentEntrance extends Component {
       WebSocketEnums.Category.TOURNAMENT,
       this.#tournamentJoinHandler,
     );
-    UserSessionManager.getInstance().myInfo.attach(
+    UserSessionManager.getInstance().myInfo.detach(
       this.#syncDefaultDisplayName,
     );
   }

--- a/frontend/pong/js/components/tournament/TournamentEntrance.js
+++ b/frontend/pong/js/components/tournament/TournamentEntrance.js
@@ -62,12 +62,11 @@ export class TournamentEntrance extends Component {
   _onConnect() {
     const { defaultTournamentIdStr } = this._getState();
 
-    const defaultDisplayName = UserSessionManager.myInfo.observe(
-      (data) => {
+    const defaultDisplayName =
+      UserSessionManager.getInstance().myInfo.observe((data) => {
         const { displayName } = data;
         return displayName;
-      },
-    );
+      });
 
     this.#displayNameInput = new ObservableInput(
       {},
@@ -100,14 +99,14 @@ export class TournamentEntrance extends Component {
       pathname: Paths.HOME,
     });
 
-    UserSessionManager.webSocket.attachHandler(
+    UserSessionManager.getInstance().webSocket.attachHandler(
       WebSocketEnums.Category.TOURNAMENT,
       this.#tournamentJoinHandler,
     );
   }
 
   _onDisconnect() {
-    UserSessionManager.webSocket.detachHandler(
+    UserSessionManager.getInstance().webSocket.detachHandler(
       WebSocketEnums.Category.TOURNAMENT,
       this.#tournamentJoinHandler,
     );

--- a/frontend/pong/js/components/tournament/TournamentEntrance.js
+++ b/frontend/pong/js/components/tournament/TournamentEntrance.js
@@ -20,6 +20,7 @@ export class TournamentEntrance extends Component {
   #toHome;
   #displayNameInput;
   #tournamentJoinHandler;
+  #syncDefaultDisplayName;
 
   constructor(state = {}) {
     super({ isJoinError: false, ...state });
@@ -103,12 +104,22 @@ export class TournamentEntrance extends Component {
       WebSocketEnums.Category.TOURNAMENT,
       this.#tournamentJoinHandler,
     );
+
+    this.#syncDefaultDisplayName = ({ displayName }) => {
+      this.#displayNameInput.setValue(displayName);
+    };
+    UserSessionManager.getInstance().myInfo.attach(
+      this.#syncDefaultDisplayName,
+    );
   }
 
   _onDisconnect() {
     UserSessionManager.getInstance().webSocket.detachHandler(
       WebSocketEnums.Category.TOURNAMENT,
       this.#tournamentJoinHandler,
+    );
+    UserSessionManager.getInstance().myInfo.attach(
+      this.#syncDefaultDisplayName,
     );
   }
 

--- a/frontend/pong/js/components/tournament/TournamentJoinButton.js
+++ b/frontend/pong/js/components/tournament/TournamentJoinButton.js
@@ -19,7 +19,7 @@ export class TournamentJoinButton extends StyledButton {
       );
       if (isError) return;
 
-      UserSessionManager.webSocket.send(
+      UserSessionManager.getInstance().webSocket.send(
         WebSocketEnums.Category.TOURNAMENT,
         TournamentPayload.createJoin({
           joinType,

--- a/frontend/pong/js/components/tournament/TournamentProgress.js
+++ b/frontend/pong/js/components/tournament/TournamentProgress.js
@@ -56,10 +56,12 @@ export class TournamentProgress extends Component {
   _onConnect() {
     const { tournamentId } = this._getState();
 
-    const myId = UserSessionManager.myInfo.observe(({ id }) => id);
+    const myId = UserSessionManager.getInstance().myInfo.observe(
+      ({ id }) => id,
+    );
     this.#players = new TournamentPlayers({ tournamentId });
     const onMessageSubmit = (value) =>
-      UserSessionManager.webSocket.send(
+      UserSessionManager.getInstance().webSocket.send(
         WebSocketEnums.Category.CHAT,
         ChatPayload.createGroupChat({
           fromId: myId,
@@ -91,14 +93,14 @@ export class TournamentProgress extends Component {
       });
     };
 
-    UserSessionManager.webSocket.attachHandler(
+    UserSessionManager.getInstance().webSocket.attachHandler(
       WebSocketEnums.Category.CHAT,
       this.#listenGroupChat,
     );
   }
 
   _onDisconnect() {
-    UserSessionManager.webSocket.detachHandler(
+    UserSessionManager.getInstance().webSocket.detachHandler(
       WebSocketEnums.Category.CHAT,
       this.#listenGroupChat,
     );
@@ -106,7 +108,7 @@ export class TournamentProgress extends Component {
 
     const { tournamentId } = this._getState();
 
-    UserSessionManager.webSocket.send(
+    UserSessionManager.getInstance().webSocket.send(
       WebSocketEnums.Category.TOURNAMENT,
       TournamentPayload.createLeave({
         tournamentId,

--- a/frontend/pong/js/components/user/UserProfileHeader.js
+++ b/frontend/pong/js/components/user/UserProfileHeader.js
@@ -24,14 +24,18 @@ export class UserProfileHeader extends Component {
   }
 
   _onConnect() {
-    UserSessionManager.myInfo.observe((myInfoData) => {
+    UserSessionManager.getInstance().myInfo.observe((myInfoData) => {
       Object.assign(this._state, { user: createUser(myInfoData) });
     });
-    UserSessionManager.myInfo.attach(this.#userDataObserver);
+    UserSessionManager.getInstance().myInfo.attach(
+      this.#userDataObserver,
+    );
   }
 
   _onDisconnect() {
-    UserSessionManager.myInfo.detach(this.#userDataObserver);
+    UserSessionManager.getInstance().myInfo.detach(
+      this.#userDataObserver,
+    );
   }
 
   _render() {

--- a/frontend/pong/js/components/utils/ObservableInput.js
+++ b/frontend/pong/js/components/utils/ObservableInput.js
@@ -33,6 +33,10 @@ export class ObservableInput extends Component {
     this.append(this.#input);
   }
 
+  setValue(value) {
+    this.#input.value = value;
+  }
+
   setError() {
     BootstrapBorders.setDanger(this.#input);
   }

--- a/frontend/pong/js/components/utils/ObservableInput.js
+++ b/frontend/pong/js/components/utils/ObservableInput.js
@@ -35,6 +35,7 @@ export class ObservableInput extends Component {
 
   setValue(value) {
     this.#input.value = value;
+    this.#subject.updateData({ value });
   }
 
   setError() {

--- a/frontend/pong/js/components/views/FriendsView.js
+++ b/frontend/pong/js/components/views/FriendsView.js
@@ -2,10 +2,10 @@ import { getFriends } from "../../api/users/getFriends";
 import { BootstrapDisplay } from "../../bootstrap/utilities/display";
 import { BootstrapFlex } from "../../bootstrap/utilities/flex";
 import { BootstrapSizing } from "../../bootstrap/utilities/sizing";
-import { View } from "../../core/View";
+import { AuthView } from "../../core/AuthView";
 import { UserListContainer } from "../user/UserListContainer";
 
-export class FriendsView extends View {
+export class FriendsView extends AuthView {
   #friendsListContainer;
 
   _setStyle() {

--- a/frontend/pong/js/components/views/LoginView.js
+++ b/frontend/pong/js/components/views/LoginView.js
@@ -1,8 +1,12 @@
-import { View } from "../../core/View";
+import { AuthView } from "../../core/AuthView";
 import { LoginContainer } from "../auth/LoginContainer";
 
-export class LoginView extends View {
+export class LoginView extends AuthView {
   #main;
+
+  constructor(state = {}) {
+    super({ authType: AuthView.Type.PROHIBITED });
+  }
 
   _onConnect() {
     this.#main = new LoginContainer();

--- a/frontend/pong/js/components/views/MyPageView.js
+++ b/frontend/pong/js/components/views/MyPageView.js
@@ -1,6 +1,6 @@
-import { View } from "../../core/View";
+import { AuthView } from "../../core/AuthView";
 
-export class MyPageView extends View {
+export class MyPageView extends AuthView {
   _render() {
     const title = document.createElement("h2");
     title.textContent = "My Page View";

--- a/frontend/pong/js/components/views/TournamentsView.js
+++ b/frontend/pong/js/components/views/TournamentsView.js
@@ -1,10 +1,10 @@
 import { BootstrapDisplay } from "../../bootstrap/utilities/display";
 import { BootstrapFlex } from "../../bootstrap/utilities/flex";
 import { BootstrapSizing } from "../../bootstrap/utilities/sizing";
-import { View } from "../../core/View";
+import { AuthView } from "../../core/AuthView";
 import { TournamentContainer } from "../tournament/TournamentContainer";
 
-export class TournamentsView extends View {
+export class TournamentsView extends AuthView {
   #tournamentContainer;
 
   _setStyle() {

--- a/frontend/pong/js/components/views/UsersView.js
+++ b/frontend/pong/js/components/views/UsersView.js
@@ -2,10 +2,10 @@ import { getUsers } from "../../api/users/getUsers";
 import { BootstrapDisplay } from "../../bootstrap/utilities/display";
 import { BootstrapFlex } from "../../bootstrap/utilities/flex";
 import { BootstrapSizing } from "../../bootstrap/utilities/sizing";
-import { View } from "../../core/View";
+import { AuthView } from "../../core/AuthView";
 import { UserListContainer } from "../user/UserListContainer";
 
-export class UsersView extends View {
+export class UsersView extends AuthView {
   #userListContainer;
 
   _setStyle() {

--- a/frontend/pong/js/constants/Endpoints.js
+++ b/frontend/pong/js/constants/Endpoints.js
@@ -12,9 +12,11 @@ export const Endpoints = Object.freeze({
   USERS: {
     default: new URL("/api/users/", BASE_URL),
     withId: (userId) => new URL(`${userId}`, Endpoints.USERS.default),
+    me: () => new URL("me/", Endpoints.USERS.default),
     defaultAvatar: new URL(DEFAULT_AVATAR_IMAGE_PATH, BASE_URL),
   },
   TOKEN: new URL("/api/token/", BASE_URL),
+  REFRESH_TOKEN: new URL("/api/token/refresh/", BASE_URL),
   FRIENDS: new URL("/api/users/me/friends/", BASE_URL),
   PARTICIPATIONS: new URL(
     "/api/tournaments/participations/",

--- a/frontend/pong/js/core/AuthView.js
+++ b/frontend/pong/js/core/AuthView.js
@@ -1,0 +1,27 @@
+import { UserSessionManager } from "../session/UserSessionManager";
+import { View } from "./View";
+
+export class AuthView extends View {
+  static Type = Object.freeze({
+    REQUIRED: "REQUIRED",
+    PROHIBITED: "PROHIBITED",
+  });
+
+  constructor(state = {}) {
+    super({ authType: AuthView.Type.REQUIRED, ...state });
+  }
+
+  _preConnect() {
+    const { authType } = this._getState();
+    switch (authType) {
+      case AuthView.Type.REQUIRED:
+        UserSessionManager.getInstance().assertAuth();
+        break;
+      case AuthView.Type.PROHIBITED:
+        UserSessionManager.getInstance().assertNoAuth();
+        break;
+      default:
+        break;
+    }
+  }
+}

--- a/frontend/pong/js/core/Component.js
+++ b/frontend/pong/js/core/Component.js
@@ -16,6 +16,7 @@ export class Component extends HTMLElement {
     this._update();
   }
 
+  _preConnect() {}
   _onConnect() {}
   _onDisconnect() {}
   _render() {}
@@ -25,6 +26,7 @@ export class Component extends HTMLElement {
   _setStyle() {}
 
   connectedCallback() {
+    this._preConnect();
     this._onConnect();
     this._setStyle();
     this._render();

--- a/frontend/pong/js/main.js
+++ b/frontend/pong/js/main.js
@@ -21,7 +21,7 @@ function main() {
     if (isUpdated) window.history.pushState({}, "", path);
   });
 
-  UserSessionManager.main({
+  UserSessionManager.getInstance().main({
     app,
     appLocal,
     appGlobal,

--- a/frontend/pong/js/mocks/handlers/friends.js
+++ b/frontend/pong/js/mocks/handlers/friends.js
@@ -1,12 +1,22 @@
 import { http, HttpResponse } from "msw";
 import { Endpoints } from "../../constants/Endpoints";
 import { sampleFriends } from "../utils/createSamples";
+import {
+  notAuthenticatedHttpResponse,
+  verifyToken,
+} from "../utils/mockToken";
 
 export const handlers = [
-  http.get(Endpoints.FRIENDS.href, async () => {
-    return HttpResponse.json({
-      status: "ok",
-      data: sampleFriends,
-    });
-  }),
+  http.get(
+    Endpoints.FRIENDS.href,
+    async ({ request: { headers } }) => {
+      if (!verifyToken(headers))
+        return notAuthenticatedHttpResponse();
+
+      return HttpResponse.json({
+        status: "ok",
+        data: sampleFriends,
+      });
+    },
+  ),
 ];

--- a/frontend/pong/js/mocks/handlers/index.js
+++ b/frontend/pong/js/mocks/handlers/index.js
@@ -1,6 +1,7 @@
 import { handlers as friendsHandlers } from "./friends";
 import { handlers as healthHandlers } from "./health";
 import { handlers as participationsHandlers } from "./participations";
+import { handlers as tokenHandlers } from "./token";
 import { handlers as usersHandlers } from "./users";
 import { handlers as webSocketHandlers } from "./webSocket";
 
@@ -8,6 +9,7 @@ export const handlers = [
   ...friendsHandlers,
   ...healthHandlers,
   ...participationsHandlers,
+  ...tokenHandlers,
   ...usersHandlers,
   ...webSocketHandlers,
 ];

--- a/frontend/pong/js/mocks/handlers/participations.js
+++ b/frontend/pong/js/mocks/handlers/participations.js
@@ -1,24 +1,34 @@
 import { http, HttpResponse } from "msw";
 import { Endpoints } from "../../constants/Endpoints";
 import { sampleParticipations } from "../utils/createSamples";
+import {
+  notAuthenticatedHttpResponse,
+  verifyToken,
+} from "../utils/mockToken";
 
 export const handlers = [
-  http.get(Endpoints.PARTICIPATIONS.href, async ({ request }) => {
-    const url = new URL(request.url);
-    const tournamentId = Number.parseInt(
-      url.searchParams.get("tournament-id"),
-    );
+  http.get(
+    Endpoints.PARTICIPATIONS.href,
+    async ({ request: { url, headers } }) => {
+      if (!verifyToken(headers))
+        return notAuthenticatedHttpResponse();
 
-    let participations = sampleParticipations;
-    if (tournamentId)
-      participations = participations.filter(
-        (participation) =>
-          participation.tournament_id === tournamentId,
+      const requestUrl = new URL(url);
+      const tournamentId = Number.parseInt(
+        requestUrl.searchParams.get("tournament-id"),
       );
 
-    return HttpResponse.json({
-      status: "ok",
-      data: participations,
-    });
-  }),
+      let participations = sampleParticipations;
+      if (tournamentId)
+        participations = participations.filter(
+          (participation) =>
+            participation.tournament_id === tournamentId,
+        );
+
+      return HttpResponse.json({
+        status: "ok",
+        data: participations,
+      });
+    },
+  ),
 ];

--- a/frontend/pong/js/mocks/handlers/token.js
+++ b/frontend/pong/js/mocks/handlers/token.js
@@ -1,0 +1,59 @@
+import { http, HttpResponse } from "msw";
+import { Endpoints } from "../../constants/Endpoints";
+import {
+  MOCK_EMAIL,
+  MOCK_JWT_TOKEN_ACCESS,
+  MOCK_JWT_TOKEN_REFRESH,
+  MOCK_PASSWORD,
+} from "../utils/mockToken";
+
+export const handlers = [
+  http.post(Endpoints.TOKEN.href, async ({ request }) => {
+    const { email, password } = await request.json();
+    const isValidCredentials =
+      email === MOCK_EMAIL && password === MOCK_PASSWORD;
+    return createTokenResponse(isValidCredentials);
+  }),
+  http.post(Endpoints.REFRESH_TOKEN.href, async ({ request }) => {
+    const { refresh } = await request.json();
+    const isValidRefreshToken = refresh === MOCK_JWT_TOKEN_REFRESH;
+    return createRefreshTokenResponse(isValidRefreshToken);
+  }),
+];
+
+const createTokenResponse = (isValidCredentials) =>
+  isValidCredentials
+    ? HttpResponse.json({
+        status: "ok",
+        data: {
+          access: MOCK_JWT_TOKEN_ACCESS,
+          refresh: MOCK_JWT_TOKEN_REFRESH,
+        },
+      })
+    : new HttpResponse(
+        JSON.stringify({ status: "error", code: "not_exists" }),
+        {
+          status: 401,
+          headers: {
+            "Content-Type": "application/json",
+          },
+        },
+      );
+
+const createRefreshTokenResponse = (isValidRefreshToken) =>
+  isValidRefreshToken
+    ? HttpResponse.json({
+        status: "ok",
+        data: {
+          access: MOCK_JWT_TOKEN_ACCESS,
+        },
+      })
+    : new HttpResponse(
+        JSON.stringify({ status: "error", code: "invalid" }),
+        {
+          status: 401,
+          headers: {
+            "Content-Type": "application/json",
+          },
+        },
+      );

--- a/frontend/pong/js/mocks/handlers/users.js
+++ b/frontend/pong/js/mocks/handlers/users.js
@@ -1,32 +1,58 @@
 import { http, HttpResponse } from "msw";
 import { Endpoints } from "../../constants/Endpoints";
-import { sampleUsers } from "../utils/createSamples";
+import { sampleMyInfo, sampleUsers } from "../utils/createSamples";
+import {
+  notAuthenticatedHttpResponse,
+  verifyToken,
+} from "../utils/mockToken";
 
 export const handlers = [
-  http.get(Endpoints.USERS.default.href, async () => {
-    return HttpResponse.json({
-      status: "ok",
-      data: sampleUsers,
-    });
-  }),
-  http.get(Endpoints.USERS.withId(":userId").href, async (req) => {
-    const {
-      params: { userId },
-    } = req;
-    const user = sampleUsers.find(
-      ({ id }) => id.toString() === userId,
-    );
+  http.get(
+    Endpoints.USERS.default.href,
+    async ({ request: { headers } }) => {
+      if (!verifyToken(headers))
+        return notAuthenticatedHttpResponse();
 
-    const responseBody = user
-      ? {
-          status: "ok",
-          data: user,
-        }
-      : {
-          status: "error",
-        };
-    return HttpResponse.json(responseBody);
-  }),
+      return HttpResponse.json({
+        status: "ok",
+        data: sampleUsers,
+      });
+    },
+  ),
+  http.get(
+    Endpoints.USERS.me().href,
+    async ({ request: { headers } }) => {
+      if (!verifyToken(headers))
+        return notAuthenticatedHttpResponse();
+
+      const responseBody = {
+        status: "ok",
+        data: sampleMyInfo,
+      };
+      return HttpResponse.json(responseBody);
+    },
+  ),
+  http.get(
+    Endpoints.USERS.withId(":userId").href,
+    async ({ request: { headers }, params: { userId } }) => {
+      if (!verifyToken(headers))
+        return notAuthenticatedHttpResponse();
+
+      const user = sampleUsers.find(
+        ({ id }) => id.toString() === userId,
+      );
+
+      const responseBody = user
+        ? {
+            status: "ok",
+            data: user,
+          }
+        : {
+            status: "error",
+          };
+      return HttpResponse.json(responseBody);
+    },
+  ),
   http.get(Endpoints.USERS.defaultAvatar.href, async () => {
     const imageBuffer = await fetch("/sample.png").then((res) =>
       res.arrayBuffer(),

--- a/frontend/pong/js/mocks/utils/createSamples.js
+++ b/frontend/pong/js/mocks/utils/createSamples.js
@@ -1,6 +1,7 @@
 const SAMPLE_COUNT = 30; // userId: 1 ~ SAMPLE_COUNT
 
 const MY_USER_ID = 1;
+const MY_EMAIL = "mock@example.com";
 
 const createSampleUser = (number) =>
   Object.freeze({
@@ -13,6 +14,11 @@ const createSampleUser = (number) =>
 const sampleUsers = Array.from({ length: SAMPLE_COUNT }).map(
   (_, idx) => createSampleUser(idx + 1),
 );
+
+const sampleMyInfo = {
+  ...sampleUsers.find(({ id }) => id === MY_USER_ID),
+  email: MY_EMAIL,
+};
 
 const createSampleFriend = (idx) =>
   Object.freeze({
@@ -68,4 +74,9 @@ const sampleParticipations = [
   },
 ];
 
-export { sampleUsers, sampleFriends, sampleParticipations };
+export {
+  sampleUsers,
+  sampleMyInfo,
+  sampleFriends,
+  sampleParticipations,
+};

--- a/frontend/pong/js/mocks/utils/mockToken.js
+++ b/frontend/pong/js/mocks/utils/mockToken.js
@@ -1,0 +1,34 @@
+import { HttpResponse } from "msw";
+
+const MOCK_EMAIL = "pong";
+const MOCK_PASSWORD = "pong";
+const MOCK_JWT_TOKEN_ACCESS = "mock-access";
+const MOCK_JWT_TOKEN_REFRESH = "mock-refresh";
+
+const verifyToken = (headers) => {
+  const authHeader = headers.get("Authorization");
+
+  return authHeader === `Bearer ${MOCK_JWT_TOKEN_ACCESS}`;
+};
+
+const notAuthenticatedHttpResponse = () =>
+  new HttpResponse(
+    JSON.stringify({
+      detail: "Authentication credentials were not provided.",
+    }),
+    {
+      status: 401,
+      headers: {
+        "Content-Type": "application/json",
+      },
+    },
+  );
+
+export {
+  MOCK_EMAIL,
+  MOCK_PASSWORD,
+  MOCK_JWT_TOKEN_ACCESS,
+  MOCK_JWT_TOKEN_REFRESH,
+  verifyToken,
+  notAuthenticatedHttpResponse,
+};

--- a/frontend/pong/js/session/UserSession.js
+++ b/frontend/pong/js/session/UserSession.js
@@ -35,7 +35,7 @@ export class UserSession {
 
     const isValid = await this.#reset();
     if (isValid) {
-      this.signIn();
+      await this.signIn();
       this.updateWindowPath();
     }
     return isValid;

--- a/frontend/pong/js/session/UserSession.js
+++ b/frontend/pong/js/session/UserSession.js
@@ -1,4 +1,7 @@
+import { getMyInfo } from "../api/users/getMyInfo";
 import { ChatGlobal } from "../components/chat/ChatGlobal";
+import { Paths } from "../constants/Paths";
+import { PongEvents } from "../constants/PongEvents";
 import { DataSubject } from "../core/DataSubject";
 import { WebSocketWrapper } from "../websocket/WebSocketWrapper";
 
@@ -6,7 +9,10 @@ export class UserSession {
   #apps;
   #myInfo;
   #webSocket;
+
+  // TODO: manage tokens
   #accessToken;
+  #refreshToken;
 
   constructor() {
     this.#apps = {};
@@ -14,47 +20,84 @@ export class UserSession {
     this.#webSocket = new WebSocketWrapper();
   }
 
-  signIn(userData) {
-    this.#myInfo.updateData({ ...userData, isSignedIn: true });
-    // TODO: WebSocket LOGIN
+  redirect(path = Paths.HOME) {
+    const { app } = this.#apps;
+    app.dispatchEvent(PongEvents.UPDATE_ROUTER.create(path));
   }
 
-  signOut() {
-    this.#reset();
+  updateWindowPath() {
+    const { updateWindowPath } = this.#apps;
+    updateWindowPath();
   }
 
-  main(apps) {
+  async main(apps) {
     Object.assign(this.#apps, apps);
-    this.#reset();
+
+    const isValid = await this.#reset();
+    if (isValid) {
+      this.signIn();
+      this.updateWindowPath();
+    }
+    return isValid;
   }
 
-  #reset() {
-    const {
-      appGlobal,
-      updateWindowPath,
-      displayMainLoading,
-      displayMainError,
-    } = this.#apps;
+  async #reset() {
+    const { displayMainLoading, displayMainError } = this.#apps;
 
-    clearGlobalFeatures(appGlobal);
     displayMainLoading();
 
-    this.#init().then((isGood) => {
-      if (isGood) {
-        initGlobalFeatures(appGlobal);
-        updateWindowPath();
-      } else {
-        displayMainError();
-      }
-    });
+    const isValid = await this.#init();
+    if (!isValid) displayMainError();
+    return isValid;
   }
 
   async #init() {
+    const { appGlobal } = this.#apps;
+    clearGlobalFeatures(appGlobal);
+    this.#initTokens();
     this.#myInfo.init({ isSignedIn: false });
     this.#webSocket.close();
 
     const isConnected = await this.#webSocket.connect();
     return isConnected;
+  }
+
+  async signIn(authData = null) {
+    if (authData) {
+      const { access, refresh } = authData;
+      this.setAccessToken(access);
+      this.setRefreshToken(refresh);
+    }
+    const isVerified = await this.verifyAuth();
+    // TODO: WebSocket LOGIN
+    // initGlobalFeatures(appGlobal);
+    return isVerified;
+  }
+
+  async signOut() {
+    const isValid = await this.#reset();
+    if (isValid) this.updateWindowPath();
+    return isValid;
+  }
+
+  async verifyAuth() {
+    const { myInfo, error } = await getMyInfo();
+    if (error) return false;
+    this.#myInfo.updateData({ ...myInfo, isSignedIn: true });
+    return true;
+  }
+
+  async assertAuth() {
+    const isVerified = await this.verifyAuth();
+    if (!isVerified && (await this.#reset()))
+      this.redirect(Paths.LOGIN);
+    return isVerified;
+  }
+
+  async assertNoAuth() {
+    const isVerified = await this.verifyAuth();
+    if (isVerified) this.redirect(Paths.HOME);
+    return isVerified;
   }
 
   get myInfo() {
@@ -63,6 +106,28 @@ export class UserSession {
 
   get webSocket() {
     return this.#webSocket;
+  }
+
+  // TODO: manage tokens
+  getAccessToken() {
+    return this.#accessToken;
+  }
+
+  getRefreshToken() {
+    return this.#refreshToken;
+  }
+
+  setAccessToken(access) {
+    this.#accessToken = access;
+  }
+
+  setRefreshToken(refresh) {
+    this.#refreshToken = refresh;
+  }
+
+  #initTokens() {
+    this.#accessToken = "";
+    this.#refreshToken = "";
   }
 }
 

--- a/frontend/pong/js/session/UserSessionManager.js
+++ b/frontend/pong/js/session/UserSessionManager.js
@@ -10,10 +10,5 @@ export const UserSessionManager = (() => {
 
   return {
     getInstance,
-    main: getInstance().main.bind(getInstance()),
-    signIn: getInstance().signIn.bind(getInstance()),
-    signOut: getInstance().signOut.bind(getInstance()),
-    myInfo: getInstance().myInfo,
-    webSocket: getInstance().webSocket,
   };
 })();


### PR DESCRIPTION
## タスクやディスカッションのリンク
なし

## やったこと
- データを取得するときに、認証つきでリクエストが送信されるように対応
- ビューを継承して、レンダリング前に認証の ON, OFF を確認するような認証ビューを作成
- モックを使用し、仮のトークンを用いて軽く検証できるように対応

## やらないこと
- getAccessToken, setAccessToken などの実際の中身は未実装です。一旦、仮にメンバー変数にしておきました。

## 動作確認
- `cd frontend/pong && npm install && npm run dev`
- 認証なしで、ホームとログイン画面は大丈夫であることを確認
- 他の一覧画面やトーナメント画面などは `/login` にリダイレクトされることを確認
- email `pong` password `pong` でサインインし、ホーム画面や一覧画面などが表示できることを確認
- 他の email, password ではサインインできないことを確認

## 特にレビューをお願いしたい箇所
なし

## その他
なし

## 参考リンク
なし


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新機能**
  - 認証付きデータ取得とトークン自動更新により、ユーザー情報、友達、参加情報などのデータ取得がより安全かつ確実になりました。
  - ログイン・サインアウト処理が改善され、スムーズなセッション管理とリダイレクトが実現されています。
  - 新しいメソッドにより、入力要素の値をプログラムから直接設定できるようになりました。

- **リファクタリング**
  - 各画面で認証用のベースビューが採用され、アクセス制御が統一されました。
  - ユーザーセッション管理がシングルトンパターンに移行し、内部処理の整合性が向上しました。
  - ユーザーセッションのメソッドが整理され、より明確で保守性の高い構造になりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->