### PR TITLE
⚡ [users] UsersSerializer に match_wins, match_losses 追加

### DIFF
--- a/backend/pong/accounts/views.py
+++ b/backend/pong/accounts/views.py
@@ -53,7 +53,8 @@ class AccountCreateView(views.APIView):
                                 constants.PlayerFields.AVATAR: "/media/avatars/sample.png",
                                 users_constants.UsersFields.IS_FRIEND: False,
                                 users_constants.UsersFields.IS_BLOCKED: False,
-                                # todo: is_online,win_match,lose_match追加
+                                users_constants.UsersFields.MATCH_WINS: 0,
+                                users_constants.UsersFields.MATCH_LOSSES: 0,
                             },
                         },
                     ),

--- a/backend/pong/users/blocks/serializers/create_serializers.py
+++ b/backend/pong/users/blocks/serializers/create_serializers.py
@@ -22,7 +22,8 @@ class BlockRelationshipCreateSerializer(serializers.ModelSerializer):
             accounts_constants.PlayerFields.AVATAR,
             users_constants.UsersFields.IS_FRIEND,
             users_constants.UsersFields.IS_BLOCKED,
-            # todo: is_online,win_match,lose_match追加
+            users_constants.UsersFields.MATCH_WINS,
+            users_constants.UsersFields.MATCH_LOSSES,
         ),
     )
 

--- a/backend/pong/users/blocks/serializers/list_serializers.py
+++ b/backend/pong/users/blocks/serializers/list_serializers.py
@@ -18,7 +18,8 @@ class BlockRelationshipListSerializer(drf_serializers.ModelSerializer):
             accounts_constants.PlayerFields.AVATAR,
             users_constants.UsersFields.IS_FRIEND,
             users_constants.UsersFields.IS_BLOCKED,
-            # todo: is_online,win_match,lose_match追加
+            users_constants.UsersFields.MATCH_WINS,
+            users_constants.UsersFields.MATCH_LOSSES,
         ),
     )
 

--- a/backend/pong/users/blocks/serializers/tests/test_create_serializers.py
+++ b/backend/pong/users/blocks/serializers/tests/test_create_serializers.py
@@ -19,6 +19,8 @@ DISPLAY_NAME: Final[str] = accounts_constants.PlayerFields.DISPLAY_NAME
 AVATAR: Final[str] = accounts_constants.PlayerFields.AVATAR
 IS_FRIEND: Final[str] = users_constants.UsersFields.IS_FRIEND
 IS_BLOCKED: Final[str] = users_constants.UsersFields.IS_BLOCKED
+MATCH_WINS: Final[str] = users_constants.UsersFields.MATCH_WINS
+MATCH_LOSSES: Final[str] = users_constants.UsersFields.MATCH_LOSSES
 
 USER_ID: Final[str] = constants.BlockRelationshipFields.USER_ID
 BLOCKED_USER_ID: Final[str] = constants.BlockRelationshipFields.BLOCKED_USER_ID
@@ -91,7 +93,8 @@ class BlockRelationshipCreateSerializerTests(TestCase):
                     AVATAR: "/media/avatars/sample.png",  # todo: デフォルト画像が変更になったら修正
                     IS_FRIEND: False,
                     IS_BLOCKED: True,
-                    # todo: is_online,win_match,lose_match追加
+                    MATCH_WINS: 0,
+                    MATCH_LOSSES: 0,
                 },
             },
         )

--- a/backend/pong/users/blocks/serializers/tests/test_list_serializers.py
+++ b/backend/pong/users/blocks/serializers/tests/test_list_serializers.py
@@ -20,6 +20,8 @@ DISPLAY_NAME: Final[str] = accounts_constants.PlayerFields.DISPLAY_NAME
 AVATAR: Final[str] = accounts_constants.PlayerFields.AVATAR
 IS_FRIEND: Final[str] = users_constants.UsersFields.IS_FRIEND
 IS_BLOCKED: Final[str] = users_constants.UsersFields.IS_BLOCKED
+MATCH_WINS: Final[str] = users_constants.UsersFields.MATCH_WINS
+MATCH_LOSSES: Final[str] = users_constants.UsersFields.MATCH_LOSSES
 
 USER_ID: Final[str] = constants.BlockRelationshipFields.USER_ID
 BLOCKED_USER: Final[str] = constants.BlockRelationshipFields.BLOCKED_USER
