### PR TITLE
[OAuth2] `/api/oauth2/callback`のエラー処理作成

### DIFF
--- a/backend/pong/oauth2/create_oauth2_account.py
+++ b/backend/pong/oauth2/create_oauth2_account.py
@@ -1,33 +1,32 @@
 import utils.result
 from accounts.create_account import create_account
+from accounts.user import serializers as user_serializers
 
-from . import models, serializers
+from . import serializers
 
 CreateOAuth2UserResult = utils.result.Result[dict, dict]
 CreateOAuth2Result = utils.result.Result[dict, dict]
 
 
+# todo: パスワードを引数に渡せるようにし、callbackないでランダムなパスワードで設定する
 def create_oauth2_user(
     email: str, display_name: str
 ) -> CreateOAuth2UserResult:
     oauth2_user_data: dict[str, str] = {
         "username": create_account.get_unique_random_username(),
         "email": email,
-        "password": "",
+        "password": "p1a2s3s4w5o6rd",
     }
-    oauth2_user_serializer: serializers.UserSerializer = (
-        serializers.UserSerializer(data=oauth2_user_data)
+    oauth2_user_serializer: user_serializers.UserSerializer = (
+        user_serializers.UserSerializer(data=oauth2_user_data)
     )
     if not oauth2_user_serializer.is_valid():
         return CreateOAuth2UserResult.error(oauth2_user_serializer.errors)
     player_data: dict = {"display_name": display_name}
-    # create_accountのdataを取得する前に、UserSerializerを保存する必要がある
-    oauth2_user: models.User = oauth2_user_serializer.save()
     oauth2_account_result: create_account.CreateAccountResult = (
         create_account.create_account(oauth2_user_serializer, player_data)
     )
     if not oauth2_account_result.is_ok:
-        oauth2_user.delete()
         return CreateOAuth2UserResult.error(
             oauth2_account_result.unwrap_error()
         )

--- a/backend/pong/oauth2/create_oauth2_account.py
+++ b/backend/pong/oauth2/create_oauth2_account.py
@@ -8,14 +8,15 @@ CreateOAuth2UserResult = utils.result.Result[dict, dict]
 CreateOAuth2Result = utils.result.Result[dict, dict]
 
 
-# todo: パスワードを引数に渡せるようにし、callbackないでランダムなパスワードで設定する
 def create_oauth2_user(
-    email: str, display_name: str
+    email: str,
+    password: str,
+    display_name: str,
 ) -> CreateOAuth2UserResult:
     oauth2_user_data: dict[str, str] = {
         "username": create_account.get_unique_random_username(),
         "email": email,
-        "password": "p1a2s3s4w5o6rd",
+        "password": password,
     }
     oauth2_user_serializer: user_serializers.UserSerializer = (
         user_serializers.UserSerializer(data=oauth2_user_data)

--- a/backend/pong/oauth2/serializers.py
+++ b/backend/pong/oauth2/serializers.py
@@ -4,29 +4,6 @@ from rest_framework import serializers
 from . import models
 
 
-class UserSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = User
-        fields = (
-            "id",
-            "username",
-            "email",
-            "password",
-        )
-        extra_kwargs = {
-            "email": {"required": True},
-            "password": {"write_only": True, "allow_blank": True},
-        }
-
-    def create(self, validated_data: dict) -> User:
-        user: User = User.objects.create_user(
-            username=validated_data["username"],
-            email=validated_data["email"],
-            password="",
-        )
-        return user
-
-
 class OAuth2Serializer(serializers.ModelSerializer):
     user = serializers.PrimaryKeyRelatedField(queryset=User.objects.all())
 

--- a/backend/pong/oauth2/tests/unit/test_create_oauth2_account.py
+++ b/backend/pong/oauth2/tests/unit/test_create_oauth2_account.py
@@ -38,7 +38,9 @@ class CreateOAuth2AccountTestCase(TestCase):
         OAuth2ユーザーの作成が成功することを確認するテスト
         """
         oauth2_user_result: create_oauth2_account.CreateOAuth2UserResult = (
-            create_oauth2_account.create_oauth2_user("pong@gmail.com", "pong")
+            create_oauth2_account.create_oauth2_user(
+                "pong@gmail.com", "random_password", "pong"
+            )
         )
         self.assertTrue(oauth2_user_result.is_ok)
 
@@ -49,7 +51,7 @@ class CreateOAuth2AccountTestCase(TestCase):
         # todo: django の email バリデーションを調べてからそれをそのまま使うか、自分達で定義するか決める
         oauth2_user_result: create_oauth2_account.CreateOAuth2UserResult = (
             create_oauth2_account.create_oauth2_user(
-                "invalid--@gmail-com", "pong"
+                "invalid--@gmail-com", "random_password", "pong"
             )
         )
         self.assertTrue(oauth2_user_result.is_error)

--- a/backend/pong/oauth2/tests/unit/test_serializers.py
+++ b/backend/pong/oauth2/tests/unit/test_serializers.py
@@ -2,6 +2,7 @@ from typing import Final
 
 from django.test import TestCase
 
+from accounts.user import serializers as user_serializers
 from oauth2 import models, serializers
 
 REQUIRED: Final[str] = "required"
@@ -26,7 +27,7 @@ class UserSerializerTestCase(TestCase):
         初期設定
         - self.SerializerにUserSerializerのクラスを代入
         """
-        self.Serializer = serializers.UserSerializer
+        self.Serializer = user_serializers.UserSerializer
 
     # todo: パスワードに文字列を入力した場合のテストを書く?（現状だとパスワードの値は入る）
     #       その場合は関数名を変更する。
@@ -35,20 +36,23 @@ class UserSerializerTestCase(TestCase):
         正しいデータの場合、正しく機能するかを確認するテスト
         """
 
-        # passwordが空文字を想定
         user_data: dict = {
             "id": 1,
             "username": "pong",
             "email": "pong@gmail.com",
-            "password": "",
+            "password": "random_password",
         }
-        serializer: serializers.UserSerializer = self.Serializer(
+        serializer: user_serializers.UserSerializer = self.Serializer(
             data=user_data
         )
         self.assertTrue(serializer.is_valid())
         self.assertEqual(
             serializer.validated_data,
-            {"username": "pong", "email": "pong@gmail.com", "password": ""},
+            {
+                "username": "pong",
+                "email": "pong@gmail.com",
+                "password": "random_password",
+            },
         )
         self.assertEqual(
             serializer.data, {"username": "pong", "email": "pong@gmail.com"}
@@ -66,7 +70,7 @@ class UserSerializerTestCase(TestCase):
             "email",
             "password",
         ]
-        serializer: serializers.UserSerializer = self.Serializer(
+        serializer: user_serializers.UserSerializer = self.Serializer(
             data=missing_required_fields_data
         )
         self.assertFalse(serializer.is_valid())
@@ -86,7 +90,7 @@ class UserSerializerTestCase(TestCase):
             "email",
             "password",
         ]
-        serializer: serializers.UserSerializer = self.Serializer(
+        serializer: user_serializers.UserSerializer = self.Serializer(
             data=empty_data
         )
         self.assertFalse(serializer.is_valid())
@@ -97,7 +101,9 @@ class UserSerializerTestCase(TestCase):
         """
         Noneの場合、期待通りにエラーを返すかを確認するテスト
         """
-        serializer: serializers.UserSerializer = self.Serializer(data=None)
+        serializer: user_serializers.UserSerializer = self.Serializer(
+            data=None
+        )
         self.assertFalse(serializer.is_valid())
         self.assertEqual(serializer.errors["non_field_errors"][0].code, NULL)
 

--- a/backend/pong/oauth2/views.py
+++ b/backend/pong/oauth2/views.py
@@ -265,6 +265,6 @@ class OAuth2CallbackView(OAuth2BaseView):
                 status=response.status_code,
             )
         return custom_response.CustomResponse(
-            data=response.data,
+            data=response.data["data"],
             status=response.status_code,
         )

--- a/backend/pong/oauth2/views.py
+++ b/backend/pong/oauth2/views.py
@@ -5,6 +5,7 @@ from urllib.parse import urlencode
 
 import requests
 from django.urls import reverse
+from django.utils.crypto import get_random_string
 from drf_spectacular.utils import (
     OpenApiExample,
     OpenApiResponse,
@@ -202,12 +203,13 @@ class OAuth2CallbackView(OAuth2BaseView):
             )
         # =============================================================
 
+        random_password: str = get_random_string(length=12)
         # ====== todo: OAuth2の登録（リファクタリング）======
         # 成功: oauth2_userを返す
         # 失敗: 例外, InternalServerError
         oauth2_user_result: create_oauth2_account.CreateOAuth2UserResult = (
             create_oauth2_account.create_oauth2_user(
-                user_info["email"], user_info["login"]
+                user_info["email"], random_password, user_info["login"]
             )
         )
         # todo: internal_errorのエラーハンドリングを追加する
@@ -247,8 +249,7 @@ class OAuth2CallbackView(OAuth2BaseView):
             reverse("jwt:token_obtain_pair"),
             {
                 "email": oauth2_user["email"],
-                # todo: ランダムでパスワードを取得する
-                "password": "p1a2s3s4w5o6rd",
+                "password": random_password,
             },
             format="json",
         )


### PR DESCRIPTION
## タスクやディスカッションのリンク
<!-- - URLをここに貼る -->
* #400 

## やったこと
<!-- - このタスクでやったことはなにか？ -->
* `/api/oauth2/callback`作成
  * リクエスト、レスポンスのOpenAPI
  * カスタムレスポンスの設定

## やらないこと
<!-- - このタスクでやらないことはなにか？（やらない場合いつやるのか？無ければ「なし」を記述） -->
* 統合テストの作成 / ブラウザを経由してユーザーにアプリの権限を求めるため、自動化するのが難しい
* `/api/oauth2/callback`のリファクタリング

## 動作確認
<!-- - どのような動作確認を行い、結果はどうだったのか？(適宜スクショ等添付) -->
1. `.env`にある`OAUTH2_CLIENT_SECRET_KEY`を更新する
https://www.notion.so/env-6c88f2d914a94c63a8f92c277e342f89
2. `make build-up`
3. ブラウザで`http://localhost:8000/api/oauth2/authorize/`にアクセスし、挙動を確認する

- 承認ボタンをおすと、`/api/oauth2/callback`の200のレスポンスの内容通りに返ってくるかどうか
- 拒否ボタンをおすと`/api/oauth2/callback`の401のレスポンスの内容通りに返ってくるかどうか
- `code`が不正の場合、401のレスポンスの内容通りに返ってくるかどうか
　`http://localhost:8000/api/oauth2/callback/?code=dddd`

一度、42ユーザー作成するとemailの重複を許可しないため、emailがユニークである必要があるっていうエラーが出ます。そのため
`http://localhost:8000/admin/`で作成した42ユーザーを削除しながら挙動を確認する形になると思います！

## 特にレビューをお願いしたい箇所
<!-- - 特にチェックをお願いしたいポイントを簡潔に記述する -->
* `/api/oauth2/callback`のOpenAPIの形式と実際のレスポンス内容に誤りはないかどうか
* callbackのレスポンスは`/api/token`のカスタムレスポンスをそのまま返すような処理を書きたいんですけど、うまく書けなかったので知恵を借りたいです。
* パスワードをランダムに12文字生成していますが、問題ないかどうか

## その他
<!-- - 実装上の懸念点、注意点等あれば記載する -->

## 参考リンク
<!-- - 実装に際し参考にした、記事やサイトのリンクを記載する -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - OAuth2認証プロセスが改善され、認証成功時にはアクセストークンとリフレッシュトークンを明瞭に含むレスポンスが返され、エラー時は詳細なエラーメッセージが提供されるようになりました。
  
- **バグ修正**
  - 認証フローにおける不正な処理や予期せぬエラー発生時のハンドリングが強化され、全体の信頼性とセキュリティが向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->