### PR TITLE
:zap: 作成・更新のためのトーナメント参加シリアライザ―

### DIFF
--- a/backend/pong/tournaments/participation/serializers.py
+++ b/backend/pong/tournaments/participation/serializers.py
@@ -100,7 +100,7 @@ class ParticipationCommandSerializer(serializers.ModelSerializer):
 
         return data
 
-    def validate_ranking(self, value):
+    def validate_ranking(self, value: int) -> int:
         if value is not None and (
             value < 1 or value > constants.MAX_PARTICIPATIONS
         ):

--- a/backend/pong/tournaments/participation/serializers.py
+++ b/backend/pong/tournaments/participation/serializers.py
@@ -1,3 +1,4 @@
+from django.core.validators import RegexValidator
 from rest_framework import serializers
 
 from accounts.player.models import Player
@@ -37,6 +38,16 @@ class ParticipationCommandSerializer(serializers.ModelSerializer):
     )
     player_id = serializers.PrimaryKeyRelatedField(
         queryset=Player.objects.all(), source="player"
+    )
+    participation_name: serializers.CharField = serializers.CharField(
+        max_length=15,
+        validators=[
+            # 使用可能文字列を指定: 英子文字・英大文字・数字・記号(-_.~)
+            RegexValidator(
+                regex=r"^[a-zA-Z0-9-_.~]+$",
+                message="Must contain only alphanumeric characters or some symbols(-_.~)",
+            )
+        ],
     )
 
     class Meta:

--- a/backend/pong/tournaments/participation/serializers.py
+++ b/backend/pong/tournaments/participation/serializers.py
@@ -4,7 +4,11 @@ from .. import constants
 from . import models
 
 
-class ParticipationSerializer(serializers.ModelSerializer):
+class ParticipationQuerySerializer(serializers.ModelSerializer):
+    """
+    Participationモデルのクエリ(読み取り)操作のためのシリアライザ
+    """
+
     user_id = serializers.IntegerField(source="player.user.id", read_only=True)
 
     class Meta:

--- a/backend/pong/tournaments/participation/serializers.py
+++ b/backend/pong/tournaments/participation/serializers.py
@@ -1,5 +1,8 @@
 from rest_framework import serializers
 
+from accounts.player.models import Player
+from tournaments.tournament.models import Tournament
+
 from .. import constants
 from . import models
 
@@ -23,7 +26,53 @@ class ParticipationQuerySerializer(serializers.ModelSerializer):
             constants.ParticipationFields.UPDATED_AT,
         )
 
-    # TODO: rankingに渡される値が正確かどうかのバリデーション実装
-    # TODO: rankingをrequired=False, default=Noneを追加
-    # TODO: participation_nameが空だったらエラー
-    # TODO: UniqueTogetherValidatorを追加
+
+class ParticipationCommandSerializer(serializers.ModelSerializer):
+    """
+    Participationモデルのコマンド(書き込み)操作のためのシリアライザ
+    """
+
+    tournament_id = serializers.PrimaryKeyRelatedField(
+        queryset=Tournament.objects.all(), source="tournament"
+    )
+    player_id = serializers.PrimaryKeyRelatedField(
+        queryset=Player.objects.all(), source="player"
+    )
+
+    class Meta:
+        model = models.Participation
+        fields = (
+            constants.ParticipationFields.ID,
+            constants.ParticipationFields.TOURNAMENT_ID,
+            constants.ParticipationFields.PLAYER_ID,
+            constants.ParticipationFields.PARTICIPATION_NAME,
+            constants.ParticipationFields.RANKING,
+        )
+        extra_kwargs = {
+            constants.ParticipationFields.TOURNAMENT_ID: {
+                "required": True,
+            },
+            constants.ParticipationFields.PLAYER_ID: {
+                "required": True,
+            },
+            constants.ParticipationFields.PARTICIPATION_NAME: {
+                "required": True,
+            },
+            constants.ParticipationFields.RANKING: {
+                "required": False,
+                "allow_null": True,
+                "default": None,
+            },
+        }
+        # ユニーク制約を追加
+        # TODO: なぜか効かなくて図っと詰まってしまったのでいったんモデルの方で行う
+        # validators = [
+        #    UniqueTogetherValidator(
+        #        queryset=models.Participation.objects.all(),
+        #        fields=(
+        #            constants.ParticipationFields.TOURNAMENT_ID,
+        #            constants.ParticipationFields.PLAYER_ID,
+        #        ),
+        #        message="このトーナメントとプレイヤーの組み合わせは既に存在します。",
+        #    )
+        # ]