@@ -99,7 +101,8 @@ class BlockRelationshipListSerializerTests(TestCase):
                         AVATAR: "/media/avatars/sample.png",  # todo: デフォルト画像が変更になったら修正
                         IS_FRIEND: False,
                         IS_BLOCKED: True,
-                        # todo: is_online,win_match,lose_match追加
+                        MATCH_WINS: 0,
+                        MATCH_LOSSES: 0,
                     },
                 },
                 {
@@ -110,7 +113,8 @@ class BlockRelationshipListSerializerTests(TestCase):
                         AVATAR: "/media/avatars/sample.png",  # todo: デフォルト画像が変更になったら修正
                         IS_FRIEND: False,
                         IS_BLOCKED: True,
-                        # todo: is_online,win_match,lose_match追加
+                        MATCH_WINS: 0,
+                        MATCH_LOSSES: 0,
                     },
                 },
             ],

--- a/backend/pong/users/blocks/tests/integration/test_create_views.py
+++ b/backend/pong/users/blocks/tests/integration/test_create_views.py
@@ -21,6 +21,8 @@ DISPLAY_NAME: Final[str] = accounts_constants.PlayerFields.DISPLAY_NAME
 AVATAR: Final[str] = accounts_constants.PlayerFields.AVATAR
 IS_FRIEND: Final[str] = users_constants.UsersFields.IS_FRIEND
 IS_BLOCKED: Final[str] = users_constants.UsersFields.IS_BLOCKED
+MATCH_WINS: Final[str] = users_constants.UsersFields.MATCH_WINS
+MATCH_LOSSES: Final[str] = users_constants.UsersFields.MATCH_LOSSES
 
 USER_ID: Final[str] = constants.BlockRelationshipFields.USER_ID
 BLOCKED_USER_ID: Final[str] = constants.BlockRelationshipFields.BLOCKED_USER_ID
@@ -110,7 +112,8 @@ class BlocksCreateViewTests(test.APITestCase):
                     AVATAR: "/media/avatars/sample.png",  # todo: デフォルト画像が変更になったら修正
                     IS_FRIEND: False,
                     IS_BLOCKED: True,
-                    # todo: is_online,win_match,lose_match追加
+                    MATCH_WINS: 0,
+                    MATCH_LOSSES: 0,
                 },
             },
         )

--- a/backend/pong/users/blocks/tests/integration/test_list_views.py
+++ b/backend/pong/users/blocks/tests/integration/test_list_views.py
@@ -22,6 +22,8 @@ DISPLAY_NAME: Final[str] = accounts_constants.PlayerFields.DISPLAY_NAME
 AVATAR: Final[str] = accounts_constants.PlayerFields.AVATAR
 IS_FRIEND: Final[str] = users_constants.UsersFields.IS_FRIEND
 IS_BLOCKED: Final[str] = users_constants.UsersFields.IS_BLOCKED
+MATCH_WINS: Final[str] = users_constants.UsersFields.MATCH_WINS
+MATCH_LOSSES: Final[str] = users_constants.UsersFields.MATCH_LOSSES
 
 BLOCKED_USER: Final[str] = constants.BlockRelationshipFields.BLOCKED_USER
 
@@ -157,7 +159,8 @@ class BlocksListViewTests(test.APITestCase):
                             AVATAR: "/media/avatars/sample.png",  # todo: デフォルト画像が変更になったら修正
                             IS_FRIEND: False,
                             IS_BLOCKED: True,
-                            # todo: is_online,win_match,lose_match追加
+                            MATCH_WINS: 0,
+                            MATCH_LOSSES: 0,
                         },
                     },
                     {
@@ -168,7 +171,8 @@ class BlocksListViewTests(test.APITestCase):
                             AVATAR: "/media/avatars/sample.png",  # todo: デフォルト画像が変更になったら修正
                             IS_FRIEND: False,
                             IS_BLOCKED: True,
-                            # todo: is_online,win_match,lose_match追加
+                            MATCH_WINS: 0,
+                            MATCH_LOSSES: 0,
                         },
                     },
                 ],
