### PR TITLE
:zap: 非同期に使用するトーナメントのDB操作関数を作成。

### DIFF
--- a/backend/pong/ws/consumers.py
+++ b/backend/pong/ws/consumers.py
@@ -9,7 +9,7 @@ from .match import handler as match_handler
 from .share import constants as ws_constants
 from .share import serializers as ws_serializers
 
-logger = logging.getLogger("django")
+logger = logging.getLogger(__name__)
 
 
 class MultiEventConsumer(AsyncJsonWebsocketConsumer):

--- a/backend/pong/ws/tournament/async_db_serivice.py
+++ b/backend/pong/ws/tournament/async_db_serivice.py
@@ -12,7 +12,7 @@ from tournaments.participation import serializers as participation_serializers
 from tournaments.tournament import models as tournament_models
 from tournaments.tournament import serializers as tournament_serializers
 
-logger = logging.getLogger("django")
+logger = logging.getLogger(__name__)
 CreateTournamentResult = utils.result.Result[dict, dict]
 UpdateTournamentResult = utils.result.Result[dict, dict]
 UpdateParticipationResult = utils.result.Result[dict, dict]

--- a/backend/pong/ws/tournament/async_db_serivice.py
+++ b/backend/pong/ws/tournament/async_db_serivice.py
@@ -73,3 +73,21 @@ async def create_tournament_with_participation(
 
     # 使う想定なのはidだけだが、一応dictごとと返す
     return CreateTournamentResult.ok(tournament_serializer.data)
+
+
+async def get_waiting_tournament() -> Optional[int]:
+    """
+    募集中のトーナメントクエリセットの中で最初の1件を取得する
+
+    Return:
+        int: 正常に取得できた場合
+        None: 募集中のトーナメントが一つもない場合
+    """
+    tournament = await tournament_models.Tournament.objects.filter(
+        status=constants.TournamentFields.StatusEnum.NOT_STARTED.value
+    ).afirst()
+
+    if tournament is not None:
+        return tournament.id
+
+    return None

--- a/backend/pong/ws/tournament/async_db_serivice.py
+++ b/backend/pong/ws/tournament/async_db_serivice.py
@@ -151,8 +151,6 @@ def update_participation_ranking(
     """
     大会終了時にtournament_participationsテーブルのランキングを更新
 
-    同じプレーヤーが同じトーナメントに参加することはないため、同時にトーナメント参加レコードに対して更新処理をすることはない。よってここではトランザクションで処理をまとめていない。
-
     Returns:
         UpdateTournamentResult: 作成されたtournamentのシリアライズ後のデータのResult
           - ok: Participationのranking更新に成功した場合

--- a/backend/pong/ws/tournament/async_db_serivice.py
+++ b/backend/pong/ws/tournament/async_db_serivice.py
@@ -1,0 +1,75 @@
+import logging
+from typing import Optional
+
+from asgiref.sync import sync_to_async
+
+from django.db import DatabaseError, transaction
+from rest_framework import serializers as drf_serializers
+
+import utils.result
+from tournaments import constants
+
+from tournaments.participation import serializers as participation_serializers
+from tournaments.tournament import models as tournament_models
+from tournaments.tournament import serializers as tournament_serializers
+
+logger = logging.getLogger("django")
+CreateTournamentResult = utils.result.Result[dict, dict]
+
+
+async def create_tournament_with_participation(
+    player_id: int, participation_name: str
+) -> CreateTournamentResult:
+    """
+    トーナメントと参加情報を一つのトランザクションで作成する関数。
+
+    Args:
+        player_id (int): 参加プレイヤーの ID
+        participation_name (str): トーナメント内での表示名
+
+    Returns:
+        CreateTournamentResult: 作成されたtournamentのシリアライズ後のデータのResult
+          - ok: Tournament,Participationの作成に成功した場合
+          - error: ParticipationSerializerに渡すplayer_idかparticipation_nameのValidationError、またはDatabaseError
+    """
+    try:
+        with transaction.atomic():
+            # 1. トーナメントを作成
+            tournament_serializer = (
+                tournament_serializers.TournamentCommandSerializer(data={})
+            )
+            tournament_serializer.is_valid(raise_exception=True)
+            tournament: dict = await sync_to_async(
+                tournament_serializer.save
+            )()
+
+            # 2. 参加情報を作成
+            participation_data = {
+                constants.ParticipationFields.TOURNAMENT_ID: tournament[
+                    constants.TournamentFields.ID
+                ],
+                constants.ParticipationFields.PLAYER_ID: player_id,
+                constants.ParticipationFields.PARTICIPATION_NAME: participation_name,
+            }
+            participation_serializer = (
+                participation_serializers.ParticipationCommandSerializer(
+                    data=participation_data
+                )
+            )
+            participation_serializer.is_valid(raise_exception=True)
+            await sync_to_async(participation_serializer.save)()
+
+    except drf_serializers.ValidationError as e:
+        logger.error(f"VaridationError: {e}")
+        if isinstance(e.detail, list):
+            return CreateTournamentResult.error({"ValidationError": e.detail})
+        return CreateTournamentResult.error(e.detail)
+
+    except DatabaseError as e:
+        logger.error(f"DatabaseError: {e}")
+        return CreateTournamentResult.error(
+            {"DatabaseError": f"Failed to create account. Details: {str(e)}."}
+        )
+
+    # 使う想定なのはidだけだが、一応dictごとと返す
+    return CreateTournamentResult.ok(tournament_serializer.data)

--- a/backend/pong/ws/tournament/async_db_serivice.py
+++ b/backend/pong/ws/tournament/async_db_serivice.py
@@ -127,6 +127,14 @@ def update_tournament_status(
             return UpdateTournamentResult.error({"ValidationError": e.detail})
         return UpdateTournamentResult.error(e.detail)
 
+    except tournament_models.Tournament.DoesNotExist as e:
+        logger.error(f"DoesNotExist: {e}")
+        return UpdateTournamentResult.error(
+            {
+                "DoesNotExist": f"Tournament object does not exists. Details: {str(e)}."
+            }
+        )
+
     except DatabaseError as e:
         logger.error(f"DatabaseError: {e}")
         return UpdateTournamentResult.error(
@@ -179,6 +187,12 @@ def update_participation_ranking(
         return UpdateParticipationResult.error(e.detail)
 
     except DatabaseError as e:
+        logger.error(f"DatabaseError: {e}")
+        return UpdateParticipationResult.error(
+            {"DatabaseError": f"Failed to create account. Details: {str(e)}."}
+        )
+
+    except participation_models.Participation.DoesNotExist as e:
         logger.error(f"DatabaseError: {e}")
         return UpdateParticipationResult.error(
             {"DatabaseError": f"Failed to create account. Details: {str(e)}."}


### PR DESCRIPTION
## タスクやディスカッションのリンク
<!-- - URLをここに貼る -->
- Closes #261 
- [notion djangoの非同期サポートについて](https://www.notion.so/Django-a8e645721fa84d79b36b534a9222107e)

## やったこと
<!-- - このタスクでやったことはなにか？ -->
- トーナメントの進行で使用するDB操作のための非同期関数を作成

## やらないこと
<!-- - このタスクでやらないことはなにか？（やらない場合いつやるのか？無ければ「なし」を記述） -->
- シリアライザーはテスト済みなのとあまり時間がないためテストは書かないかもしれないのです。
- マッチやラウンドを作成、更新する関数の作成はまた別PR
- 参加レコードの削除も必要ですが、ちょっと多くなったので別PRで行います。

## 動作確認
<!-- - どのような動作確認を行い、結果はどうだったのか？(適宜スクショ等添付) -->
- 実際に作成しているのはテスト済みのシリアライザ―なので特にテストはしていません。

## 特にレビューをお願いしたい箇所
<!-- - 特にチェックをお願いしたいポイントを簡潔に記述する -->
- 処理ロジックに何かおかしいところがあれば教えていただきたいです。

## その他
<!-- - 実装上の懸念点、注意点等あれば記載する -->

## 参考リンク
<!-- - 実装に際し参考にした、記事やサイトのリンクを記載する -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 非同期処理を活用したトーナメント管理機能を追加。これにより、トーナメントの生成、状態更新、参加ランキングの調整、待機中のトーナメントの取得が迅速かつ効率的に実施できるようになりました。

- **Chores**
  - 内部のロギング体制を改善し、エラー追跡の精度が向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->