--- a/backend/pong/tournaments/participation/serializers.py
+++ b/backend/pong/tournaments/participation/serializers.py
@@ -1,8 +1,10 @@
+from typing import Optional
+
 from django.core.validators import RegexValidator
 from rest_framework import serializers
 
-from accounts.player.models import Player
-from tournaments.tournament.models import Tournament
+from accounts.player import models as player_models
+from tournaments.tournament import models as tournament_models
 
 from .. import constants
 from . import models
@@ -34,12 +36,14 @@ class ParticipationCommandSerializer(serializers.ModelSerializer):
     """
 
     tournament_id = serializers.PrimaryKeyRelatedField(
-        queryset=Tournament.objects.all(), source="tournament"
+        queryset=tournament_models.Tournament.objects.all(),
+        source="tournament",
     )
     player_id = serializers.PrimaryKeyRelatedField(
-        queryset=Player.objects.all(), source="player"
+        queryset=player_models.Player.objects.all(),
+        source="player",
     )
-    participation_name: serializers.CharField = serializers.CharField(
+    participation_name = serializers.CharField(
         max_length=15,
         validators=[
             # 使用可能文字列を指定: 英子文字・英大文字・数字・記号(-_.~)
@@ -60,17 +64,8 @@ class ParticipationCommandSerializer(serializers.ModelSerializer):
             constants.ParticipationFields.RANKING,
         )
         extra_kwargs = {
-            constants.ParticipationFields.TOURNAMENT_ID: {
-                "required": True,
-            },
-            constants.ParticipationFields.PLAYER_ID: {
-                "required": True,
-            },
-            constants.ParticipationFields.PARTICIPATION_NAME: {
-                "required": True,
-            },
             constants.ParticipationFields.RANKING: {
-                "required": False,
+                "required": False,  # デフォルトではTrue
                 "allow_null": True,
                 "default": None,
             },
@@ -111,7 +106,7 @@ class ParticipationCommandSerializer(serializers.ModelSerializer):
 
         return data
 
-    def validate_ranking(self, value: int) -> int:
+    def validate_ranking(self, value: Optional[int]) -> Optional[int]:
         if value is not None and (
             value < 1 or value > constants.MAX_PARTICIPATIONS
         ):

--- a/backend/pong/tournaments/participation/tests/test_command_serializers.py
+++ b/backend/pong/tournaments/participation/tests/test_command_serializers.py
@@ -154,3 +154,23 @@ class ParticipationCommandSerializerTestCase(TestCase):
         self.assertIn(
             constants.ParticipationFields.RANKING, update_serializer.errors
         )
+
+    # TODO: ユニーク制約をシリアライザ―でできたら追加
+    # def test_unique_together_constraint(self):
+    #    """ユニーク制約が正しく適用されることを確認"""
+    #    # 既に存在する参加者のデータ
+    #    participation_models.Participation.objects.create(
+    #        tournament=self.tournament,
+    #        player=self.player,
+    #        participation_name="Player 1",
+    #    )
+
+    #    # 同じ組み合わせで再度データを作成しようとするとエラー
+    #    data = {
+    #        constants.ParticipationFields.TOURNAMENT_ID: self.tournament.id,
+    #        constants.ParticipationFields.PLAYER_ID: self.player.id,
+    #        constants.ParticipationFields.PARTICIPATION_NAME: "Player 2",
+    #    }
+    #    serializer = ParticipationCommandSerializer(data=data)
+    #    with self.assertRaises(ValidationError):
+    #        serializer.is_valid(raise_exception=True)

--- a/backend/pong/tournaments/participation/tests/test_command_serializers.py
+++ b/backend/pong/tournaments/participation/tests/test_command_serializers.py
@@ -1,0 +1,38 @@
+from django.contrib.auth.models import User
+from django.test import TestCase
+from rest_framework.serializers import ValidationError
+
+from accounts.player import models as player_models
+from tournaments import constants
+from tournaments.tournament import models as tournament_models
+
+from .. import models as participation_models
+from ..serializers import ParticipationCommandSerializer
+
+
+class ParticipationCommandSerializerTestCase(TestCase):
+    def setUp(self) -> None:
+        # プレーヤーのモックを作成
+        self.user = User.objects.create(
+            username="testuser_1",
+            email="testuser_1@example.com",
+            password="testpassword",
+        )
+        self.player = player_models.Player.objects.create(
+            user=self.user, display_name="Test Player"
+        )
+        self.tournament = tournament_models.Tournament.objects.create()
+
+    def test_successful_creation(self) -> None:
+        """正常にデータが作成できる場合"""
+        data = {
+            constants.ParticipationFields.TOURNAMENT_ID: self.tournament.id,
+            constants.ParticipationFields.PLAYER_ID: self.player.id,
+            constants.ParticipationFields.PARTICIPATION_NAME: "New Player",
+        }
+        serializer = ParticipationCommandSerializer(data=data)
+        self.assertTrue(serializer.is_valid())
+        self.assertEqual(
+            None,
+            serializer.validated_data[constants.ParticipationFields.RANKING],
+        )

--- a/backend/pong/tournaments/participation/tests/test_command_serializers.py
+++ b/backend/pong/tournaments/participation/tests/test_command_serializers.py
@@ -36,3 +36,39 @@ class ParticipationCommandSerializerTestCase(TestCase):
             None,
             serializer.validated_data[constants.ParticipationFields.RANKING],
         )
+
+    def test_missing_tournament_id(self) -> None:
+        """必須フィールドであるtournament_idが不足している場合のテスト"""
+        data = {
+            constants.ParticipationFields.PLAYER_ID: self.player.id,
+            constants.ParticipationFields.PARTICIPATION_NAME: "player_x",
+        }
+        serializer = ParticipationCommandSerializer(data=data)
+        self.assertFalse(serializer.is_valid())
+        self.assertIn(
+            constants.ParticipationFields.TOURNAMENT_ID, serializer.errors
+        )
+
+    def test_missing_player_id(self) -> None:
+        """必須フィールドであるplayer_idが不足している場合のテスト"""
+        data = {
+            constants.ParticipationFields.TOURNAMENT_ID: self.tournament.id,
+            constants.ParticipationFields.PARTICIPATION_NAME: "player_x",
+        }
+        serializer = ParticipationCommandSerializer(data=data)
+        self.assertFalse(serializer.is_valid())
+        self.assertIn(
+            constants.ParticipationFields.PLAYER_ID, serializer.errors
+        )
+
+    def test_missing_participation_name(self) -> None:
+        """必須フィールドであるparticipation_nameが不足している場合のテスト"""
+        data = {
+            constants.ParticipationFields.TOURNAMENT_ID: self.tournament.id,
+            constants.ParticipationFields.PLAYER_ID: self.player.id,
+        }
+        serializer = ParticipationCommandSerializer(data=data)
+        self.assertFalse(serializer.is_valid())
+        self.assertIn(
+            constants.ParticipationFields.PARTICIPATION_NAME, serializer.errors
+        )

--- a/backend/pong/tournaments/participation/tests/test_command_serializers.py
+++ b/backend/pong/tournaments/participation/tests/test_command_serializers.py
@@ -28,7 +28,7 @@ class ParticipationCommandSerializerTestCase(TestCase):
         data = {
             constants.ParticipationFields.TOURNAMENT_ID: self.tournament.id,
             constants.ParticipationFields.PLAYER_ID: self.player.id,
-            constants.ParticipationFields.PARTICIPATION_NAME: "New Player",
+            constants.ParticipationFields.PARTICIPATION_NAME: "player_x",
         }
         serializer = ParticipationCommandSerializer(data=data)
         self.assertTrue(serializer.is_valid())
@@ -83,20 +83,20 @@ class ParticipationCommandSerializerTestCase(TestCase):
                 password="testpassword",
             )
             player = player_models.Player.objects.create(
-                user=user, display_name="Test Player"
+                user=user, display_name="Test_Player"
             )
 
             participation_models.Participation.objects.create(
                 tournament_id=self.tournament.id,
                 player_id=player.id,
-                participation_name="Player {}".format(i + 1),
+                participation_name=f"player_{i}",
             )
 
         # 参加者がMAX_PARTICIPATIONSを超えた場合、エラーが発生
         data = {
             constants.ParticipationFields.TOURNAMENT_ID: self.tournament.id,
             constants.ParticipationFields.PLAYER_ID: self.player.id,
-            constants.ParticipationFields.PARTICIPATION_NAME: "New Player",
+            constants.ParticipationFields.PARTICIPATION_NAME: "player_x",
         }
         serializer = ParticipationCommandSerializer(data=data)
         with self.assertRaises(ValidationError):
@@ -108,7 +108,7 @@ class ParticipationCommandSerializerTestCase(TestCase):
         creation_data = {
             constants.ParticipationFields.TOURNAMENT_ID: self.tournament.id,
             constants.ParticipationFields.PLAYER_ID: self.player.id,
-            constants.ParticipationFields.PARTICIPATION_NAME: "New Player",
+            constants.ParticipationFields.PARTICIPATION_NAME: "player_x",
         }
         create_serializer = ParticipationCommandSerializer(data=creation_data)
         self.assertTrue(create_serializer.is_valid())
@@ -135,7 +135,7 @@ class ParticipationCommandSerializerTestCase(TestCase):
         creation_data = {
             constants.ParticipationFields.TOURNAMENT_ID: self.tournament.id,
             constants.ParticipationFields.PLAYER_ID: self.player.id,
-            constants.ParticipationFields.PARTICIPATION_NAME: "New Player",
+            constants.ParticipationFields.PARTICIPATION_NAME: "player_x",
         }
         create_serializer = ParticipationCommandSerializer(data=creation_data)
         self.assertTrue(create_serializer.is_valid())
@@ -154,6 +154,7 @@ class ParticipationCommandSerializerTestCase(TestCase):
         self.assertIn(
             constants.ParticipationFields.RANKING, update_serializer.errors
         )
+
 
     # TODO: ユニーク制約をシリアライザ―でできたら追加
     # def test_unique_together_constraint(self):

--- a/backend/pong/tournaments/participation/tests/test_command_serializers.py
+++ b/backend/pong/tournaments/participation/tests/test_command_serializers.py
@@ -101,3 +101,56 @@ class ParticipationCommandSerializerTestCase(TestCase):
         serializer = ParticipationCommandSerializer(data=data)
         with self.assertRaises(ValidationError):
             serializer.is_valid(raise_exception=True)
+
+    def test_ranking_validation_upper_limit(self):
+        """ランキング更新時の範囲チェック"""
+        # 参加テーブルを作成
+        creation_data = {
+            constants.ParticipationFields.TOURNAMENT_ID: self.tournament.id,
+            constants.ParticipationFields.PLAYER_ID: self.player.id,
+            constants.ParticipationFields.PARTICIPATION_NAME: "New Player",
+        }
+        create_serializer = ParticipationCommandSerializer(data=creation_data)
+        self.assertTrue(create_serializer.is_valid())
+        participation = create_serializer.save()
+
+        # ランキングを更新
+        update_data = {
+            constants.ParticipationFields.RANKING: constants.MAX_PARTICIPATIONS
+            + 1
+        }  # 不正なランキング
+
+        # エラーになるか
+        update_serializer = ParticipationCommandSerializer(
+            instance=participation, data=update_data, partial=True
+        )
+        self.assertFalse(update_serializer.is_valid())
+        self.assertIn(
+            constants.ParticipationFields.RANKING, update_serializer.errors
+        )
+
+    def test_ranking_validation_lower_limit(self) -> None:
+        """ランキング更新時の範囲チェック"""
+        # 参加テーブルを作成
+        creation_data = {
+            constants.ParticipationFields.TOURNAMENT_ID: self.tournament.id,
+            constants.ParticipationFields.PLAYER_ID: self.player.id,
+            constants.ParticipationFields.PARTICIPATION_NAME: "New Player",
+        }
+        create_serializer = ParticipationCommandSerializer(data=creation_data)
+        self.assertTrue(create_serializer.is_valid())
+        participation = create_serializer.save()
+
+        # ランキングを更新
+        update_data = {
+            constants.ParticipationFields.RANKING: 0
+        }  # 不正なランキング
+
+        # エラーになるか
+        update_serializer = ParticipationCommandSerializer(
+            instance=participation, data=update_data, partial=True
+        )
+        self.assertFalse(update_serializer.is_valid())
+        self.assertIn(
+            constants.ParticipationFields.RANKING, update_serializer.errors
+        )

--- a/backend/pong/tournaments/participation/tests/test_command_serializers.py
+++ b/backend/pong/tournaments/participation/tests/test_command_serializers.py
@@ -102,7 +102,7 @@ class ParticipationCommandSerializerTestCase(TestCase):
         with self.assertRaises(ValidationError):
             serializer.is_valid(raise_exception=True)
 
-    def test_ranking_validation_upper_limit(self):
+    def test_ranking_validation_upper_limit(self) -> None:
         """ランキング更新時の範囲チェック"""
         # 参加テーブルを作成
         creation_data = {

--- a/backend/pong/tournaments/participation/views.py
+++ b/backend/pong/tournaments/participation/views.py
@@ -163,7 +163,7 @@ from . import models, serializers
 )
 class ParticipationReadOnlyViewSet(viewsets.ReadOnlyModelViewSet):
     permission_classes = (permissions.IsAuthenticated,)
-    serializer_class = serializers.ParticipationSerializer
+    serializer_class = serializers.ParticipationQuerySerializer
     renderer_classes = [readonly_custom_renderer.ReadOnlyCustomJSONRenderer]
 
     def get_queryset(self) -> QuerySet:


### PR DESCRIPTION
## タスクやディスカッションのリンク
<!-- - URLをここに貼る -->

## やったこと
<!-- - このタスクでやったことはなにか？ -->
- トーナメント参加テーブルの作成・更新のためのシリアライザ―を追加しました。
- こちらも元々あったシリアライザーの命名を変更いたしました。
- シリアライザ―の単体テストも追加してしまっています。

## やらないこと
<!-- - このタスクでやらないことはなにか？（やらない場合いつやるのか？無ければ「なし」を記述） -->
- 特になし

## 動作確認
<!-- - どのような動作確認を行い、結果はどうだったのか？(適宜スクショ等添付) -->
- 作成した単体テストが通っていること

## 特にレビューをお願いしたい箇所
<!-- - 特にチェックをお願いしたいポイントを簡潔に記述する -->
- ほかにテストケースが必要なものがあれば教えていただきたいです。

## その他
<!-- - 実装上の懸念点、注意点等あれば記載する -->
- 少し量が多くなってしまい申し訳ないのですが、よろしくお願いします。

## 参考リンク
<!-- - 実装に際し参考にした、記事やサイトのリンクを記載する -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新機能**
	- トーナメント参加の情報処理が改善され、参照操作と登録操作が明確に分離されました。
	- 入力内容の検証が強化され、参加者名の形式、ランキングの範囲、参加上限に対するチェックが追加されました。
	- 参加データの精度と一貫性が向上し、不正な入力時に適切なエラーメッセージが提供されるようになりました。

- **テスト**
	- `ParticipationCommandSerializer`の機能を検証する新しいテストスイートが追加されました。これにより、参加データの作成や入力内容の検証が正しく行われることが確認されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->