@@ -200,7 +204,8 @@ class BlocksListViewTests(test.APITestCase):
                             AVATAR: "/media/avatars/sample.png",  # todo: デフォルト画像が変更になったら修正
                             IS_FRIEND: False,
                             IS_BLOCKED: True,
-                            # todo: is_online,win_match,lose_match追加
+                            MATCH_WINS: 0,
+                            MATCH_LOSSES: 0,
                         },
                     },
                 ],
@@ -232,7 +237,8 @@ class BlocksListViewTests(test.APITestCase):
                             AVATAR: "/media/avatars/sample.png",  # todo: デフォルト画像が変更になったら修正
                             IS_FRIEND: False,
                             IS_BLOCKED: True,
-                            # todo: is_online,win_match,lose_match追加
+                            MATCH_WINS: 0,
+                            MATCH_LOSSES: 0,
                         },
                     },
                 ],

--- a/backend/pong/users/blocks/views.py
+++ b/backend/pong/users/blocks/views.py
@@ -144,7 +144,8 @@ logger = logging.getLogger(__name__)
                                     accounts_constants.PlayerFields.AVATAR: "/media/avatars/sample.png",
                                     users_constants.UsersFields.IS_FRIEND: False,
                                     users_constants.UsersFields.IS_BLOCKED: True,
-                                    # todo: is_online,win_match,lose_match追加
+                                    users_constants.UsersFields.MATCH_WINS: 1,
+                                    users_constants.UsersFields.MATCH_LOSSES: 0,
                                 },
                             },
                         },

--- a/backend/pong/users/blocks/views.py
+++ b/backend/pong/users/blocks/views.py
@@ -65,7 +65,8 @@ logger = logging.getLogger(__name__)
                                             accounts_constants.PlayerFields.AVATAR: "/media/avatars/sample.png",
                                             users_constants.UsersFields.IS_FRIEND: False,
                                             users_constants.UsersFields.IS_BLOCKED: True,
-                                            # todo: is_online,win_match,lose_match追加
+                                            users_constants.UsersFields.MATCH_WINS: 1,
+                                            users_constants.UsersFields.MATCH_LOSSES: 0,
                                         },
                                     },
                                     "...",

--- a/backend/pong/users/constants.py
+++ b/backend/pong/users/constants.py
@@ -15,4 +15,5 @@ class Code:
 class UsersFields:
     IS_FRIEND: Final[str] = "is_friend"
     IS_BLOCKED: Final[str] = "is_blocked"
-    # todo: is_online,win_match,lose_match追加
+    MATCH_WINS: Final[str] = "match_wins"
+    MATCH_LOSSES: Final[str] = "match_losses"

--- a/backend/pong/users/friends/serializers/create_serializers.py
+++ b/backend/pong/users/friends/serializers/create_serializers.py
@@ -22,7 +22,8 @@ class FriendshipCreateSerializer(serializers.ModelSerializer):
             accounts_constants.PlayerFields.AVATAR,
             users_constants.UsersFields.IS_FRIEND,
             users_constants.UsersFields.IS_BLOCKED,
-            # todo: is_online,win_match,lose_match追加
+            users_constants.UsersFields.MATCH_WINS,
+            users_constants.UsersFields.MATCH_LOSSES,
         ),
     )
 

--- a/backend/pong/users/friends/serializers/list_serializers.py
+++ b/backend/pong/users/friends/serializers/list_serializers.py
@@ -18,7 +18,8 @@ class FriendshipListSerializer(drf_serializers.ModelSerializer):
             accounts_constants.PlayerFields.AVATAR,
             users_constants.UsersFields.IS_FRIEND,
             users_constants.UsersFields.IS_BLOCKED,
-            # todo: is_online,win_match,lose_match追加
+            users_constants.UsersFields.MATCH_WINS,
+            users_constants.UsersFields.MATCH_LOSSES,
         ),
     )
 

--- a/backend/pong/users/friends/serializers/tests/test_create_serializers.py
+++ b/backend/pong/users/friends/serializers/tests/test_create_serializers.py
@@ -19,6 +19,8 @@ DISPLAY_NAME: Final[str] = accounts_constants.PlayerFields.DISPLAY_NAME
 AVATAR: Final[str] = accounts_constants.PlayerFields.AVATAR
 IS_FRIEND: Final[str] = users_constants.UsersFields.IS_FRIEND
 IS_BLOCKED: Final[str] = users_constants.UsersFields.IS_BLOCKED
