### PR TITLE
:zap: 作成・更新のためのトーナメントシリアライザ―作成

### DIFF
--- a/backend/pong/tournaments/constants.py
+++ b/backend/pong/tournaments/constants.py
@@ -1,5 +1,8 @@
 import dataclasses
 from enum import Enum
+from typing import Final
+
+MAX_PARTICIPATIONS: Final[int] = 4
 
 
 @dataclasses.dataclass(frozen=True)

--- a/backend/pong/tournaments/tournament/serializers.py
+++ b/backend/pong/tournaments/tournament/serializers.py
@@ -49,3 +49,47 @@ class TournamentCommandSerializer(drf_serializers.ModelSerializer):
                 "default": constants.TournamentFields.StatusEnum.NOT_STARTED.value,
             }
         }
+
+    def validate(self, data: dict) -> dict:
+        """
+        validate()のオーバーライド関数。
+
+        Raises:
+            ValidationError:
+                更新時:
+                    状態をON_GOINGにするときにまだ参加者がMAX_PARTICIPATIONS人いない場合。
+                    状態をCANCELEDにするときにまだ参加者がいる場合。
+        """
+        # 作成時のバリデーション
+        # return data
+        new_status = data.get(constants.TournamentFields.STATUS)
+
+        if self.instance:  # 更新時
+            # ON_GOING に変更する場合のバリデーション
+            if (
+                new_status
+                == constants.TournamentFields.StatusEnum.ON_GOING.value
+            ):
+                # MAX_PARTICIPATIONS 人に達していない場合はエラーを発生
+                max_participations = (
+                    constants.MAX_PARTICIPATIONS
+                )  # 定義されている最大参加人数
+                current_participants_count = (
+                    self.instance.tournament_participations.count()
+                )
+                if current_participants_count < max_participations:
+                    raise drf_serializers.ValidationError(
+                        f"Cannot set the status to ON_GOING with less than {max_participations} participants."
+                    )
+            # CANCELEDに変更する場合のバリデーション
+            if (
+                self.instance
+                and new_status
+                == constants.TournamentFields.StatusEnum.CANCELED.value
+            ):
+                if self.instance.tournament_participations.exists():
+                    raise drf_serializers.ValidationError(
+                        "Cannot cancel a tournament with participants."
+                    )
+
+        return data

--- a/backend/pong/tournaments/tournament/serializers.py
+++ b/backend/pong/tournaments/tournament/serializers.py
@@ -5,9 +5,9 @@ from ..round import serializers as round_serializers
 from . import models
 
 
-class TournamentSerializer(drf_serializers.ModelSerializer):
+class TournamentQuerySerializer(drf_serializers.ModelSerializer):
     """
-    Tournamentモデルのシリアライザ
+    Tournamentモデルのクエリ(読み取り)操作のためのシリアライザ
     """
 
     rounds = round_serializers.RoundSerializer(

--- a/backend/pong/tournaments/tournament/serializers.py
+++ b/backend/pong/tournaments/tournament/serializers.py
@@ -23,3 +23,29 @@ class TournamentQuerySerializer(drf_serializers.ModelSerializer):
             constants.TournamentFields.UPDATED_AT,
             "rounds",
         )
+
+
+class TournamentCommandSerializer(drf_serializers.ModelSerializer):
+    """
+    Tournamentモデルのコマンド(書き込み)操作のためのシリアライザ
+    """
+
+    class Meta:
+        model = models.Tournament
+        fields = (
+            constants.TournamentFields.ID,
+            constants.TournamentFields.STATUS,
+            constants.TournamentFields.CREATED_AT,
+            constants.TournamentFields.UPDATED_AT,
+        )
+        read_only_fields = (
+            constants.TournamentFields.ID,
+            constants.TournamentFields.CREATED_AT,
+            constants.TournamentFields.UPDATED_AT,
+        )
+        extra_kwargs = {
+            constants.TournamentFields.STATUS: {
+                "required": False,
+                "default": constants.TournamentFields.StatusEnum.NOT_STARTED.value,
+            }
+        }

--- a/backend/pong/tournaments/tournament/serializers.py
+++ b/backend/pong/tournaments/tournament/serializers.py
@@ -64,7 +64,7 @@ class TournamentCommandSerializer(drf_serializers.ModelSerializer):
         # return data
         new_status = data.get(constants.TournamentFields.STATUS)
 
