### PR TITLE
♻️ [accounts] handle_exception() で 500 をまとめて投げるように変更

### DIFF
--- a/backend/pong/accounts/views.py
+++ b/backend/pong/accounts/views.py
@@ -167,15 +167,6 @@ class AccountCreateView(views.APIView):
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
-        def _handle_unexpected_error(errors: dict) -> response.Response:
-            # 実装上のミスor予期せぬエラーのみ
-            logger.error("[500] Failed to create account")
-            return custom_response.CustomResponse(
-                code=[constants.Code.INTERNAL_ERROR],
-                errors=errors,
-                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            )
-
         # サインアップ専用のUserSerializerを作成
         user_serializer: user_serializers.UserSerializer = (
             _create_user_serializer(request.data)
@@ -191,9 +182,11 @@ class AccountCreateView(views.APIView):
             )
         )
         if create_account_result.is_error:
-            return _handle_unexpected_error(
-                create_account_result.unwrap_error()
+            logger.error(
+                f"Unexpected error occurred while creating account: \
+                {create_account_result.unwrap_error()}"
             )
+            raise Exception
 
         user_serializer_data: dict = create_account_result.unwrap()
         # todo: logger.info()追加

--- a/backend/pong/accounts/views.py
+++ b/backend/pong/accounts/views.py
@@ -115,8 +115,27 @@ class AccountCreateView(views.APIView):
                     ),
                 ],
             ),
-            # todo: 詳細のschemaが必要であれば追加する
-            500: utils.OpenApiResponse(description="Internal server error"),
+            500: utils.OpenApiResponse(
+                description="Internal server error",
+                response={
+                    "type": "object",
+                    "properties": {
+                        custom_response.STATUS: {"type": "string"},
+                        custom_response.CODE: {"type": "list"},
+                    },
+                },
+                examples=[
+                    utils.OpenApiExample(
+                        "Example 500 response",
+                        value={
+                            custom_response.STATUS: custom_response.Status.ERROR,
+                            custom_response.CODE: [
+                                constants.Code.INTERNAL_ERROR
+                            ],
+                        },
+                    ),
+                ],
+            ),
         },
     )
     def post(


### PR DESCRIPTION
## タスクやディスカッションのリンク
<!-- - URLをここに貼る -->
- #384 

## やったこと
<!-- - このタスクでやったことはなにか？ -->
リファクタのみです
- `accounts` app の view で 500 の場合に `handle_exception()` で一括して受け取るようにしました
- extend_schema も修正

## やらないこと
<!-- - このタスクでやらないことはなにか？（やらない場合いつやるのか？無ければ「なし」を記述） -->
上記以外

## 動作確認
<!-- - どのような動作確認を行い、結果はどうだったのか？(適宜スクショ等添付) -->
- swagger-ui で accounts の 500 の extend_schema が code を返すものになっていること
- 実際に view のどこかで raise Exception して code 有りの 500 が返ること

## 特にレビューをお願いしたい箇所
<!-- - 特にチェックをお願いしたいポイントを簡潔に記述する -->
リファクタのみなので、主に extend_schema の確認をお願いします

## その他
<!-- - 実装上の懸念点、注意点等あれば記載する -->
特になし

## 参考リンク
<!-- - 実装に際し参考にした、記事やサイトのリンクを記載する -->
特になし

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **新機能**
  - 強化されたエラー処理により、内部エラー発生時に一貫したカスタムレスポンス（エラーコードと詳細メッセージ）が提供されるようになりました。

- **ドキュメント**
  - APIドキュメントが更新され、500エラー時のレスポンス仕様と具体例が明確化されています。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->