### PR TITLE
🌱 [pagination] BE全体で使用する一覧取得系のページネーションのカスタム版作成

### DIFF
--- a/backend/pong/pong/custom_pagination/custom_pagination.py
+++ b/backend/pong/pong/custom_pagination/custom_pagination.py
@@ -1,0 +1,56 @@
+import dataclasses
+
+from django.core.exceptions import ObjectDoesNotExist
+from rest_framework import pagination, response, status
+
+from ..custom_response import custom_response
+
+
+@dataclasses.dataclass(frozen=True)
+class PaginationFields:
+    COUNT: str = "count"
+    NEXT: str = "next"
+    PREVIOUS: str = "previous"
+    RESULTS: str = "results"
+
+
+class CustomPagination(pagination.PageNumberPagination):
+    """
+    ページネーションのカスタムクラス
+    複数のアイテムをlistで返す場合に使用する
+
+    Attributes:
+        page_size: 1ページあたりのアイテム数
+    """
+
+    def __init__(self, page_size: int = 20) -> None:
+        self.page_size = page_size
+
+    def get_paginated_response(
+        self, paginated_data: list, status_code: int = status.HTTP_200_OK
+    ) -> response.Response:
+        """
+        get_paginated_response()のオーバーライド
+        ページネーションされたデータをCustomResponseに変換して返す
+
+        Args:
+            paginated_data: ページネーションされたデータ
+            status_code: レスポンスのステータスコード
+
+        Returns:
+            response.Response: ページネーションされたデータがdataにセットされたCustomResponse
+
+        Raises:
+            ObjectDoesNotExist: self.pageがNoneの場合
+        """
+        # mypyがself.pageがNoneの可能性を検出しているため念のため例外を投げているが、恐らくNoneにはならない
+        if self.page is None:
+            raise ObjectDoesNotExist("CustomPagination: self.page is None.")
+
+        data: dict = {
+            PaginationFields.COUNT: self.page.paginator.count,
+            PaginationFields.NEXT: self.get_next_link(),
+            PaginationFields.PREVIOUS: self.get_previous_link(),
+            PaginationFields.RESULTS: paginated_data,
+        }
+        return custom_response.CustomResponse(data=data, status=status_code)

--- a/backend/pong/pong/custom_pagination/test_custom_pagination.py
+++ b/backend/pong/pong/custom_pagination/test_custom_pagination.py
@@ -111,3 +111,33 @@ class CustomPaginationTests(TestCase):
                 RESULTS: [self.data3],  # 1アイテム
             },
         )
+
+    def test_get_200_non_item(self) -> None:
+        """
+        アイテムが0の場合、エラーにならず空のリストが返ることを確認
+        """
+        paginator: custom_pagination.CustomPagination = (
+            custom_pagination.CustomPagination()  # page_sizeの指定なし(デフォルト)
+        )
+        request: drf_request.Request = drf_request.Request(
+            self.factory.get("/")
+        )
+        # アイテム0という意味の空リストを渡す
+        paginated_data: Optional[list] = paginator.paginate_queryset(
+            [],  # type: ignore[arg-type]
+            request,
+        )
+        response: drf_response.Response = paginator.get_paginated_response(
+            paginated_data  # type: ignore[arg-type]
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            response.data[DATA],
+            {
+                COUNT: 0,
+                NEXT: None,
+                PREVIOUS: None,
+                RESULTS: [],  # 0アイテム
+            },
+        )

--- a/backend/pong/pong/custom_pagination/test_custom_pagination.py
+++ b/backend/pong/pong/custom_pagination/test_custom_pagination.py
@@ -1,0 +1,58 @@
+from typing import Final, Optional
+
+from django.test import TestCase
+from rest_framework import request as drf_request
+from rest_framework import response as drf_response
+from rest_framework import status, test
+
+from ..custom_pagination import custom_pagination
+from ..custom_response import custom_response
+
+DATA: Final[str] = custom_response.DATA
+
+COUNT: Final[str] = custom_pagination.PaginationFields.COUNT
+NEXT: Final[str] = custom_pagination.PaginationFields.NEXT
+PREVIOUS: Final[str] = custom_pagination.PaginationFields.PREVIOUS
+RESULTS: Final[str] = custom_pagination.PaginationFields.RESULTS
+
+
+class CustomPaginationTests(TestCase):
+    def setUp(self) -> None:
+        # 3つのアイテムを用意(pongではmodelのインスタンスに相当)
+        self.data1 = {"key1": "value1"}
+        self.data2 = {"key2": "value2"}
+        self.data3 = {"key3": "value3"}
+        self.paginated_data = [self.data1, self.data2, self.data3]
+
+        self.factory: test.APIRequestFactory = test.APIRequestFactory()
+
+    def test_get_200_default_page_size(self) -> None:
+        """
+        デフォルト(1ページ20アイテム)のページネーションされたデータが返ることを確認
+        3つのアイテムが1ページで返る
+        """
+        paginator: custom_pagination.CustomPagination = (
+            custom_pagination.CustomPagination()  # page_sizeの指定なし(デフォルト)
+        )
+        request: drf_request.Request = drf_request.Request(
+            self.factory.get("/")
+        )
+
+        paginated_data: Optional[list] = paginator.paginate_queryset(
+            self.paginated_data,  # type: ignore[arg-type]
+            request,
+        )
+        response: drf_response.Response = paginator.get_paginated_response(
+            paginated_data  # type: ignore[arg-type]
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            response.data[DATA],
+            {
+                COUNT: 3,
+                NEXT: None,
+                PREVIOUS: None,
+                RESULTS: self.paginated_data,  # 3アイテム
+            },
+        )

