### PR TITLE
⚡ [users, friends, blocks] 一覧取得系のエンドポイントで CustomPagination を使用するよう変更

### DIFF
--- a/backend/pong/users/blocks/tests/integration/test_list_views.py
+++ b/backend/pong/users/blocks/tests/integration/test_list_views.py
@@ -7,6 +7,7 @@ from rest_framework import status, test
 
 from accounts import constants as accounts_constants
 from accounts.player import models as players_models
+from pong.custom_pagination import custom_pagination
 from pong.custom_response import custom_response
 from users import constants as users_constants
 
@@ -25,6 +26,11 @@ IS_BLOCKED: Final[str] = users_constants.UsersFields.IS_BLOCKED
 BLOCKED_USER: Final[str] = constants.BlockRelationshipFields.BLOCKED_USER
 
 DATA: Final[str] = custom_response.DATA
+
+COUNT: Final[str] = custom_pagination.PaginationFields.COUNT
+NEXT: Final[str] = custom_pagination.PaginationFields.NEXT
+PREVIOUS: Final[str] = custom_pagination.PaginationFields.PREVIOUS
+RESULTS: Final[str] = custom_pagination.PaginationFields.RESULTS
 
 
 class BlocksListViewTests(test.APITestCase):
@@ -124,7 +130,10 @@ class BlocksListViewTests(test.APITestCase):
         response: drf_response.Response = self.client.get(self.url)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data[DATA], [])