+MATCH_WINS: Final[str] = users_constants.UsersFields.MATCH_WINS
+MATCH_LOSSES: Final[str] = users_constants.UsersFields.MATCH_LOSSES
 
 USER_ID: Final[str] = constants.FriendshipFields.USER_ID
 FRIEND_USER_ID: Final[str] = constants.FriendshipFields.FRIEND_USER_ID
@@ -92,7 +94,8 @@ class FriendshipCreateSerializerTests(TestCase):
                     AVATAR: "/media/avatars/sample.png",  # todo: デフォルト画像が変更になったら修正
                     IS_FRIEND: True,
                     IS_BLOCKED: False,
-                    # todo: is_online,win_match,lose_match追加
+                    MATCH_WINS: 0,
+                    MATCH_LOSSES: 0,
                 },
             },
         )

--- a/backend/pong/users/friends/serializers/tests/test_list_serializers.py
+++ b/backend/pong/users/friends/serializers/tests/test_list_serializers.py
@@ -20,6 +20,8 @@ DISPLAY_NAME: Final[str] = accounts_constants.PlayerFields.DISPLAY_NAME
 AVATAR: Final[str] = accounts_constants.PlayerFields.AVATAR
 IS_FRIEND: Final[str] = users_constants.UsersFields.IS_FRIEND
 IS_BLOCKED: Final[str] = users_constants.UsersFields.IS_BLOCKED
+MATCH_WINS: Final[str] = users_constants.UsersFields.MATCH_WINS
+MATCH_LOSSES: Final[str] = users_constants.UsersFields.MATCH_LOSSES
 
 USER_ID: Final[str] = constants.FriendshipFields.USER_ID
 FRIEND: Final[str] = constants.FriendshipFields.FRIEND
@@ -95,7 +97,8 @@ class FriendshipListSerializerTests(TestCase):
                         AVATAR: "/media/avatars/sample.png",  # todo: デフォルト画像が変更になったら修正
                         IS_FRIEND: True,
                         IS_BLOCKED: False,
-                        # todo: is_online,win_match,lose_match追加
+                        MATCH_WINS: 0,
+                        MATCH_LOSSES: 0,
                     },
                 },
                 {
@@ -106,7 +109,8 @@ class FriendshipListSerializerTests(TestCase):
                         AVATAR: "/media/avatars/sample.png",  # todo: デフォルト画像が変更になったら修正
                         IS_FRIEND: True,
                         IS_BLOCKED: False,
-                        # todo: is_online,win_match,lose_match追加
+                        MATCH_WINS: 0,
+                        MATCH_LOSSES: 0,
                     },
                 },
             ],

--- a/backend/pong/users/friends/tests/integration/test_create_views.py
+++ b/backend/pong/users/friends/tests/integration/test_create_views.py
@@ -21,6 +21,8 @@ DISPLAY_NAME: Final[str] = accounts_constants.PlayerFields.DISPLAY_NAME
 AVATAR: Final[str] = accounts_constants.PlayerFields.AVATAR
 IS_FRIEND: Final[str] = users_constants.UsersFields.IS_FRIEND
 IS_BLOCKED: Final[str] = users_constants.UsersFields.IS_BLOCKED
+MATCH_WINS: Final[str] = users_constants.UsersFields.MATCH_WINS
+MATCH_LOSSES: Final[str] = users_constants.UsersFields.MATCH_LOSSES
 
 USER_ID: Final[str] = constants.FriendshipFields.USER_ID
 FRIEND_USER_ID: Final[str] = constants.FriendshipFields.FRIEND_USER_ID
@@ -110,7 +112,8 @@ class FriendsCreateViewTests(test.APITestCase):
                     AVATAR: "/media/avatars/sample.png",  # todo: デフォルト画像が変更になったら修正
                     IS_FRIEND: True,
                     IS_BLOCKED: False,
-                    # todo: is_online,win_match,lose_match追加
+                    MATCH_WINS: 0,
+                    MATCH_LOSSES: 0,
                 },
             },
         )

