### PR TITLE
⚡ [users] `/api/users/me/`, `PATCH` で自分の avatar を更新できるように

### DIFF
--- a/backend/pong/accounts/player/serializers.py
+++ b/backend/pong/accounts/player/serializers.py
@@ -33,7 +33,7 @@ class PlayerSerializer(serializers.ModelSerializer):
     avatar: serializers.ImageField = serializers.ImageField(
         required=False,
         allow_null=True,
-        # todo: 画像の最大サイズを指定
+        # todo: 画像の最大サイズを指定・拡張子を制限・リサイズする
         # max_length=constants.MAX_AVATAR_SIZE,
     )
 

--- a/backend/pong/users/serializers.py
+++ b/backend/pong/users/serializers.py
@@ -1,4 +1,5 @@
 import os
+from typing import Optional
 
 from django.core.files.uploadedfile import InMemoryUploadedFile
 from rest_framework import serializers
@@ -108,6 +109,24 @@ class UsersSerializer(serializers.Serializer):
                 ).values_list("blocked_user_id", flat=True)
             )
         return player.user.id in self._blocked_relationships_cache
+
+    def validate(self, data: dict) -> dict:
+        """
+        validate()のオーバーライド
+        """
+        # avatar更新時
+        if accounts_constants.PlayerFields.AVATAR in data:
+            avatar: Optional[InMemoryUploadedFile] = data[
+                accounts_constants.PlayerFields.AVATAR
+            ]
+            # 更新時(既にinstanceが存在している時)にNoneの場合はエラー
+            if self.instance and avatar is None:
+                raise serializers.ValidationError(
+                    {
+                        accounts_constants.PlayerFields.AVATAR: "This field may not be blank."
+                    }
+                )
+        return data
 
     def _update_avatar(
         self, player: player_models.Player, new_avatar: InMemoryUploadedFile

--- a/backend/pong/users/serializers.py
+++ b/backend/pong/users/serializers.py
@@ -110,6 +110,11 @@ class UsersSerializer(serializers.Serializer):
     def _update_avatar(
         self, player: player_models.Player, new_avatar: InMemoryUploadedFile
     ) -> InMemoryUploadedFile:
+        # 更新前の画像がデフォルト画像ではない場合は削除してから新しい画像を保存する
+        # todo: デフォルト画像がなくなったら、古いアバターを必ず削除するように変更
+        if player.avatar.name != "avatars/sample.png":
+            player.avatar.delete(save=False)
+
         # todo: 一意なためusernameをファイル名にしているが、良くない場合はuuidなどを追加する
         # todo: 拡張子も新しい画像に合わせる
         new_avatar.name = f"avatars/{player.user.username}.png"

--- a/backend/pong/users/serializers.py
+++ b/backend/pong/users/serializers.py
@@ -1,3 +1,5 @@
+import os
+
 from django.core.files.uploadedfile import InMemoryUploadedFile
 from rest_framework import serializers
 
@@ -115,9 +117,11 @@ class UsersSerializer(serializers.Serializer):
         if player.avatar.name != "avatars/sample.png":
             player.avatar.delete(save=False)
 
+        # ファイル名を変更
+        # mypyにnew_avatar.nameがNoneの可能性を指摘されるが、ImageFieldのvalidatorでextensionがあることは確認済みのため無視
+        _, extension = os.path.splitext(new_avatar.name)  # type: ignore[type-var]
         # todo: 一意なためusernameをファイル名にしているが、良くない場合はuuidなどを追加する
-        # todo: 拡張子も新しい画像に合わせる
-        new_avatar.name = f"avatars/{player.user.username}.png"
+        new_avatar.name = f"avatars/{player.user.username}{extension}"
         return new_avatar
 
     def update(

--- a/backend/pong/users/serializers.py
+++ b/backend/pong/users/serializers.py
@@ -111,14 +111,18 @@ class UsersSerializer(serializers.Serializer):
     ) -> player_models.Player:
         """
         Playerインスタンスを更新するupdate()のオーバーライド
+        更新するフィールドに新しい値を代入し、update_fieldsに指定する
         """
-        player.display_name = validated_data.get(
-            accounts_constants.PlayerFields.DISPLAY_NAME, player.display_name
-        )
+        update_fields: list[str] = []
+
+        # display_nameがあれば更新
+        if accounts_constants.PlayerFields.DISPLAY_NAME in validated_data:
+            player.display_name = validated_data[
+                accounts_constants.PlayerFields.DISPLAY_NAME
+            ]
+            update_fields.append(accounts_constants.PlayerFields.DISPLAY_NAME)
         # todo: avatarも新しいものを代入・save()のupdate_fieldsにも追加
 
         # create()をオーバーライドしない場合、update()内でsave()は必須
-        player.save(
-            update_fields=[accounts_constants.PlayerFields.DISPLAY_NAME]
-        )
+        player.save(update_fields=update_fields)
         return player

--- a/backend/pong/users/views/me.py
+++ b/backend/pong/users/views/me.py
@@ -10,6 +10,7 @@ from rest_framework import (
     status,
     views,
 )
+from rest_framework.parsers import JSONParser, MultiPartParser
 
 from accounts import constants as accounts_constants
 from pong.custom_response import custom_response
@@ -27,6 +28,8 @@ class UsersMeView(views.APIView):
 
     # プロフィールを全て返すのでIsAuthenticatedをセットする必要がある
     permission_classes = [permissions.IsAuthenticated]
+    # アバター画像用にMultiPartParserを追加
+    parser_classes = (JSONParser, MultiPartParser)
 
     def handle_exception(self, exc: Exception) -> response.Response:
         """

--- a/backend/pong/users/views/me.py
+++ b/backend/pong/users/views/me.py
@@ -154,18 +154,27 @@ class UsersMeView(views.APIView):
         )
 
     @utils.extend_schema(
-        request=utils.OpenApiRequest(
-            serializers.UsersSerializer,
-            examples=[
-                utils.OpenApiExample(
-                    "Example request",
-                    value={
-                        accounts_constants.PlayerFields.DISPLAY_NAME: "new_name",
-                        # todo: avatarも追加？
+        request={
+            "application/json": {
+                "type": "object",
+                "properties": {
+                    accounts_constants.PlayerFields.DISPLAY_NAME: {
+                        "type": "string",
+                        "example": "new_name",
                     },
-                ),
-            ],
-        ),
+                },
+            },
+            "multipart/form-data": {
+                "type": "object",
+                "properties": {
+                    accounts_constants.PlayerFields.AVATAR: {
+                        "type": "string",
+                        "format": "binary",
+                        "example": "example.png",
+                    },
+                },
+            },
+        },
         responses={
             200: utils.OpenApiResponse(
                 description="My user profile",


### PR DESCRIPTION
## タスクやディスカッションのリンク
<!-- - URLをここに貼る -->
- #344 

## やったこと
<!-- - このタスクでやったことはなにか？ -->
- 自分のアバター画像を更新できるようにしました
- 簡単なテスト追加 (原因よく分かってないですが、今回は actions でもテストが通ったので追加しました)

## やらないこと
<!-- - このタスクでやらないことはなにか？（やらない場合いつやるのか？無ければ「なし」を記述） -->
- 画像のリサイズ
- 拡張子の制限
- ファイルサイズのバリデーション
- ファイル名に uuid などをつける

## 動作確認
<!-- - どのような動作確認を行い、結果はどうだったのか？(適宜スクショ等添付) -->
- swagger-ui でログインして `/api/users/me/`, `PATCH` にリクエストを送る
- Request body が `application/json`, `multipart/form-data` と選択できることを確認
- `multipart/form-data` を選び、画像を適当に選択してリクエストを送ると、`200` でログインユーザーのアバター画像が更新され、`pong/media/avatars/` の中に `{username}{拡張子}` のファイル名でアップロードした画像が保存されていることを確認
- アバター更新前の画像がデフォルト画像 (`sample.png`) の場合は、更新しても前のデフォルト画像は削除されず、
  アバター更新前の画像がアップロードしたデフォルト画像以外の場合は、更新すると前の画像が削除される
- ファイルを添付せずにリクエストを送ると、`400`, `code=invalid` が返る
- `application/json` の方では今まで通り display_name の更新が可能

## 特にレビューをお願いしたい箇所
<!-- - 特にチェックをお願いしたいポイントを簡潔に記述する -->
主に動作確認と、実装面でも何かあれば

## その他
<!-- - 実装上の懸念点、注意点等あれば記載する -->
特になし

## 参考リンク
<!-- - 実装に際し参考にした、記事やサイトのリンクを記載する -->
- DRF, multipart parser : https://www.django-rest-framework.org/api-guide/parsers/#multipartparser
- Django, ImageField : https://docs.djangoproject.com/ja/5.1/ref/forms/fields/#imagefield
- Django, FileExtensionValidator : https://docs.djangoproject.com/ja/5.1/ref/validators/#fileextensionvalidator

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - ユーザーアバター更新処理を改善し、アップロード時に既存の画像が不要な場合は自動的に削除され、新しい画像はユーザー名を含む名称で保存されます。
  - アップロードリクエストの処理が強化され、JSONとフォームデータの両方に対応できるようになりました。

- **テスト**
  - 有効な画像アップロードおよび無効なファイル名での更新を検証するテストが追加され、品質向上に寄与しています。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->