+        self.assertEqual(
+            response.data[DATA],
+            {COUNT: 0, NEXT: None, PREVIOUS: None, RESULTS: []},
+        )
 
     def test_200_get_block_list(self) -> None:
         """
@@ -135,30 +144,35 @@ class BlocksListViewTests(test.APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(
             response.data[DATA],
-            [
-                {
-                    BLOCKED_USER: {
-                        ID: self.user2.id,
-                        USERNAME: self.user_data2[USERNAME],
-                        DISPLAY_NAME: self.player_data2[DISPLAY_NAME],
-                        AVATAR: "/media/avatars/sample.png",  # todo: デフォルト画像が変更になったら修正
-                        IS_FRIEND: False,
-                        IS_BLOCKED: True,
-                        # todo: is_online,win_match,lose_match追加
+            {
+                COUNT: 2,
+                NEXT: None,
+                PREVIOUS: None,
+                RESULTS: [
+                    {
+                        BLOCKED_USER: {
+                            ID: self.user2.id,
+                            USERNAME: self.user_data2[USERNAME],
+                            DISPLAY_NAME: self.player_data2[DISPLAY_NAME],
+                            AVATAR: "/media/avatars/sample.png",  # todo: デフォルト画像が変更になったら修正
+                            IS_FRIEND: False,
+                            IS_BLOCKED: True,
+                            # todo: is_online,win_match,lose_match追加
+                        },
                     },
-                },
-                {
-                    BLOCKED_USER: {
-                        ID: self.user3.id,
-                        USERNAME: self.user_data3[USERNAME],
-                        DISPLAY_NAME: self.player_data3[DISPLAY_NAME],
-                        AVATAR: "/media/avatars/sample.png",  # todo: デフォルト画像が変更になったら修正
-                        IS_FRIEND: False,
-                        IS_BLOCKED: True,
-                        # todo: is_online,win_match,lose_match追加
+                    {
+                        BLOCKED_USER: {
+                            ID: self.user3.id,
+                            USERNAME: self.user_data3[USERNAME],
+                            DISPLAY_NAME: self.player_data3[DISPLAY_NAME],
+                            AVATAR: "/media/avatars/sample.png",  # todo: デフォルト画像が変更になったら修正
+                            IS_FRIEND: False,
+                            IS_BLOCKED: True,
+                            # todo: is_online,win_match,lose_match追加
+                        },
                     },
-                },
-            ],
+                ],
+            },
         )
 
     def test_200_delete_block_user(self) -> None:
@@ -173,19 +187,24 @@ class BlocksListViewTests(test.APITestCase):
         # user3のみブロック一覧に残る
         self.assertEqual(
             response.data[DATA],
-            [
-                {
-                    BLOCKED_USER: {
-                        ID: self.user3.id,
-                        USERNAME: self.user_data3[USERNAME],
-                        DISPLAY_NAME: self.player_data3[DISPLAY_NAME],
-                        AVATAR: "/media/avatars/sample.png",  # todo: デフォルト画像が変更になったら修正
-                        IS_FRIEND: False,
-                        IS_BLOCKED: True,
-                        # todo: is_online,win_match,lose_match追加
+            {
+                COUNT: 1,
+                NEXT: None,
+                PREVIOUS: None,
+                RESULTS: [
+                    {
+                        BLOCKED_USER: {
+                            ID: self.user3.id,
+                            USERNAME: self.user_data3[USERNAME],
+                            DISPLAY_NAME: self.player_data3[DISPLAY_NAME],
+                            AVATAR: "/media/avatars/sample.png",  # todo: デフォルト画像が変更になったら修正
+                            IS_FRIEND: False,
+                            IS_BLOCKED: True,
+                            # todo: is_online,win_match,lose_match追加
+                        },
                     },
-                },
-            ],
+                ],
+            },
         )
 
     def test_200_exists_non_player(self) -> None:
@@ -200,19 +219,24 @@ class BlocksListViewTests(test.APITestCase):
         # user2のみブロック一覧に表示される
         self.assertEqual(
             response.data[DATA],
-            [
-                {
-                    BLOCKED_USER: {
-                        ID: self.user2.id,
-                        USERNAME: self.user_data2[USERNAME],
-                        DISPLAY_NAME: self.player_data2[DISPLAY_NAME],
-                        AVATAR: "/media/avatars/sample.png",  # todo: デフォルト画像が変更になったら修正
-                        IS_FRIEND: False,
-                        IS_BLOCKED: True,
-                        # todo: is_online,win_match,lose_match追加
+            {
+                COUNT: 1,
+                NEXT: None,
+                PREVIOUS: None,
+                RESULTS: [
+                    {
+                        BLOCKED_USER: {
+                            ID: self.user2.id,
+                            USERNAME: self.user_data2[USERNAME],
+                            DISPLAY_NAME: self.player_data2[DISPLAY_NAME],
+                            AVATAR: "/media/avatars/sample.png",  # todo: デフォルト画像が変更になったら修正
+                            IS_FRIEND: False,
+                            IS_BLOCKED: True,
+                            # todo: is_online,win_match,lose_match追加
+                        },
                     },
-                },
-            ],
+                ],
+            },
         )
 
     def test_401_unauthenticated_user(self) -> None:

--- a/backend/pong/users/blocks/views.py
+++ b/backend/pong/users/blocks/views.py
@@ -325,6 +325,14 @@ class BlocksViewSet(viewsets.ViewSet):
             # 401はCustomResponseにせずそのまま返す
             return super().handle_exception(exc)
 
+        if isinstance(exc, exceptions.NotFound):
+            logger.error(f"[404] Not found: {str(exc)}")
+            return custom_response.CustomResponse(
+                code=[users_constants.Code.INTERNAL_ERROR],
+                errors={"detail": str(exc)},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
         logger.error(f"[500] Internal server error: {str(exc)}")
         response: custom_response.CustomResponse = (
             custom_response.CustomResponse(
@@ -367,6 +375,7 @@ class BlocksViewSet(viewsets.ViewSet):
         paginator: custom_pagination.CustomPagination = (
             custom_pagination.CustomPagination()
         )
+        # クエリパラメータのpage番号が存在しない場合はraise exceptions.NotFound()される
         paginated_block_users: Optional[list[models.BlockRelationship]] = (
             paginator.paginate_queryset(block_users, request)
         )

--- a/backend/pong/users/blocks/views.py
+++ b/backend/pong/users/blocks/views.py
@@ -32,6 +32,15 @@ logger = logging.getLogger(__name__)
 
 @utils.extend_schema_view(
     list=utils.extend_schema(
+        parameters=[
+            utils.OpenApiParameter(
+                name="page",
+                description="paginationのページ数",
+                required=False,
+                type=int,
+                location=utils.OpenApiParameter.QUERY,
+            ),
+        ],
         responses={
             200: utils.OpenApiResponse(
                 description="A list of blocks for the authenticated user.",

--- a/backend/pong/users/blocks/views.py
+++ b/backend/pong/users/blocks/views.py
@@ -43,20 +43,25 @@ logger = logging.getLogger(__name__)
                         "Example 200 response",
                         value={
                             custom_response.STATUS: custom_response.Status.OK,
-                            custom_response.DATA: [
-                                {
-                                    constants.BlockRelationshipFields.BLOCKED_USER: {
-                                        accounts_constants.UserFields.ID: 2,
-                                        accounts_constants.UserFields.USERNAME: "username2",
-                                        accounts_constants.PlayerFields.DISPLAY_NAME: "display_name2",
-                                        accounts_constants.PlayerFields.AVATAR: "/media/avatars/sample.png",
-                                        users_constants.UsersFields.IS_FRIEND: False,
-                                        users_constants.UsersFields.IS_BLOCKED: True,
-                                        # todo: is_online,win_match,lose_match追加
+                            custom_response.DATA: {
+                                custom_pagination.PaginationFields.COUNT: 25,
+                                custom_pagination.PaginationFields.NEXT: "http://localhost:8000/api/users/me/blocks/?page=2",
+                                custom_pagination.PaginationFields.PREVIOUS: None,
+                                custom_pagination.PaginationFields.RESULTS: [
+                                    {
+                                        constants.BlockRelationshipFields.BLOCKED_USER: {
+                                            accounts_constants.UserFields.ID: 2,
+                                            accounts_constants.UserFields.USERNAME: "username2",
+                                            accounts_constants.PlayerFields.DISPLAY_NAME: "display_name2",
+                                            accounts_constants.PlayerFields.AVATAR: "/media/avatars/sample.png",
+                                            users_constants.UsersFields.IS_FRIEND: False,
+                                            users_constants.UsersFields.IS_BLOCKED: True,
+                                            # todo: is_online,win_match,lose_match追加
+                                        },
                                     },
-                                },
-                                {"...", "..."},
-                            ],
+                                    "...",
+                                ],
+                            },
                         },
                     ),
                 ],

--- a/backend/pong/users/friends/tests/integration/test_list_views.py
+++ b/backend/pong/users/friends/tests/integration/test_list_views.py
@@ -7,6 +7,7 @@ from rest_framework import status, test
 
 from accounts import constants as accounts_constants
 from accounts.player import models as players_models
+from pong.custom_pagination import custom_pagination
 from pong.custom_response import custom_response
 from users import constants as users_constants
 
@@ -25,6 +26,11 @@ IS_BLOCKED: Final[str] = users_constants.UsersFields.IS_BLOCKED
 FRIEND: Final[str] = constants.FriendshipFields.FRIEND
 
 DATA: Final[str] = custom_response.DATA
+
+COUNT: Final[str] = custom_pagination.PaginationFields.COUNT
+NEXT: Final[str] = custom_pagination.PaginationFields.NEXT
+PREVIOUS: Final[str] = custom_pagination.PaginationFields.PREVIOUS
+RESULTS: Final[str] = custom_pagination.PaginationFields.RESULTS
 
 
 class FriendsListViewTests(test.APITestCase):
@@ -120,7 +126,10 @@ class FriendsListViewTests(test.APITestCase):
         response: drf_response.Response = self.client.get(self.url)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data[DATA], [])
+        self.assertEqual(
+            response.data[DATA],
+            {COUNT: 0, NEXT: None, PREVIOUS: None, RESULTS: []},
+        )
 
     def test_200_get_friends_list(self) -> None:
         """