--- a/backend/pong/users/friends/tests/integration/test_list_views.py
+++ b/backend/pong/users/friends/tests/integration/test_list_views.py
@@ -22,6 +22,8 @@ DISPLAY_NAME: Final[str] = accounts_constants.PlayerFields.DISPLAY_NAME
 AVATAR: Final[str] = accounts_constants.PlayerFields.AVATAR
 IS_FRIEND: Final[str] = users_constants.UsersFields.IS_FRIEND
 IS_BLOCKED: Final[str] = users_constants.UsersFields.IS_BLOCKED
+MATCH_WINS: Final[str] = users_constants.UsersFields.MATCH_WINS
+MATCH_LOSSES: Final[str] = users_constants.UsersFields.MATCH_LOSSES
 
 FRIEND: Final[str] = constants.FriendshipFields.FRIEND
 
@@ -153,7 +155,8 @@ class FriendsListViewTests(test.APITestCase):
                             AVATAR: "/media/avatars/sample.png",  # todo: デフォルト画像が変更になったら修正
                             IS_FRIEND: True,
                             IS_BLOCKED: False,
-                            # todo: is_online,win_match,lose_match追加
+                            MATCH_WINS: 0,
+                            MATCH_LOSSES: 0,
                         },
                     },
                     {
@@ -164,7 +167,8 @@ class FriendsListViewTests(test.APITestCase):
                             AVATAR: "/media/avatars/sample.png",  # todo: デフォルト画像が変更になったら修正
                             IS_FRIEND: True,
                             IS_BLOCKED: False,
-                            # todo: is_online,win_match,lose_match追加
+                            MATCH_WINS: 0,
+                            MATCH_LOSSES: 0,
                         },
                     },
                 ],
@@ -196,7 +200,8 @@ class FriendsListViewTests(test.APITestCase):
                             AVATAR: "/media/avatars/sample.png",  # todo: デフォルト画像が変更になったら修正
                             IS_FRIEND: True,
                             IS_BLOCKED: False,
-                            # todo: is_online,win_match,lose_match追加
+                            MATCH_WINS: 0,
+                            MATCH_LOSSES: 0,
                         },
                     },
                 ],
@@ -228,7 +233,8 @@ class FriendsListViewTests(test.APITestCase):
                             AVATAR: "/media/avatars/sample.png",  # todo: デフォルト画像が変更になったら修正
                             IS_FRIEND: True,
                             IS_BLOCKED: False,
-                            # todo: is_online,win_match,lose_match追加
+                            MATCH_WINS: 0,
+                            MATCH_LOSSES: 0,
                         },
                     },
                 ],

--- a/backend/pong/users/friends/views.py
+++ b/backend/pong/users/friends/views.py
@@ -140,7 +140,8 @@ logger = logging.getLogger(__name__)
                                     accounts_constants.PlayerFields.AVATAR: "/media/avatars/sample.png",
                                     users_constants.UsersFields.IS_FRIEND: True,
                                     users_constants.UsersFields.IS_BLOCKED: False,
-                                    # todo: is_online,win_match,lose_match追加
+                                    users_constants.UsersFields.MATCH_WINS: 1,
+                                    users_constants.UsersFields.MATCH_LOSSES: 0,
                                 },
                             },
                         },

--- a/backend/pong/users/friends/views.py
+++ b/backend/pong/users/friends/views.py
@@ -63,7 +63,8 @@ logger = logging.getLogger(__name__)
                                             accounts_constants.PlayerFields.AVATAR: "/media/avatars/sample.png",
                                             users_constants.UsersFields.IS_FRIEND: True,
                                             users_constants.UsersFields.IS_BLOCKED: False,
-                                            # todo: is_online,win_match,lose_match追加
+                                            users_constants.UsersFields.MATCH_WINS: 1,
+                                            users_constants.UsersFields.MATCH_LOSSES: 0,
                                         },
                                     },
                                     "...",

--- a/backend/pong/users/tests/integration/test_list.py
+++ b/backend/pong/users/tests/integration/test_list.py
@@ -21,6 +21,8 @@ DISPLAY_NAME: Final[str] = accounts_constants.PlayerFields.DISPLAY_NAME
 AVATAR: Final[str] = accounts_constants.PlayerFields.AVATAR
 IS_FRIEND: Final[str] = constants.UsersFields.IS_FRIEND
 IS_BLOCKED: Final[str] = constants.UsersFields.IS_BLOCKED