-        if self.instance:  # 更新時
+        if isinstance(self.instance, models.Tournament):
             # ON_GOING に変更する場合のバリデーション
             if (
                 new_status

--- a/backend/pong/tournaments/tournament/serializers.py
+++ b/backend/pong/tournaments/tournament/serializers.py
@@ -60,11 +60,8 @@ class TournamentCommandSerializer(drf_serializers.ModelSerializer):
                     状態をON_GOINGにするときにまだ参加者がMAX_PARTICIPATIONS人いない場合。
                     状態をCANCELEDにするときにまだ参加者がいる場合。
         """
-        # 作成時のバリデーション
-        # return data
-        new_status = data.get(constants.TournamentFields.STATUS)
-
         if isinstance(self.instance, models.Tournament):
+            new_status = data.get(constants.TournamentFields.STATUS)
             # ON_GOING に変更する場合のバリデーション
             if (
                 new_status
@@ -81,10 +78,10 @@ class TournamentCommandSerializer(drf_serializers.ModelSerializer):
                     raise drf_serializers.ValidationError(
                         f"Cannot set the status to ON_GOING with less than {max_participations} participants."
                     )
+
             # CANCELEDに変更する場合のバリデーション
             if (
-                self.instance
-                and new_status
+                new_status
                 == constants.TournamentFields.StatusEnum.CANCELED.value
             ):
                 if self.instance.tournament_participations.exists():

--- a/backend/pong/tournaments/tournament/tests/test_command_serializers.py
+++ b/backend/pong/tournaments/tournament/tests/test_command_serializers.py
@@ -11,6 +11,11 @@ from ..serializers import TournamentCommandSerializer
 
 
 class TournamentCommandSerializerTest(TestCase):
+    def setUp(self):
+        # テスト用のトーナメントインスタンスを作成
+        self.tournament = models.Tournament.objects.create(
+            status=constants.TournamentFields.StatusEnum.NOT_STARTED.value
+        )
 
     def test_default_status(self):
         """
@@ -25,3 +30,47 @@ class TournamentCommandSerializerTest(TestCase):
             serializer.validated_data[constants.TournamentFields.STATUS],
             constants.TournamentFields.StatusEnum.NOT_STARTED.value,
         )
+
+    def test_on_going_status_with_insufficient_participants(self):
+        """
+        `status` を `ON_GOING` に変更する際、参加者が足りない場合にエラーが発生するかを確認するテスト
+        """
+        serializer_data = {
+            constants.TournamentFields.STATUS: constants.TournamentFields.StatusEnum.ON_GOING.value,
+        }
+        serializer = TournamentCommandSerializer(
+            self.tournament, data=serializer_data
+        )
+        with self.assertRaises(ValidationError):
+            serializer.is_valid(raise_exception=True)
+
+    def test_cancelled_status_with_participants(self):
+        """
+        参加者がいる場合に `status` を `CANCELED` に変更できないことを確認するテスト
+        """
+        # プレーヤーのモックを作成
+        user = User.objects.create(
+            username="testuser_1",
+            email="testuser_1@example.com",
+            password="testpassword",
+        )
+        player = player_models.Player.objects.create(
+            user=user, display_name="Test Player"
+        )
+
+
+        # 参加者を追加
+        participation_models.Participation.objects.create(
+            tournament=self.tournament,
+            player=player,
+            participation_name="Player 1",
+        )
+
+        serializer_data = {
+            constants.TournamentFields.STATUS: constants.TournamentFields.StatusEnum.CANCELED.value,
+        }
+        serializer = TournamentCommandSerializer(
+            self.tournament, data=serializer_data
+        )
+        with self.assertRaises(ValidationError):
+            serializer.is_valid(raise_exception=True)

--- a/backend/pong/tournaments/tournament/tests/test_command_serializers.py
+++ b/backend/pong/tournaments/tournament/tests/test_command_serializers.py
@@ -1,0 +1,27 @@
+from django.test import TestCase
+from django.contrib.auth.models import User
+from rest_framework.serializers import ValidationError
+
+from tournaments import constants
+from tournaments.participation import models as participation_models
+from accounts.player import models as player_models
+
+from .. import models
+from ..serializers import TournamentCommandSerializer
+
+
+class TournamentCommandSerializerTest(TestCase):
+
+    def test_default_status(self):
+        """
+        `status` が指定されていない場合にデフォルト値が設定されているかを確認するテスト
+        """
+        serializer_data = {
+            constants.TournamentFields.ID: self.tournament.id,
+        }
+        serializer = TournamentCommandSerializer(data=serializer_data)
+        self.assertTrue(serializer.is_valid())  # バリデーション成功
+        self.assertEqual(
+            serializer.validated_data[constants.TournamentFields.STATUS],
+            constants.TournamentFields.StatusEnum.NOT_STARTED.value,
+        )