--- a/backend/pong/pong/custom_pagination/test_custom_pagination.py
+++ b/backend/pong/pong/custom_pagination/test_custom_pagination.py
@@ -56,3 +56,58 @@ class CustomPaginationTests(TestCase):
                 RESULTS: self.paginated_data,  # 3アイテム
             },
         )
+
+    def test_get_200_low_page_size(self) -> None:
+        """
+        page sizeよりアイテム数が多い場合、複数ページに分かれて全てのアイテムが返ることを確認
+        page sizeを2に設定し、1ページ目は2アイテム・2ページ目は1アイテムが返る
+        """
+        paginator: custom_pagination.CustomPagination = (
+            custom_pagination.CustomPagination(page_size=2)  # page_sizeを指定
+        )
+
+        # 1ページ目を取得
+        request: drf_request.Request = drf_request.Request(
+            self.factory.get("/")
+        )
+        paginated_data: Optional[list] = paginator.paginate_queryset(
+            self.paginated_data,  # type: ignore[arg-type]
+            request,
+        )
+        response: drf_response.Response = paginator.get_paginated_response(
+            paginated_data  # type: ignore[arg-type]
+        )
+        # 1ページ目のdataを確認
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            response.data[DATA],
+            {
+                COUNT: 3,
+                NEXT: "http://testserver/?page=2",
+                PREVIOUS: None,
+                RESULTS: [self.data1, self.data2],  # 2アイテム
+            },
+        )
+
+        # 2ページ目を取得
+        request2: drf_request.Request = drf_request.Request(
+            self.factory.get("/?page=2")
+        )
+        paginated_data2: Optional[list] = paginator.paginate_queryset(
+            self.paginated_data,  # type: ignore[arg-type]
+            request2,
+        )
+        response2: drf_response.Response = paginator.get_paginated_response(
+            paginated_data2  # type: ignore[arg-type]
+        )
+        # 2ページ目のdataを確認
+        self.assertEqual(response2.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            response2.data[DATA],
+            {
+                COUNT: 3,
+                NEXT: None,
+                PREVIOUS: "http://testserver/",
+                RESULTS: [self.data3],  # 1アイテム
+            },
+        )


### PR DESCRIPTION
## タスクやディスカッションのリンク
<!-- - URLをここに貼る -->
- #377 

## やったこと
<!-- - このタスクでやったことはなにか？ -->
- DRF のページネーションクラスを継承し、`CustomResponse` 形式でレスポンスを返す `CustomPagination` クラスを作成しました
- 簡単にテストも追加

## やらないこと
<!-- - このタスクでやらないことはなにか？（やらない場合いつやるのか？無ければ「なし」を記述） -->
- 各 app で使用すること -> 別 PR でします
- トーナメントなどはよろしくお願いします！

## 動作確認
<!-- - どのような動作確認を行い、結果はどうだったのか？(適宜スクショ等添付) -->
- テストが通ること

## 特にレビューをお願いしたい箇所
<!-- - 特にチェックをお願いしたいポイントを簡潔に記述する -->
実装面でカスタム方法が大丈夫そうか、他に気になる点などあればなんでも

## その他
<!-- - 実装上の懸念点、注意点等あれば記載する -->
- 本当は DRF の pagination を使用する際は `settings.py` に以下のようにデフォルトのページネーションクラスを指定するようなのですが、設定してみたところ、自動で `PaginatedTournamentsListList`, `PaginatedFriendsListList` のようなスキーマが作られて (なぜか PaginatedBlockListList など他のものは作られない)、extend_schema で上書きしても examples が変なスキーマになってしまうという現象が発生したので、一旦 settings.py には書かずに個別に view で使いたい場面で使うことにしました
```py
REST_FRAMEWORK = {
         :
    # pagination
    "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",  # これまたは
    "DEFAULT_PAGINATION_CLASS": "pong.custom_pagination.custom_pagination.CustomPagination",  # これ
    "PAGE_SIZE": 20,  # 1ページあたりのアイテム数のデフォルト値
}
```
- 実際に view で使う際は以下のように書くとページネーションされたレスポンスが返せます (PR #382 で実際に使用しているので参考になればと思います)
```py
    def list(self, request: request.Request) -> response.Response:
        """
        自分のフレンドのユーザープロフィール一覧を取得するGETメソッド
        """
        # ログインユーザーの取得
        user: User = self._get_authenticated_user(request.user)

        # 自分のフレンド一覧を取得
        friends: QuerySet[models.Friendship] = self.queryset.filter(user=user)
        paginator: custom_pagination.CustomPagination = (
            custom_pagination.CustomPagination()
        )
        paginated_friends: Optional[list[models.Friendship]] = (
            paginator.paginate_queryset(friends, request)
        )
        list_serializer: list_serializers.FriendshipListSerializer = (
            list_serializers.FriendshipListSerializer(
                paginated_friends,
                many=True,
                context={constants.FriendshipFields.USER_ID: user.id},
            )
        )
        return paginator.get_paginated_response(list(list_serializer.data))
```

## 参考リンク
<!-- - 実装に際し参考にした、記事やサイトのリンクを記載する -->
- DRF, PageNumberPagination : https://www.django-rest-framework.org/api-guide/pagination/#pagenumberpagination
- DRF, Custom pagination : https://www.django-rest-framework.org/api-guide/pagination/#custom-pagination-styles

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - APIレスポンス用のカスタムページネーションを導入し、デフォルトのページサイズ設定とレスポンスのフォーマットが改善されました。
- **テスト**
  - ページネーション機能に対するユニットテストが追加され、通常の動作、指定ページサイズ、および空データ時の動作が確認されました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->