+MATCH_WINS: Final[str] = constants.UsersFields.MATCH_WINS
+MATCH_LOSSES: Final[str] = constants.UsersFields.MATCH_LOSSES
 
 DATA: Final[str] = custom_response.DATA
 
@@ -118,7 +120,8 @@ class UsersListViewTests(test.APITestCase):
                         AVATAR: self.player1.avatar.url,
                         IS_FRIEND: False,
                         IS_BLOCKED: False,
-                        # todo: is_online,win_match,lose_match追加
+                        MATCH_WINS: 0,
+                        MATCH_LOSSES: 0,
                     },
                     {
                         ID: self.user2.id,
@@ -127,7 +130,8 @@ class UsersListViewTests(test.APITestCase):
                         AVATAR: self.player2.avatar.url,
                         IS_FRIEND: False,
                         IS_BLOCKED: False,
-                        # todo: is_online,win_match,lose_match追加
+                        MATCH_WINS: 0,
+                        MATCH_LOSSES: 0,
                     },
                 ],
             },

--- a/backend/pong/users/tests/integration/test_me.py
+++ b/backend/pong/users/tests/integration/test_me.py
@@ -24,6 +24,8 @@ DISPLAY_NAME: Final[str] = accounts_constants.PlayerFields.DISPLAY_NAME
 AVATAR: Final[str] = accounts_constants.PlayerFields.AVATAR
 IS_FRIEND: Final[str] = constants.UsersFields.IS_FRIEND
 IS_BLOCKED: Final[str] = constants.UsersFields.IS_BLOCKED
+MATCH_WINS: Final[str] = constants.UsersFields.MATCH_WINS
+MATCH_LOSSES: Final[str] = constants.UsersFields.MATCH_LOSSES
 
 DATA: Final[str] = custom_response.DATA
 CODE: Final[str] = custom_response.CODE
@@ -98,7 +100,8 @@ class UsersMeViewTests(test.APITestCase):
                 AVATAR: self.player.avatar.url,
                 IS_FRIEND: False,
                 IS_BLOCKED: False,
-                # todo: is_online,win_match,lose_match追加
+                MATCH_WINS: 0,
+                MATCH_LOSSES: 0,
             },
         )
 

--- a/backend/pong/users/tests/integration/test_retrieve.py
+++ b/backend/pong/users/tests/integration/test_retrieve.py
@@ -20,6 +20,8 @@ DISPLAY_NAME: Final[str] = accounts_constants.PlayerFields.DISPLAY_NAME
 AVATAR: Final[str] = accounts_constants.PlayerFields.AVATAR
 IS_FRIEND: Final[str] = constants.UsersFields.IS_FRIEND
 IS_BLOCKED: Final[str] = constants.UsersFields.IS_BLOCKED
+MATCH_WINS: Final[str] = constants.UsersFields.MATCH_WINS
+MATCH_LOSSES: Final[str] = constants.UsersFields.MATCH_LOSSES
 
 DATA: Final[str] = custom_response.DATA
 CODE: Final[str] = custom_response.CODE
@@ -117,7 +119,8 @@ class UsersRetrieveViewTests(test.APITestCase):
                     AVATAR: user.player.avatar.url,
                     IS_FRIEND: False,
                     IS_BLOCKED: False,
-                    # todo: is_online,win_match,lose_match追加
+                    MATCH_WINS: 0,
+                    MATCH_LOSSES: 0,
                 },
             )
 

--- a/backend/pong/users/tests/unit/test_users_serializer.py
+++ b/backend/pong/users/tests/unit/test_users_serializer.py
@@ -22,6 +22,8 @@ DISPLAY_NAME: Final[str] = accounts_constants.PlayerFields.DISPLAY_NAME
 AVATAR: Final[str] = accounts_constants.PlayerFields.AVATAR
 IS_FRIEND: Final[str] = constants.UsersFields.IS_FRIEND
 IS_BLOCKED: Final[str] = constants.UsersFields.IS_BLOCKED
+MATCH_WINS: Final[str] = constants.UsersFields.MATCH_WINS
+MATCH_LOSSES: Final[str] = constants.UsersFields.MATCH_LOSSES
 
 USER_ID: Final[str] = friends_constants.FriendshipFields.USER_ID
 
