### PR TITLE
:zap: Match系DBの作成・更新をする非同期関数の単体テストを作成

### DIFF
--- a/backend/pong/ws/match/async_db_service.py
+++ b/backend/pong/ws/match/async_db_service.py
@@ -114,14 +114,20 @@ def update_participation_is_win(
 
 @database_sync_to_async
 def create_score(
-    participation_id: int, pos_x: int, pos_y: int
+    match_id: int, user_id: int, pos_x: int, pos_y: int
 ) -> CreateScoreResult:
     """
-    スコアを作成する。
+    指定された match_id と user_id に対応する試合参加情報に紐づくスコアを作成する。
     """
     try:
+        participation = participation_models.Participation.objects.get(
+            match_id=match_id, player__user_id=user_id
+        )
+
         score = score_models.Score.objects.create(
-            match_participation_id=participation_id, pos_x=pos_x, pos_y=pos_y
+            match_participation=participation,
+            pos_x=pos_x,
+            pos_y=pos_y,
         )
     except DatabaseError as e:
         logger.error(f"DatabaseError: {e}")
@@ -129,6 +135,7 @@ def create_score(
     return CreateScoreResult.ok(
         {
             constants.ScoreFields.ID: score.id,
+            constants.ScoreFields.MATCH_PARTICIPATION_ID: score.match_participation_id,
             constants.ScoreFields.POS_X: score.pos_x,
             constants.ScoreFields.POS_Y: score.pos_y,
         }

--- a/backend/pong/ws/match/async_db_service.py
+++ b/backend/pong/ws/match/async_db_service.py
@@ -120,15 +120,19 @@ def create_score(
     指定された match_id と user_id に対応する試合参加情報に紐づくスコアを作成する。
     """
     try:
-        participation = participation_models.Participation.objects.get(
-            match_id=match_id, player__user_id=user_id
-        )
+        with transaction.atomic():
+            participation = participation_models.Participation.objects.get(
+                match_id=match_id, player__user_id=user_id
+            )
 
-        score = score_models.Score.objects.create(
-            match_participation=participation,
-            pos_x=pos_x,
-            pos_y=pos_y,
-        )
+            score = score_models.Score.objects.create(
+                match_participation=participation,
+                pos_x=pos_x,
+                pos_y=pos_y,
+            )
+    except participation_models.Participation.DoesNotExist as e:
+        logger.error(f"DoesNotExist: {e}")
+        return CreateScoreResult.error({"DoesNotExist": str(e)})
     except DatabaseError as e:
         logger.error(f"DatabaseError: {e}")
         return CreateScoreResult.error({"DatabaseError": str(e)})

--- a/backend/pong/ws/match/tests/pytest_async_db_service.py
+++ b/backend/pong/ws/match/tests/pytest_async_db_service.py
@@ -4,9 +4,15 @@ from channels.db import database_sync_to_async  # type: ignore
 from django.contrib.auth.models import User
 
 from accounts.player.models import Player
+from matches.constants import MatchFields
+from matches.match.models import Match
 from tournaments.constants import RoundFields, TournamentFields
 from tournaments.round.models import Round
 from tournaments.tournament.models import Tournament
+from ws.match.async_db_service import (
+    create_match,
+    update_match_status,
+)
 
 
 @database_sync_to_async
@@ -55,3 +61,52 @@ async def user_and_player() -> tuple[User, Player]:
     非同期フィクスチャ：ユーザーとプレイヤーを作成
     """
     return await create_user_and_player()
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+async def test_create_match(
+    tournament_and_round: tuple[Tournament, Round],
+) -> None:
+    """
+    matchが正常に作成されるかテスト
+    """
+    tournament, round_instance = tournament_and_round
+
+    # create_matchを呼び出し、round_idを渡す
+    round_id = round_instance.id
+    result = await create_match(round_id)
+    print("result=", result)
+
+    # 結果の検証
+    assert result.is_ok
+    result_value = result.unwrap()
+    assert result_value[MatchFields.ID] is not None
+    match = await database_sync_to_async(Match.objects.get)(
+        id=result_value[MatchFields.ID]
+    )
+    assert match.round_id == round_id
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+async def test_update_match_status(
+    tournament_and_round: tuple[Tournament, Round],
+) -> None:
+    tournament, round_instance = tournament_and_round
+
+    # 試合を作成
+    match = await database_sync_to_async(Match.objects.create)(
+        round_id=round_instance.id
+    )
+
+    # update_match_statusを呼び出し、試合のステータスを更新
+    status = MatchFields.StatusEnum.ON_GOING.value
+    result = await update_match_status(match.id, status)
+
+    # 結果の検証
+    assert result.is_ok
+    result_value = result.unwrap()
+    assert result_value[MatchFields.STATUS] == status
+    await database_sync_to_async(match.refresh_from_db)()
+    assert match.status == status

--- a/backend/pong/ws/match/tests/pytest_async_db_service.py
+++ b/backend/pong/ws/match/tests/pytest_async_db_service.py
@@ -176,6 +176,7 @@ async def test_update_participation_is_win(
     assert result_value[ParticipationFields.IS_WIN] is True
     await database_sync_to_async(participation.refresh_from_db)()
     assert participation.is_win is True
+    assert participation.team is team
 
 
 @pytest.mark.django_db(transaction=True)

--- a/backend/pong/ws/match/tests/pytest_async_db_service.py
+++ b/backend/pong/ws/match/tests/pytest_async_db_service.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 import pytest
 import pytest_asyncio
 from channels.db import database_sync_to_async  # type: ignore
@@ -36,8 +38,14 @@ def create_tournament_and_round() -> tuple[Tournament, Round]:
     return tournament, round_instance
 
 
+@mock.patch(
+    "accounts.player.identicon.generate_identicon",
+    return_value="avatars/sample.png",
+)
 @database_sync_to_async
-def create_user_and_player() -> tuple[User, Player]:
+def create_user_and_player(
+    mock_identicon: mock.MagicMock,
+) -> tuple[User, Player]:
     """
     テストの前処理として使用する関数
     ユーザーとプレーヤーを作成

--- a/backend/pong/ws/match/tests/pytest_async_db_service.py
+++ b/backend/pong/ws/match/tests/pytest_async_db_service.py
@@ -1,0 +1,57 @@
+import pytest
+import pytest_asyncio
+from channels.db import database_sync_to_async  # type: ignore
+from django.contrib.auth.models import User
+
+from accounts.player.models import Player
+from tournaments.constants import RoundFields, TournamentFields
+from tournaments.round.models import Round
+from tournaments.tournament.models import Tournament
+
+
+@database_sync_to_async
+def create_tournament_and_round() -> tuple[Tournament, Round]:
+    """
+    テストの前処理として使用する関数
+    トーナメントとラウンドを作成
+    """
+    tournament = Tournament.objects.create(
+        status=TournamentFields.StatusEnum.ON_GOING.value
+    )
+    round_instance = Round.objects.create(
+        tournament=tournament,
+        round_number=1,
+        status=RoundFields.StatusEnum.NOT_STARTED.value,
+    )
+    return tournament, round_instance
+
+
+@database_sync_to_async
+def create_user_and_player() -> tuple[User, Player]:
+    """
+    テストの前処理として使用する関数
+    ユーザーとプレーヤーを作成
+    """
+    user = User.objects.create(
+        username="async_test1",
+        email="async_test1@example.com",
+        password="async_test1_password",
+    )
+    player = Player.objects.create(user=user)
+    return user, player
+
+
+@pytest_asyncio.fixture
+async def tournament_and_round() -> tuple[Tournament, Round]:
+    """
+    非同期フィクスチャ：トーナメントとラウンドを作成
+    """
+    return await create_tournament_and_round()
+
+
+@pytest_asyncio.fixture
+async def user_and_player() -> tuple[User, Player]:
+    """
+    非同期フィクスチャ：ユーザーとプレイヤーを作成
+    """
+    return await create_user_and_player()

--- a/backend/pong/ws/match/tests/pytest_async_db_service.py
+++ b/backend/pong/ws/match/tests/pytest_async_db_service.py
@@ -7,7 +7,6 @@ from accounts.player.models import Player
 from matches.constants import MatchFields, ParticipationFields, ScoreFields
 from matches.match.models import Match
 from matches.participation.models import Participation
-from matches.score.models import Score
 from tournaments.constants import RoundFields, TournamentFields
 from tournaments.round.models import Round
 from tournaments.tournament.models import Tournament
@@ -202,14 +201,12 @@ async def test_create_score(
     # create_scoreを呼び出し、スコアを作成
     pos_x = 0
     pos_y = 120
-    result = await create_score(participation.id, pos_x, pos_y)
+    result = await create_score(match.id, user.id, pos_x, pos_y)
 
     # 結果の検証
     assert result.is_ok
     result_value = result.unwrap()
     assert result_value[ScoreFields.ID] is not None
-    score = await database_sync_to_async(Score.objects.get)(
-        id=result_value[ScoreFields.ID]
-    )
-    assert score.pos_x == pos_x
-    assert score.pos_y == pos_y
+    assert result_value[ScoreFields.MATCH_PARTICIPATION_ID] == participation.id
+    assert result_value[ScoreFields.POS_X] == 0
+    assert result_value[ScoreFields.POS_Y] == 120


### PR DESCRIPTION
## タスクやディスカッションのリンク
<!-- - URLをここに貼る -->
- Closes #419 

## やったこと
<!-- - このタスクでやったことはなにか？ -->
- match系のDBを作成・更新する非同期関数の単体テスト

## やらないこと
<!-- - このタスクでやらないことはなにか？（やらない場合いつやるのか？無ければ「なし」を記述） -->
- テスト以外のこと

## 動作確認
<!-- - どのような動作確認を行い、結果はどうだったのか？(適宜スクショ等添付) -->
- @s1-haya さんには共有し忘れていましたが、非同期関数はpytestでしか並列で実行できないので、pytestで行うことになりました。
  - pytestのファイル名は、`pytest_*.py`になります。設定はpyproject.tomlの最後に追記してあります。
  - make test でpytestも実行されるようになっています。
- `make test`, `make test ARG=ws`, `pytest ws/match` のいずれかでテストを実行できます。

## 特にレビューをお願いしたい箇所
<!-- - 特にチェックをお願いしたいポイントを簡潔に記述する -->
- テストケースが足りないなどあれば教えていただきたいです。

## その他
<!-- - 実装上の懸念点、注意点等あれば記載する -->

## 参考リンク
<!-- - 実装に際し参考にした、記事やサイトのリンクを記載する -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **リファクタ**
  - スコア記録の処理を改善し、試合とユーザー情報の紐付けがより正確になるよう調整しました。

- **テスト**
  - 試合作成、状態更新、参加記録、スコア操作に対応する非同期テストを新たに導入し、全体の信頼性と安定性を向上させました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->