### PR TITLE
⚡ [avatar] 拡張子の制限を追加

### DIFF
--- a/backend/pong/accounts/constants.py
+++ b/backend/pong/accounts/constants.py
@@ -1,4 +1,5 @@
 import dataclasses
+from typing import Final
 
 from pong.custom_response import custom_response
 
@@ -19,6 +20,9 @@ class PlayerFields:
     AVATAR: str = "avatar"
     CREATED_AT: str = "created_at"
     UPDATED_AT: str = "updated_at"
+
+
+MAX_AVATAR_FILE_NAME_LENGTH: Final[int] = 50
 
 
 @dataclasses.dataclass(frozen=True)

--- a/backend/pong/accounts/player/serializers.py
+++ b/backend/pong/accounts/player/serializers.py
@@ -1,9 +1,30 @@
+import os
+
 from django.contrib.auth.models import User
+from django.core.files import File
 from django.core.validators import RegexValidator
 from rest_framework import serializers
 
 from .. import constants
 from . import models
+
+
+def validate_avatar_extension(avatar: File) -> None:
+    """
+    avatarの拡張子に制限をかけるバリデータ
+    extensionが空文字列の場合はImageFeildのバリデータで先にエラーになるためここではチェックしない
+    """
+    valid_extensions: set[str] = {".png", ".jpg", ".jpeg", ".gif"}
+    # mypyにavatar.nameがNoneの可能性を指摘されるが、ImageFieldのvalidatorでextensionがあることは確認済みのため無視
+    _, extension = os.path.splitext(avatar.name)  # type: ignore[type-var]
+    # is Noneも確認しないとmypyのエラーになるので念のため追加
+    if extension is None:
+        raise serializers.ValidationError("Must contain a file extension.")
+    if extension.lower() not in valid_extensions:
+        raise serializers.ValidationError(
+            f"Unsupported file extension: {extension}. "
+            f"Supported extensions are {", ".join(valid_extensions)}."
+        )
 
 
 class PlayerSerializer(serializers.ModelSerializer):
@@ -33,8 +54,9 @@ class PlayerSerializer(serializers.ModelSerializer):
     avatar: serializers.ImageField = serializers.ImageField(
         required=False,
         allow_null=True,
-        # todo: 画像の最大サイズを指定・拡張子を制限・リサイズする
+        # todo: 画像の最大サイズを指定・リサイズする
         # max_length=constants.MAX_AVATAR_SIZE,
+        validators=[validate_avatar_extension],
     )
 
     class Meta:

--- a/backend/pong/accounts/player/serializers.py
+++ b/backend/pong/accounts/player/serializers.py
@@ -55,7 +55,7 @@ class PlayerSerializer(serializers.ModelSerializer):
         required=False,
         allow_null=True,
         # todo: 画像の最大サイズを指定・リサイズする
-        # max_length=constants.MAX_AVATAR_SIZE,
+        max_length=constants.MAX_AVATAR_FILE_NAME_LENGTH,  # 画像ファイル名の長さ
         validators=[validate_avatar_extension],
     )
 

--- a/backend/pong/accounts/player/tests/test_player_serializer.py
+++ b/backend/pong/accounts/player/tests/test_player_serializer.py
@@ -208,3 +208,32 @@ class PlayerSerializerTests(TestCase):
 
         self.assertFalse(player_serializer.is_valid())
         self.assertIn(DISPLAY_NAME, player_serializer.errors)
+
+    @parameterized.parameterized.expand(
+        [
+            # 空文字列はファイル作成できないため試さない
+            ("拡張子がない場合", "not_exist_extension"),
+            ("拡張子が不正な場合", "testuser.invalid_extension"),
+            (
+                "ファイル名が最大長を超える場合",
+                "a" * (50 - len(".png") + 1) + ".png",
+            ),
+        ]
+    )
+    def test_invalid_avatar_filename(
+        self, testcase_name: str, invalid_file_name: str
+    ) -> None:
+        """
+        不正なファイル名のavatarが渡された場合に、エラーになることを確認
+        """
+        file: SimpleUploadedFile = self._create_image(invalid_file_name)
+        player_data: dict = {
+            USER: self._create_user(self.user_data).id,
+            AVATAR: file,
+        }
+        player_serializer: serializers.PlayerSerializer = (
+            serializers.PlayerSerializer(data=player_data)
+        )
+
+        self.assertFalse(player_serializer.is_valid())
+        self.assertIn(AVATAR, player_serializer.errors)


### PR DESCRIPTION
## タスクやディスカッションのリンク
<!-- - URLをここに貼る -->
- #399 

## やったこと
<!-- - このタスクでやったことはなにか？ -->
- アバター画像のバリデーションを追加しました
  - 拡張子を `.png, .jpg, .jpeg, .gif` に制限しました
  - ファイル名の最大長を 50 文字に制限しました

## やらないこと
<!-- - このタスクでやらないことはなにか？（やらない場合いつやるのか？無ければ「なし」を記述） -->
上記以外

## 動作確認
<!-- - どのような動作確認を行い、結果はどうだったのか？(適宜スクショ等添付) -->
適当にローカルで `.png, .jpg, .jpeg, .gif` のどれかのファイルを用意していただき、swagger-ui にて `/api/users/me/`, `PATCH` でアバター更新をする
- 正常なファイル名 -> `200` が返り、更新できる
- 不正なファイル名 -> 更新されずに `400`, `code=invalid` のエラーになる
	- 拡張子が上記 4 つ以外 (実際のファイルタイプは見ていないので、ファイル名を適当なものに変更して試してみて下さい)
	- 拡張子がない
	- ファイル名が 50 文字以上
	
## 特にレビューをお願いしたい箇所
<!-- - 特にチェックをお願いしたいポイントを簡潔に記述する -->
- お手数ですがファイルを用意していただき、ファイル名を変更しながら動作確認をお願いします

## その他
<!-- - 実装上の懸念点、注意点等あれば記載する -->
- 拡張子のないファイルで更新しようとすると、自作の validator より先に `ImageField` のバリデーションに引っかかり、以下のような errors が返ります。`ImageField` を継承して拡張子のチェックを完全に差し替えることもできるようなのですが、`code=invalid` は変わらず返るので特に今のままでも問題ないと考え、このままにしています。(自作の拡張子チェックはこの後に実行されるようです)
```json
{
  "status": "error",
  "code": [
    "invalid"
  ],
  "errors": {
    "avatar": [
      "File extension “” is not allowed. Allowed extensions are: bmp, dib, gif, jfif, jpe, jpg, jpeg, pbm, pgm, ppm, pnm, pfm, png, apng, blp, bufr, cur, pcx, dcx, dds, ps, eps, fit, fits, fli, flc, ftc, ftu, gbr, grib, h5, hdf, jp2, j2k, jpc, jpf, jpx, j2c, icns, ico, im, iim, mpg, mpeg, tif, tiff, mpo, msp, palm, pcd, pdf, pxr, psd, qoi, bw, rgb, rgba, sgi, ras, tga, icb, vda, vst, webp, wmf, emf, xbm, xpm."
    ]
  }
}
```

## 参考リンク
<!-- - 実装に際し参考にした、記事やサイトのリンクを記載する -->
特になし

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
	- アバター画像のアップロード時に、許可された画像形式（.png、.jpg、.jpeg、.gif）のみが受け入れられるよう、検証ロジックを強化しました。
	- アバター画像のファイル名の長さを50文字以内に制限することで、ファイル名の一貫性と管理性が向上しました。
- **テスト**
	- アバター画像のファイル名検証に関する新しいテストケースを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->