@@ -88,7 +90,8 @@ class UsersSerializerTests(TestCase):
                     AVATAR: self.player_1.avatar.url,
                     IS_FRIEND: False,
                     IS_BLOCKED: False,
-                    # todo: is_online,win_match,lose_match追加
+                    MATCH_WINS: 0,
+                    MATCH_LOSSES: 0,
                 },
                 {
                     ID: self.user_2.id,
@@ -98,7 +101,8 @@ class UsersSerializerTests(TestCase):
                     AVATAR: self.player_2.avatar.url,
                     IS_FRIEND: False,
                     IS_BLOCKED: False,
-                    # todo: is_online,win_match,lose_match追加
+                    MATCH_WINS: 0,
+                    MATCH_LOSSES: 0,
                 },
             ],
         )

--- a/backend/pong/users/tests/unit/test_users_serializers_related_matches.py
+++ b/backend/pong/users/tests/unit/test_users_serializers_related_matches.py
@@ -11,11 +11,15 @@ from tournaments.round import models as round_models
 from tournaments.tournament import models as tournament_models
 from users.friends import constants as friends_constants
 
+from ... import constants, serializers
+
 USERNAME: Final[str] = accounts_constants.UserFields.USERNAME
 EMAIL: Final[str] = accounts_constants.UserFields.EMAIL
 PASSWORD: Final[str] = accounts_constants.UserFields.PASSWORD
 USER: Final[str] = accounts_constants.PlayerFields.USER
 DISPLAY_NAME: Final[str] = accounts_constants.PlayerFields.DISPLAY_NAME
+MATCH_WINS: Final[str] = constants.UsersFields.MATCH_WINS
+MATCH_LOSSES: Final[str] = constants.UsersFields.MATCH_LOSSES
 
 USER_ID: Final[str] = friends_constants.FriendshipFields.USER_ID
 
@@ -66,3 +70,21 @@ class UsersSerializerTests(TestCase):
                 )
             )
             self.participation_list.append(participation)
+
+    def test_field_match_wins(self) -> None:
+        """
+        勝利した試合の数が正しく取得できることを確認
+        """
+        # 3つの内2つのmatchに勝利
+        for participation in self.participation_list[:2]:
+            participation.is_win = True
+            participation.save()
+        # user1をログインユーザーとしてserializer作成
+        serializer: serializers.UsersSerializer = serializers.UsersSerializer(
+            self.player,
+            context={USER_ID: self.user.id},
+        )
+
+        # 勝利した試合の数が2であることを確認
+        self.assertEqual(serializer.data[MATCH_WINS], 2)
+        # todo: 負けたCOMPLETEDな試合の数が0であることを確認

--- a/backend/pong/users/views/list.py
+++ b/backend/pong/users/views/list.py
@@ -109,7 +109,8 @@ class UsersListView(views.APIView):
                                         accounts_constants.PlayerFields.AVATAR: "/media/avatars/sample1.png",
                                         constants.UsersFields.IS_FRIEND: False,
                                         constants.UsersFields.IS_BLOCKED: False,
-                                        # todo: is_online,win_match,lose_match追加
+                                        constants.UsersFields.MATCH_WINS: 1,
+                                        constants.UsersFields.MATCH_LOSSES: 0,
                                     },
                                     {
                                         accounts_constants.UserFields.ID: 3,
@@ -118,7 +119,8 @@ class UsersListView(views.APIView):
                                         accounts_constants.PlayerFields.AVATAR: "/media/avatars/sample2.png",
                                         constants.UsersFields.IS_FRIEND: False,
                                         constants.UsersFields.IS_BLOCKED: False,
-                                        # todo: is_online,win_match,lose_match追加
+                                        constants.UsersFields.MATCH_WINS: 1,
+                                        constants.UsersFields.MATCH_LOSSES: 0,
                                     },
                                     "...",
                                 ],
@@ -198,7 +200,8 @@ class UsersListView(views.APIView):
                 accounts_constants.PlayerFields.AVATAR,
                 constants.UsersFields.IS_FRIEND,
                 constants.UsersFields.IS_BLOCKED,