@@ -131,30 +140,35 @@ class FriendsListViewTests(test.APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(
             response.data[DATA],
-            [
-                {
-                    FRIEND: {
-                        ID: self.user2.id,
-                        USERNAME: self.user_data2[USERNAME],
-                        DISPLAY_NAME: self.player_data2[DISPLAY_NAME],
-                        AVATAR: "/media/avatars/sample.png",  # todo: デフォルト画像が変更になったら修正
-                        IS_FRIEND: True,
-                        IS_BLOCKED: False,
-                        # todo: is_online,win_match,lose_match追加
+            {
+                COUNT: 2,
+                NEXT: None,
+                PREVIOUS: None,
+                RESULTS: [
+                    {
+                        FRIEND: {
+                            ID: self.user2.id,
+                            USERNAME: self.user_data2[USERNAME],
+                            DISPLAY_NAME: self.player_data2[DISPLAY_NAME],
+                            AVATAR: "/media/avatars/sample.png",  # todo: デフォルト画像が変更になったら修正
+                            IS_FRIEND: True,
+                            IS_BLOCKED: False,
+                            # todo: is_online,win_match,lose_match追加
+                        },
                     },
-                },
-                {
-                    FRIEND: {
-                        ID: self.user3.id,
-                        USERNAME: self.user_data3[USERNAME],
-                        DISPLAY_NAME: self.player_data3[DISPLAY_NAME],
-                        AVATAR: "/media/avatars/sample.png",  # todo: デフォルト画像が変更になったら修正
-                        IS_FRIEND: True,
-                        IS_BLOCKED: False,
-                        # todo: is_online,win_match,lose_match追加
+                    {
+                        FRIEND: {
+                            ID: self.user3.id,
+                            USERNAME: self.user_data3[USERNAME],
+                            DISPLAY_NAME: self.player_data3[DISPLAY_NAME],
+                            AVATAR: "/media/avatars/sample.png",  # todo: デフォルト画像が変更になったら修正
+                            IS_FRIEND: True,
+                            IS_BLOCKED: False,
+                            # todo: is_online,win_match,lose_match追加
+                        },
                     },
-                },
-            ],
+                ],
+            },
         )
 
     def test_200_delete_friend(self) -> None:
@@ -169,19 +183,24 @@ class FriendsListViewTests(test.APITestCase):
         # user3のみフレンド一覧に残る
         self.assertEqual(
             response.data[DATA],
-            [
-                {
-                    FRIEND: {
-                        ID: self.user3.id,
-                        USERNAME: self.user_data3[USERNAME],
-                        DISPLAY_NAME: self.player_data3[DISPLAY_NAME],
-                        AVATAR: "/media/avatars/sample.png",  # todo: デフォルト画像が変更になったら修正
-                        IS_FRIEND: True,
-                        IS_BLOCKED: False,
-                        # todo: is_online,win_match,lose_match追加
+            {
+                COUNT: 1,
+                NEXT: None,
+                PREVIOUS: None,
+                RESULTS: [
+                    {
+                        FRIEND: {
+                            ID: self.user3.id,
+                            USERNAME: self.user_data3[USERNAME],
+                            DISPLAY_NAME: self.player_data3[DISPLAY_NAME],
+                            AVATAR: "/media/avatars/sample.png",  # todo: デフォルト画像が変更になったら修正
+                            IS_FRIEND: True,
+                            IS_BLOCKED: False,
+                            # todo: is_online,win_match,lose_match追加
+                        },
                     },
-                },
-            ],
+                ],
+            },
         )
 
     def test_200_exists_non_player(self) -> None:
@@ -196,19 +215,24 @@ class FriendsListViewTests(test.APITestCase):
         # user2のみフレンド一覧に表示される
         self.assertEqual(
             response.data[DATA],
-            [
-                {
-                    FRIEND: {
-                        ID: self.user2.id,
-                        USERNAME: self.user_data2[USERNAME],
-                        DISPLAY_NAME: self.player_data2[DISPLAY_NAME],
-                        AVATAR: "/media/avatars/sample.png",  # todo: デフォルト画像が変更になったら修正
-                        IS_FRIEND: True,
-                        IS_BLOCKED: False,
-                        # todo: is_online,win_match,lose_match追加
+            {
+                COUNT: 1,
+                NEXT: None,
+                PREVIOUS: None,
+                RESULTS: [
+                    {
+                        FRIEND: {
+                            ID: self.user2.id,
+                            USERNAME: self.user_data2[USERNAME],
+                            DISPLAY_NAME: self.player_data2[DISPLAY_NAME],
+                            AVATAR: "/media/avatars/sample.png",  # todo: デフォルト画像が変更になったら修正
+                            IS_FRIEND: True,
+                            IS_BLOCKED: False,
+                            # todo: is_online,win_match,lose_match追加
+                        },
                     },
-                },
-            ],
+                ],
+            },
         )
 
     def test_401_unauthenticated_user(self) -> None:

--- a/backend/pong/users/friends/views.py
+++ b/backend/pong/users/friends/views.py
@@ -36,25 +36,31 @@ logger = logging.getLogger(__name__)
             200: utils.OpenApiResponse(
                 description="A list of friends for the authenticated user.",
                 response=list_serializers.FriendshipListSerializer(many=True),
+                # response=custom_response.CustomResponse,
                 examples=[
                     utils.OpenApiExample(
                         "Example 200 response",
                         value={
                             custom_response.STATUS: custom_response.Status.OK,
-                            custom_response.DATA: [
-                                {
-                                    constants.FriendshipFields.FRIEND: {
-                                        accounts_constants.UserFields.ID: 2,
-                                        accounts_constants.UserFields.USERNAME: "username2",
-                                        accounts_constants.PlayerFields.DISPLAY_NAME: "display_name2",
-                                        accounts_constants.PlayerFields.AVATAR: "/media/avatars/sample.png",
-                                        users_constants.UsersFields.IS_FRIEND: True,
-                                        users_constants.UsersFields.IS_BLOCKED: False,
-                                        # todo: is_online,win_match,lose_match追加
+                            custom_response.DATA: {
+                                custom_pagination.PaginationFields.COUNT: 25,
+                                custom_pagination.PaginationFields.NEXT: "http://localhost:8000/api/users/me/friends/?page=2",
+                                custom_pagination.PaginationFields.PREVIOUS: None,
+                                custom_pagination.PaginationFields.RESULTS: [
+                                    {
+                                        constants.FriendshipFields.FRIEND: {
+                                            accounts_constants.UserFields.ID: 2,
+                                            accounts_constants.UserFields.USERNAME: "username2",
+                                            accounts_constants.PlayerFields.DISPLAY_NAME: "display_name2",
+                                            accounts_constants.PlayerFields.AVATAR: "/media/avatars/sample.png",
+                                            users_constants.UsersFields.IS_FRIEND: True,
+                                            users_constants.UsersFields.IS_BLOCKED: False,
+                                            # todo: is_online,win_match,lose_match追加
+                                        },
                                     },
-                                },
-                                {"...", "..."},
-                            ],
+                                    "...",
+                                ],
+                            },
                         },
                     ),
                 ],

--- a/backend/pong/users/friends/views.py
+++ b/backend/pong/users/friends/views.py
@@ -45,7 +45,6 @@ logger = logging.getLogger(__name__)
             200: utils.OpenApiResponse(
                 description="A list of friends for the authenticated user.",
                 response=list_serializers.FriendshipListSerializer(many=True),
-                # response=custom_response.CustomResponse,
                 examples=[
                     utils.OpenApiExample(
                         "Example 200 response",

--- a/backend/pong/users/friends/views.py
+++ b/backend/pong/users/friends/views.py
@@ -32,6 +32,15 @@ logger = logging.getLogger(__name__)
 
 @utils.extend_schema_view(
     list=utils.extend_schema(
+        parameters=[
+            utils.OpenApiParameter(
+                name="page",
+                description="paginationのページ数",
+                required=False,
+                type=int,
+                location=utils.OpenApiParameter.QUERY,
+            ),
+        ],
         responses={
             200: utils.OpenApiResponse(
                 description="A list of friends for the authenticated user.",

--- a/backend/pong/users/friends/views.py
+++ b/backend/pong/users/friends/views.py
@@ -322,6 +322,14 @@ class FriendsViewSet(viewsets.ModelViewSet):
             # 401はCustomResponseにせずそのまま返す
             return super().handle_exception(exc)
 
+        if isinstance(exc, exceptions.NotFound):
+            logger.error(f"[404] Not found: {str(exc)}")
+            return custom_response.CustomResponse(
+                code=[users_constants.Code.INTERNAL_ERROR],
+                errors={"detail": str(exc)},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
         logger.error(f"[500] Internal server error: {str(exc)}")
         response: custom_response.CustomResponse = (
             custom_response.CustomResponse(
@@ -362,6 +370,7 @@ class FriendsViewSet(viewsets.ModelViewSet):
         paginator: custom_pagination.CustomPagination = (
             custom_pagination.CustomPagination()
         )
+        # クエリパラメータのpage番号が存在しない場合はraise exceptions.NotFound()される
         paginated_friends: Optional[list[models.Friendship]] = (
             paginator.paginate_queryset(friends, request)
         )

--- a/backend/pong/users/tests/integration/test_list.py
+++ b/backend/pong/users/tests/integration/test_list.py
@@ -7,6 +7,7 @@ from rest_framework import status, test
 
 from accounts import constants as accounts_constants
 from accounts.player import models as player_models
+from pong.custom_pagination import custom_pagination
 from pong.custom_response import custom_response
 
 from ... import constants
@@ -22,6 +23,11 @@ IS_FRIEND: Final[str] = constants.UsersFields.IS_FRIEND
 IS_BLOCKED: Final[str] = constants.UsersFields.IS_BLOCKED
 
 DATA: Final[str] = custom_response.DATA
+
+COUNT: Final[str] = custom_pagination.PaginationFields.COUNT
+NEXT: Final[str] = custom_pagination.PaginationFields.NEXT
+PREVIOUS: Final[str] = custom_pagination.PaginationFields.PREVIOUS
+RESULTS: Final[str] = custom_pagination.PaginationFields.RESULTS
 
 
 class UsersListViewTests(test.APITestCase):
@@ -100,26 +106,31 @@ class UsersListViewTests(test.APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(
             response.data[DATA],
-            [
-                {
-                    ID: self.user1.id,
-                    USERNAME: self.user_data1[USERNAME],
-                    DISPLAY_NAME: self.player_data1[DISPLAY_NAME],
-                    AVATAR: self.player1.avatar.url,
-                    IS_FRIEND: False,
-                    IS_BLOCKED: False,
-                    # todo: is_online,win_match,lose_match追加
-                },
-                {
-                    ID: self.user2.id,
-                    USERNAME: self.user_data2[USERNAME],
-                    DISPLAY_NAME: self.player_data2[DISPLAY_NAME],
-                    AVATAR: self.player2.avatar.url,
-                    IS_FRIEND: False,
-                    IS_BLOCKED: False,
-                    # todo: is_online,win_match,lose_match追加
-                },
-            ],
+            {
+                COUNT: 2,
+                NEXT: None,
+                PREVIOUS: None,
+                RESULTS: [
+                    {
+                        ID: self.user1.id,
+                        USERNAME: self.user_data1[USERNAME],
+                        DISPLAY_NAME: self.player_data1[DISPLAY_NAME],
+                        AVATAR: self.player1.avatar.url,
+                        IS_FRIEND: False,
+                        IS_BLOCKED: False,
+                        # todo: is_online,win_match,lose_match追加
+                    },
+                    {
+                        ID: self.user2.id,
+                        USERNAME: self.user_data2[USERNAME],
+                        DISPLAY_NAME: self.player_data2[DISPLAY_NAME],
+                        AVATAR: self.player2.avatar.url,
+                        IS_FRIEND: False,
+                        IS_BLOCKED: False,
+                        # todo: is_online,win_match,lose_match追加
+                    },
+                ],
+            },
         )
 
     def test_get_401_unauthenticated_user(self) -> None:

--- a/backend/pong/users/views/list.py
+++ b/backend/pong/users/views/list.py
@@ -79,6 +79,15 @@ class UsersListView(views.APIView):
     @utils.extend_schema(
         operation_id="get_users_list",
         request=None,
+        parameters=[
+            utils.OpenApiParameter(
+                name="page",
+                description="paginationのページ数",
+                required=False,
+                type=int,
+                location=utils.OpenApiParameter.QUERY,
+            ),
+        ],
         responses={
             200: utils.OpenApiResponse(
                 description="A list of user profiles",

--- a/backend/pong/users/views/list.py
+++ b/backend/pong/users/views/list.py
@@ -43,6 +43,14 @@ class UsersListView(views.APIView):
             # 401はCustomResponseにせずそのまま返す
             return super().handle_exception(exc)
 
+        if isinstance(exc, exceptions.NotFound):
+            logger.error(f"[404] Not found: {str(exc)}")
+            return custom_response.CustomResponse(
+                code=[constants.Code.INTERNAL_ERROR],
+                errors={"detail": str(exc)},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
         logger.error(f"[500] Internal server error: {str(exc)}")
         response: custom_response.CustomResponse = (
             custom_response.CustomResponse(
@@ -165,6 +173,7 @@ class UsersListView(views.APIView):
         paginator: custom_pagination.CustomPagination = (
             custom_pagination.CustomPagination()
         )
+        # クエリパラメータのpage番号が存在しない場合はraise exceptions.NotFound()される
         paginated_players: Optional[list[player_models.Player]] = (
             paginator.paginate_queryset(all_players_with_users, request)
         )

--- a/backend/pong/users/views/list.py
+++ b/backend/pong/users/views/list.py
@@ -80,27 +80,32 @@ class UsersListView(views.APIView):
                         "Example 200 response",
                         value={
                             custom_response.STATUS: custom_response.Status.OK,
-                            custom_response.DATA: [
-                                {
-                                    accounts_constants.UserFields.ID: 2,
-                                    accounts_constants.UserFields.USERNAME: "username1",
-                                    accounts_constants.PlayerFields.DISPLAY_NAME: "display_name1",
-                                    accounts_constants.PlayerFields.AVATAR: "/media/avatars/sample1.png",
-                                    constants.UsersFields.IS_FRIEND: False,
-                                    constants.UsersFields.IS_BLOCKED: False,
-                                    # todo: is_online,win_match,lose_match追加
-                                },
-                                {
-                                    accounts_constants.UserFields.ID: 3,
-                                    accounts_constants.UserFields.USERNAME: "username2",
-                                    accounts_constants.PlayerFields.DISPLAY_NAME: "display_name2",
-                                    accounts_constants.PlayerFields.AVATAR: "/media/avatars/sample2.png",
-                                    constants.UsersFields.IS_FRIEND: False,
-                                    constants.UsersFields.IS_BLOCKED: False,
-                                    # todo: is_online,win_match,lose_match追加
-                                },
-                                {"...", "..."},
-                            ],
+                            custom_response.DATA: {
+                                custom_pagination.PaginationFields.COUNT: 25,
+                                custom_pagination.PaginationFields.NEXT: "http://localhost:8000/api/users/?page=2",
+                                custom_pagination.PaginationFields.PREVIOUS: None,
+                                custom_pagination.PaginationFields.RESULTS: [
+                                    {
+                                        accounts_constants.UserFields.ID: 2,
+                                        accounts_constants.UserFields.USERNAME: "username1",
+                                        accounts_constants.PlayerFields.DISPLAY_NAME: "display_name1",
+                                        accounts_constants.PlayerFields.AVATAR: "/media/avatars/sample1.png",
+                                        constants.UsersFields.IS_FRIEND: False,
+                                        constants.UsersFields.IS_BLOCKED: False,
+                                        # todo: is_online,win_match,lose_match追加
+                                    },
+                                    {
+                                        accounts_constants.UserFields.ID: 3,
+                                        accounts_constants.UserFields.USERNAME: "username2",
+                                        accounts_constants.PlayerFields.DISPLAY_NAME: "display_name2",
+                                        accounts_constants.PlayerFields.AVATAR: "/media/avatars/sample2.png",
+                                        constants.UsersFields.IS_FRIEND: False,
+                                        constants.UsersFields.IS_BLOCKED: False,
+                                        # todo: is_online,win_match,lose_match追加
+                                    },
+                                    "...",
+                                ],
+                            },
                         },
                     ),
                 ],


### PR DESCRIPTION
## タスクやディスカッションのリンク
<!-- - URLをここに貼る -->
- #379 

## やったこと
<!-- - このタスクでやったことはなにか？ -->
(変更多そうに見えますが、レスポンスのデータのネストが深くなったのでインデントが増えただけ、みたいなのが大半です)
`users`, `friends`, `blocks` app の一覧取得エンドポイント 3 つで、`CustomPagination` を使用するように変更しました
- `/api/users/`, GET
- `/api/users/me/friends/`, GET
- `/api/users/me/blocks/`, GET

## やらないこと
<!-- - このタスクでやらないことはなにか？（やらない場合いつやるのか？無ければ「なし」を記述） -->
- 上記以外

## 動作確認
<!-- - どのような動作確認を行い、結果はどうだったのか？(適宜スクショ等添付) -->
- swagger-ui にて
  - extend_schema がページネーションが追加されたものになっていること
  - 実際にリクエストを送り、レスポンスが extend_schema と同じようにページネーションされたものであること


## 特にレビューをお願いしたい箇所
<!-- - 特にチェックをお願いしたいポイントを簡潔に記述する -->
主に上記の動作確認

## その他
<!-- - 実装上の懸念点、注意点等あれば記載する -->
- ユーザー削除機能がなくユーザー数が減ることはないため、存在しないページ番号が来た場合は実装上のミスということで微妙だとは思いますが `code=internal_error` を返しています…
- どうも settings.py でデフォルトの exception class というのを設定できるようで、app ごとに同じような `handle_exception()` を書かなくて済みそうなのですが、微妙に違うこともありそうですし、時間もないのでしなさそうです

## 参考リンク
<!-- - 実装に際し参考にした、記事やサイトのリンクを記載する -->
特になし

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **新機能**
  - ブロック、フレンド、およびユーザープロフィールの各リスト表示でページネーションが導入され、応答形式がシンプルなリストから、総件数や次／前ページの情報を含む辞書形式に変更されました。

- **テスト**
  - 各機能に対応する統合テストが更新され、新しいページネーション項目が正しく出力されるか検証されています。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->