### PR TITLE
⚡ [avatar] 更新時に resize

### DIFF
--- a/backend/pong/pong/settings.py
+++ b/backend/pong/pong/settings.py
@@ -199,6 +199,10 @@ STATIC_URL = "static/"
 MEDIA_URL = "/media/"
 MEDIA_ROOT = os.path.join(BASE_DIR, "media")
 
+FILE_UPLOAD_HANDLERS = [
+    "django.core.files.uploadhandler.TemporaryFileUploadHandler",
+]
+
 # Default primary key field type
 # https://docs.djangoproject.com/en/5.1/ref/settings/#default-auto-field
 

--- a/backend/pong/users/constants.py
+++ b/backend/pong/users/constants.py
@@ -17,3 +17,7 @@ class UsersFields:
     IS_BLOCKED: Final[str] = "is_blocked"
     MATCH_WINS: Final[str] = "match_wins"
     MATCH_LOSSES: Final[str] = "match_losses"
+
+
+# アバター更新用
+MAX_AVATAR_SIZE: Final[int] = 200 * 1024  # 200KB

--- a/backend/pong/users/constants.py
+++ b/backend/pong/users/constants.py
@@ -21,3 +21,4 @@ class UsersFields:
 
 # アバター更新用
 MAX_AVATAR_SIZE: Final[int] = 200 * 1024  # 200KB
+MAX_DIMENSION: Final[int] = 256  # 256*256(px)

--- a/backend/pong/users/serializers.py
+++ b/backend/pong/users/serializers.py
@@ -1,7 +1,7 @@
 import os
 from typing import Final, Optional
 
-from django.core.files.uploadedfile import InMemoryUploadedFile
+from django.core.files.uploadedfile import UploadedFile
 from django.db.models import Count, Q
 from PIL import Image
 from rest_framework import serializers
@@ -18,9 +18,7 @@ from users.friends import models as friends_models
 from . import constants as users_constants
 
 
-def resize_avatar(
-    avatar: InMemoryUploadedFile, max_dimension: int
-) -> InMemoryUploadedFile:
+def resize_avatar(avatar: UploadedFile, max_dimension: int) -> UploadedFile:
     """
     max_dimension * max_dimension以内に画像をリサイズする
     """
@@ -194,7 +192,7 @@ class UsersSerializer(serializers.Serializer):
         """
         return self._get_match_stats(player, "losses")
 
-    def _validate_avatar(self, avatar: InMemoryUploadedFile) -> None:
+    def _validate_avatar(self, avatar: UploadedFile) -> None:
         # avatarが存在していてsizeがNoneである場合は考えにくいがmypyのエラーを回避するためチェック
         if avatar.size is None:
             raise serializers.ValidationError(
@@ -223,7 +221,7 @@ class UsersSerializer(serializers.Serializer):
             accounts_constants.PlayerFields.AVATAR in data
             and self.instance is not None
         ):
-            avatar: Optional[InMemoryUploadedFile] = data[
+            avatar: Optional[UploadedFile] = data[
                 accounts_constants.PlayerFields.AVATAR
             ]
             # 更新時Noneの場合はエラー
@@ -237,8 +235,8 @@ class UsersSerializer(serializers.Serializer):
         return data
 
     def _update_avatar(
-        self, player: player_models.Player, new_avatar: InMemoryUploadedFile
-    ) -> InMemoryUploadedFile:
+        self, player: player_models.Player, new_avatar: UploadedFile
+    ) -> UploadedFile:
         # 更新前の画像を削除してから新しい画像を保存する
         player.avatar.delete(save=False)
 
@@ -269,7 +267,7 @@ class UsersSerializer(serializers.Serializer):
 
         # avatarがあれば更新
         if accounts_constants.PlayerFields.AVATAR in validated_data:
-            new_avatar: InMemoryUploadedFile = validated_data[
+            new_avatar: UploadedFile = validated_data[
                 accounts_constants.PlayerFields.AVATAR
             ]
             player.avatar = self._update_avatar(player, new_avatar)

--- a/backend/pong/users/serializers.py
+++ b/backend/pong/users/serializers.py
@@ -165,13 +165,16 @@ class UsersSerializer(serializers.Serializer):
         """
         validate()のオーバーライド
         """
-        # avatar更新時
-        if accounts_constants.PlayerFields.AVATAR in data:
+        # avatar更新時(self.instanceが存在する場合のみ)
+        if (
+            accounts_constants.PlayerFields.AVATAR in data
+            and self.instance is not None
+        ):
             avatar: Optional[InMemoryUploadedFile] = data[
                 accounts_constants.PlayerFields.AVATAR
             ]
-            # 更新時(既にinstanceが存在している時)にNoneの場合はエラー
-            if self.instance and avatar is None:
+            # 更新時Noneの場合はエラー
+            if avatar is None:
                 raise serializers.ValidationError(
                     {
                         accounts_constants.PlayerFields.AVATAR: "This field may not be blank."

--- a/backend/pong/users/tests/unit/test_users_serializer.py
+++ b/backend/pong/users/tests/unit/test_users_serializer.py
@@ -237,6 +237,25 @@ class UsersSerializerTests(TestCase):
 
         self.assertTrue(serializer.is_valid())
 
+    def test_update_with_invalid_avatar(self) -> None:
+        """
+        不正なavatarファイルサイズの場合にエラーになることを確認
+        """
+        # 最大ファイルサイズ200KBを超える画像
+        invalid_image_size: int = 200 * 1024 + 1
+        new_avatar: SimpleUploadedFile = self._create_image(
+            "valid_filename.png", invalid_image_size
+        )
+        serializer: serializers.UsersSerializer = serializers.UsersSerializer(
+            self.player_1,
+            data={AVATAR: new_avatar},
+            partial=True,
+            context={USER_ID: self.user_1.id},
+        )
+
+        self.assertFalse(serializer.is_valid())
+        self.assertIn(AVATAR, serializer.errors)
+
     def test_is_friend(self) -> None:
         """
         フレンドに追加するとis_friendがTrue、フレンド関係を削除するとFalseになることを確認