-                # todo: is_online,win_match,lose_match追加
+                constants.UsersFields.MATCH_WINS,
+                constants.UsersFields.MATCH_LOSSES,
             ),
             context={friends_constants.FriendshipFields.USER_ID: user.id},
         )

--- a/backend/pong/users/views/me.py
+++ b/backend/pong/users/views/me.py
@@ -88,7 +88,8 @@ class UsersMeView(views.APIView):
                                 accounts_constants.PlayerFields.AVATAR: "/media/avatars/sample.png",
                                 constants.UsersFields.IS_FRIEND: False,
                                 constants.UsersFields.IS_BLOCKED: False,
-                                # todo: is_online,win_match,lose_match追加
+                                constants.UsersFields.MATCH_WINS: 1,
+                                constants.UsersFields.MATCH_LOSSES: 0,
                             },
                         },
                     ),
@@ -192,7 +193,8 @@ class UsersMeView(views.APIView):
                                 accounts_constants.PlayerFields.AVATAR: "/media/avatars/sample.png",
                                 constants.UsersFields.IS_FRIEND: False,
                                 constants.UsersFields.IS_BLOCKED: False,
-                                # todo: is_online,win_match,lose_match追加
+                                constants.UsersFields.MATCH_WINS: 1,
+                                constants.UsersFields.MATCH_LOSSES: 0,
                             },
                         },
                     ),

--- a/backend/pong/users/views/retrieve.py
+++ b/backend/pong/users/views/retrieve.py
@@ -85,7 +85,8 @@ class UsersRetrieveView(views.APIView):
                                 accounts_constants.PlayerFields.AVATAR: "/media/avatars/sample.png",
                                 constants.UsersFields.IS_FRIEND: True,
                                 constants.UsersFields.IS_BLOCKED: False,
-                                # todo: is_online,win_match,lose_match追加
+                                constants.UsersFields.MATCH_WINS: 1,
+                                constants.UsersFields.MATCH_LOSSES: 0,
                             },
                         },
                     ),
@@ -185,7 +186,8 @@ class UsersRetrieveView(views.APIView):
                     accounts_constants.PlayerFields.AVATAR,
                     constants.UsersFields.IS_FRIEND,
                     constants.UsersFields.IS_BLOCKED,
-                    # todo: is_online,win_match,lose_match追加
+                    constants.UsersFields.MATCH_WINS,
+                    constants.UsersFields.MATCH_LOSSES,
                 ),
                 context={friends_constants.FriendshipFields.USER_ID: user.id},
             )


### PR DESCRIPTION
## タスクやディスカッションのリンク
<!-- - URLをここに貼る -->
- #383 

## やったこと
<!-- - このタスクでやったことはなにか？ -->
- ユーザープロフィールを返す以下のエンドポイント全部に、match の勝敗数を表すフィールド `match_wins`, `match_losses` を追加しました
  - accounts, POST
  - users の DELETE 以外 8 個
![image](https://github.com/user-attachments/assets/0d0e83c5-857d-42de-ba61-bc5b9197b2ed)

## やらないこと
<!-- - このタスクでやらないことはなにか？（やらない場合いつやるのか？無ければ「なし」を記述） -->
上記以外

## 動作確認
<!-- - どのような動作確認を行い、結果はどうだったのか？(適宜スクショ等添付) -->
- swagger-ui にて、上記エンドポイントの extend_schema に `match_wins`, `match_losses` が追加されてること
- 実際のレスポンスにも `match_wins`, `match_losses` が含まれていること

## 特にレビューをお願いしたい箇所
<!-- - 特にチェックをお願いしたいポイントを簡潔に記述する -->
確認するエンドポイントが多くて申し訳ないのですが、主に動作確認をよろしくお願いします

## その他
<!-- - 実装上の懸念点、注意点等あれば記載する -->
特になし

## 参考リンク
<!-- - 実装に際し参考にした、記事やサイトのリンクを記載する -->
特になし


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
	- ユーザーのアカウントやフレンド、ブロック、プロフィールなどの各画面に、試合勝数と敗北数の統計情報が追加され、より詳細なユーザーステータスが表示されるようになりました。
- **テスト**
	- 新たな統計フィールドに対応するため、関連するテストケースが更新・拡充され、正確なデータ反映が確認されています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->