--- a/backend/pong/tournaments/tournament/tests/test_command_serializers.py
+++ b/backend/pong/tournaments/tournament/tests/test_command_serializers.py
@@ -11,13 +11,13 @@ from ..serializers import TournamentCommandSerializer
 
 
 class TournamentCommandSerializerTest(TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         # テスト用のトーナメントインスタンスを作成
         self.tournament = models.Tournament.objects.create(
             status=constants.TournamentFields.StatusEnum.NOT_STARTED.value
         )
 
-    def test_default_status(self):
+    def test_default_status(self) -> None:
         """
         `status` が指定されていない場合にデフォルト値が設定されているかを確認するテスト
         """
@@ -31,7 +31,7 @@ class TournamentCommandSerializerTest(TestCase):
             constants.TournamentFields.StatusEnum.NOT_STARTED.value,
         )
 
-    def test_on_going_status_with_insufficient_participants(self):
+    def test_on_going_status_with_insufficient_participants(self) -> None:
         """
         `status` を `ON_GOING` に変更する際、参加者が足りない場合にエラーが発生するかを確認するテスト
         """
@@ -44,7 +44,7 @@ class TournamentCommandSerializerTest(TestCase):
         with self.assertRaises(ValidationError):
             serializer.is_valid(raise_exception=True)
 
-    def test_cancelled_status_with_participants(self):
+    def test_cancelled_status_with_participants(self) -> None:
         """
         参加者がいる場合に `status` を `CANCELED` に変更できないことを確認するテスト
         """
@@ -74,7 +74,7 @@ class TournamentCommandSerializerTest(TestCase):
         with self.assertRaises(ValidationError):
             serializer.is_valid(raise_exception=True)
 
-    def test_cancelled_status_without_participants(self):
+    def test_cancelled_status_without_participants(self) -> None:
         """
         参加者がいない場合に `status` を `CANCELED` に変更できることを確認するテスト
         """

--- a/backend/pong/tournaments/tournament/views.py
+++ b/backend/pong/tournaments/tournament/views.py
@@ -47,7 +47,7 @@ from . import models, serializers
         request=None,
         responses={
             200: OpenApiResponse(
-                response=serializers.TournamentSerializer,
+                response=serializers.TournamentQuerySerializer,
                 examples=[
                     OpenApiExample(
                         "Example 200 response",
@@ -235,7 +235,7 @@ from . import models, serializers
         operation_id="tournaments_retrieve_by_id",  # 明示的にoperationIdを設定
         responses={
             200: OpenApiResponse(
-                response=serializers.TournamentSerializer,
+                response=serializers.TournamentQuerySerializer,
                 examples=[
                     OpenApiExample(
                         "Example 200 response",
@@ -436,7 +436,7 @@ from . import models, serializers
 )
 class TournamentReadOnlyViewSet(viewsets.ReadOnlyModelViewSet):
     permission_classes = (permissions.IsAuthenticated,)
-    serializer_class = serializers.TournamentSerializer
+    serializer_class = serializers.TournamentQuerySerializer
     renderer_classes = [readonly_custom_renderer.ReadOnlyCustomJSONRenderer]
 
     def get_queryset(self) -> QuerySet:


### PR DESCRIPTION
## タスクやディスカッションのリンク
<!-- - URLをここに貼る -->

## やったこと
<!-- - このタスクでやったことはなにか？ -->
- BEのコード内からしか入力を渡されない、作成・更新用のトーナメントシリアライザーの作成。
- シリアライザ―が増えたので、もともとあった読み取り専用のシリアライザ―も名前を変更しました。
- シリアライザ―のテストも作成しました。

## やらないこと
<!-- - このタスクでやらないことはなにか？（やらない場合いつやるのか？無ければ「なし」を記述） -->
- participationの方は次のPRで行います。

## 動作確認
<!-- - どのような動作確認を行い、結果はどうだったのか？(適宜スクショ等添付) -->
- 作成したテストが通ること。

## 特にレビューをお願いしたい箇所
<!-- - 特にチェックをお願いしたいポイントを簡潔に記述する -->
- ほかに必要そうなテストケースがあれば教えていただきたいです。

## その他
<!-- - 実装上の懸念点、注意点等あれば記載する -->
- トーナメントの進行中はそこまでスピード重視ではないので、同期的なシリアライザ―でバリデーションを行うことにしました。
- 実際にはバリデーションを行うといっても入力はバリデーションエラーにならないように渡すことになります。

## 参考リンク
<!-- - 実装に際し参考にした、記事やサイトのリンクを記載する -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - トーナメントの参加上限が明確に設定され、状態更新時に必要な条件が強化されました。
  - 読み取り専用処理と更新処理が分離され、データの整合性と運用の安定性が向上しました。

- **テスト**
  - トーナメントの状態変更に関する各種検証が追加され、より正確な動作が確認できるようになっています。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->