### PR DESCRIPTION
## タスクやディスカッションのリンク
<!-- - URLをここに貼る -->
- #398 

## やったこと
<!-- - このタスクでやったことはなにか？ -->
- アバター画像更新時に、大きいファイルサイズが来た場合のハンドリングをしました
- 200KB より大きい場合
  -  256 * 256 px にリサイズを試みる
     - 200KB 以下になっていた場合そのまま更新する
     - リサイズしてもまだ 200KB 以下になっていない場合、大きすぎるファイルとして `code=invalid` を返す

## やらないこと
<!-- - このタスクでやらないことはなにか？（やらない場合いつやるのか？無ければ「なし」を記述） -->
上記以外

## 動作確認
<!-- - どのような動作確認を行い、結果はどうだったのか？(適宜スクショ等添付) -->
適当にローカルで `.png, .jpg, .jpeg, .gif` のどれかの拡張子で、`201KB 以上` と `200KB 以下` のファイルを用意していただき、swagger-ui にて `/api/users/me/`, `PATCH` でアバター更新をする
- 200KB 以下の正常なファイル -> `200` が返り、更新できる
- 201KB 以上のファイル -> `200` が返って更新でき、`media/avatars/` の中にリサイズされた画像がアップロードされている。Django が 2.5 MBを境に処理が変わるのに対応したので、できれば 2.5MB 未満と以上で試していただきたいです
- 数 GB とか(？)大きめなファイル -> 更新されずに `400`, `code=invalid` のエラーになる
  (エラーになるほどの大きなファイルを用意できてなくて試せていないのですが、コード内のリサイズしてる `resize_avatar()` 部分をコメントアウトして 201KB 以上のファイルで更新すると、このエラーになることが確認できると思います)


## 特にレビューをお願いしたい箇所
<!-- - 特にチェックをお願いしたいポイントを簡潔に記述する -->
主に動作確認をお願いしたいです

## その他
<!-- - 実装上の懸念点、注意点等あれば記載する -->
特になし

## 参考リンク
<!-- - 実装に際し参考にした、記事やサイトのリンクを記載する -->
Django ファイルアップロード : https://docs.djangoproject.com/ja/5.1/topics/http/file-uploads/#where-uploaded-data-is-stored

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - アバター画像のアップロード処理が改善され、画像が自動的にリサイズされるようになりました。これにより、最大200KBのファイルサイズおよび256×256ピクセルの制限内に収まるよう調整され、不適切なサイズの場合はエラーメッセージが表示されるなど、ユーザー体験が向上しました。
  - アップロードされたファイルの処理能力が向上し、ファイルの一時保存を管理する新しい設定が追加されました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->