### PR TITLE
🌱 HTTPS 対応

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 # Environments
 .env
+frontend/ssl/

--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,18 @@ DOCKER_COMPOSE		:=	docker compose -f $(COMPOSE_FILE)
 BACKEND_SERVICE		:=	backend
 DATABASE_SERVICE	:=	db
 
+# ssl
+DOMAIN_NAME		:=	localhost
+SSL_DIR			:=	frontend/ssl
+SSL_CERT_DIR	:=	$(SSL_DIR)/certs
+SSL_KEY_DIR		:=	$(SSL_DIR)/private
+SSL_CA_CERT		:=	$(SSL_CERT_DIR)/${DOMAIN_NAME}.crt
+SSL_CA_KEY		:=	$(SSL_KEY_DIR)/${DOMAIN_NAME}.key
+# SSL_DIR外に配置する
+SSL_CNF_PATH	:=	frontend/openssl.cnf
 
 .PHONY: all
-all: up
+all: gen_ssl_cert up
 
 # -------------------------------------------------------
 # docker compose
@@ -65,3 +74,24 @@ logs-be:
 .PHONY: logs-db
 logs-db:
 	@$(DOCKER_COMPOSE) logs $(DATABASE_SERVICE)
+
+# -------------------------------------------------------
+# ssl
+# -------------------------------------------------------
+.PHONY: gen_ssl_cert
+gen_ssl_cert:
+	@mkdir -p ${SSL_DIR}
+	@mkdir -p ${SSL_CERT_DIR}
+	@mkdir -p ${SSL_KEY_DIR}
+
+	@openssl genrsa -out ${SSL_CA_KEY} 2048
+	@openssl req -new -x509 \
+		-key ${SSL_CA_KEY} \
+		-out ${SSL_CA_CERT} \
+       -subj "/C=JP/ST=Tokyo/L=Shinjuku/O=42Tokyo/OU=42Pong/CN=${DOMAIN_NAME}/" \
+       -extensions v3_req \
+       -config $(SSL_CNF_PATH)
+
+.PHONY: rm_ssl_cert
+rm_ssl_cert:
+	@rm -rf ${SSL_CERT_DIR} ${SSL_KEY_DIR}

--- a/backend/pong/pong/settings.py
+++ b/backend/pong/pong/settings.py
@@ -274,7 +274,7 @@ CORS_ALLOW_METHODS = [
     "DELETE",
     "OPTIONS",
 ]
-# todo: CSRFについての設定は必要になり次第追加
+CSRF_TRUSTED_ORIGINS = ["https://localhost"]
 
 
 # Django logging

--- a/backend/pong/pong/settings.py
+++ b/backend/pong/pong/settings.py
@@ -81,7 +81,11 @@ DEBUG = env.bool("DEBUG", False)
 
 SECRET_KEY = get_valid_str_env("SECRET_KEY")
 
-ALLOWED_HOSTS: list[str] = []
+# todo: 開発時だけFalseにしたい環境変数
+# SECURE_SSL_REDIRECT = True
+SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
+
+ALLOWED_HOSTS: list[str] = ["localhost", "frontend"]
 
 # Application definition
 
@@ -260,10 +264,18 @@ ASGI_APPLICATION = "pong.asgi.application"
 # https://github.com/adamchainz/django-cors-headers
 
 # リストに追加することでオリジンを許可する
-CORS_ALLOWED_ORIGINS = [
-    f"http://localhost:{FRONT_SERVER_PORT}",  # frontendコンテナ
+CORS_ALLOWED_ORIGINS = ["https://localhost"]
+CORS_ALLOW_CREDENTIALS = True
+CORS_ALLOW_METHODS = [
+    "GET",
+    "POST",
+    "PUT",
+    "PATCH",
+    "DELETE",
+    "OPTIONS",
 ]
-# todo: CORS_ALLOW_CREDENTIALS, CSRFについての設定は必要になり次第追加
+# todo: CSRFについての設定は必要になり次第追加
+
 
 # Django logging
 # 詳細: https://docs.djangoproject.com/ja/5.1/topics/logging/

--- a/compose.yaml
+++ b/compose.yaml
@@ -10,11 +10,11 @@ services:
         condition: service_healthy
     restart: always
     ports:
-      - "${FRONT_SERVER_PORT}:8080"
+      - "${FRONT_SERVER_PORT}:443"
     networks:
       - transcendence
     healthcheck:
-      test: ["CMD-SHELL", "curl -f http://localhost:8080 || exit 1"]
+      test: ["CMD-SHELL", "curl -f https://localhost:443 -k || exit 1"]
       interval: 15s
       timeout: 5s
       retries: 6

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -19,6 +19,10 @@ FROM nginxinc/nginx-unprivileged:${NGINX_TAG} AS production
 
 COPY --from=builder --chown=nginx:nginx /app/dist /usr/share/nginx/html
 
+# ssl
+COPY --chown=nginx:nginx ./ssl/certs/* /etc/ssl/certs/
+COPY --chown=nginx:nginx ./ssl/private/* /etc/ssl/private/
+
 COPY --chown=nginx:nginx nginx.conf /etc/nginx/nginx.conf
 
 CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -38,5 +38,15 @@ http {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
     }
+
+    # FE-BE間のアバター画像用のプロキシ設定
+    # todo: volumeでFEと共有するように変更したい
+    location /media/ {
+        proxy_pass http://backend:8000/media/;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
   }
 }

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -29,5 +29,14 @@ http {
         root /usr/share/nginx/html;
         try_files $uri $uri/ /index.html;
     }
+
+    # FE-BE間のapi用のプロキシ設定
+    location /api/ {
+        proxy_pass http://backend:8000/api/;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
   }
 }

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -12,8 +12,15 @@ http {
   default_type  application/octet-stream;
 
   server {
-    # TODO: https 対応
-    listen 8080;
+    listen 443 ssl;
+    listen [::]:443 ssl;
+
+    # ssl
+    ssl_certificate /etc/ssl/certs/localhost.crt;
+    ssl_certificate_key /etc/ssl/private/localhost.key;
+
+    # set protocols for security
+    ssl_protocols TLSv1.2 TLSv1.3;
 
     # TODO: SERVER_NAME などで環境変数より定まるように設定
     server_name localhost;

--- a/frontend/openssl.cnf
+++ b/frontend/openssl.cnf
@@ -1,0 +1,20 @@
+[ req ]
+default_bits        = 2048
+prompt              = no
+default_md          = sha256
+distinguished_name  = dn
+req_extensions      = v3_req
+
+[ dn ]
+C                   = JP
+ST                  = Tokyo
+L                   = Shinjuku
+O                   = 42Tokyo
+OU                  = 42Pong
+CN                  = localhost
+
+[ v3_req ]
+subjectAltName      = @alt_names
+
+[ alt_names ]
+DNS.1               = localhost

--- a/frontend/pong/js/constants/Endpoints.js
+++ b/frontend/pong/js/constants/Endpoints.js
@@ -1,6 +1,6 @@
 // TODO: バックエンドのエントポイントベースを環境変数からのものになるように改善
-const HOST = "localhost:8000";
-const BASE_URL = new URL(`http://${HOST}`);
+const HOST = "localhost:8080";
+const BASE_URL = new URL(`https://${HOST}`);
 const WEBSOCKET_BASE_URL = new URL(`ws://${HOST}`);
 
 const DEFAULT_AVATAR_IMAGE_PATH = "/media/avatars/sample.png";


### PR DESCRIPTION
## タスクやディスカッションのリンク
<!-- - URLをここに貼る -->
- #331 

## やったこと
<!-- - このタスクでやったことはなにか？ -->
FE の入口を http -> https にしました
サブドメインで一旦 PR (#402 ) を出していましたが、それだと自己署名証明書のエラーを解決できなかったので、廃止しました

- ssl は自己署名証明書の発行にし、`frontend/ssl/` に配置しました
- FE から BE へのリクエストは `https://localhost:8080/api/` でできます

## やらないこと
<!-- - このタスクでやらないことはなにか？（やらない場合いつやるのか？無ければ「なし」を記述） -->
- BE の admin サイトなどの静的ファイルを FE に配信する -> permission 関係が解消したら別 PR を出す、またはこのままで終わるかもです。アバター画像も nginx を介すとパフォ―マンスが悪いらしく、本当は volume での共有にしたいけどしていないです
- BE の `http://localhost:8000/` にブラウザから直接アクセスできないようにすること -> 提出前にする
- `https://localhost:8080/api/存在しないURL` の場合の 404 ページの処理 (nginx で 404 を返すか、BE で何か返すか)

## 動作確認
<!-- - どのような動作確認を行い、結果はどうだったのか？(適宜スクショ等添付) -->
- `make gen_ssl_cert` -> `make build-up` で全てのコンテナが起動できること
- ブラウザで FE のホーム画面 `https://localhost:8080/` にアクセスし、ユーザー一覧・フレンド一覧などをクリックすると `401` が返ること (初回は `unsafe` を押してホーム画面にいけると思います。以降 `401` などの response は開発者ツールで確認)
- ユーザー一覧をクリックした際の BE へのリクエストの URL が `https://localhost:8080/api/users/ ` のように https になっていること
- DB に存在するユーザーの email, password でサインインし、ユーザー一覧などを押すと、レスポンスの body にユーザー一覧が返ってきていること (console にエラーが出ますが、これはまだ FE がページネーションに対応してないだけだと思われます。実際の response body にユーザー一覧情報が入っていれば大丈夫です)

## 特にレビューをお願いしたい箇所
<!-- - 特にチェックをお願いしたいポイントを簡潔に記述する -->
- 主に動作確認と、気になる点あればよろしくお願いします

## その他
<!-- - 実装上の懸念点、注意点等あれば記載する -->
- ayase-mstk さん、ws -> wss にするのをよろしくお願いします…

## 参考リンク
<!-- - 実装に際し参考にした、記事やサイトのリンクを記載する -->
- Django, https : https://docs.djangoproject.com/ja/5.1/topics/security/#ssl-https

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新機能**
  - フロントエンドおよびバックエンド間の通信がHTTPSに統一され、全体のセキュリティが向上しました。
  - サーバー設定が更新され、APIやメディアリクエストの安全なプロキシ転送とSSL証明書管理が追加されました。
  - セキュリティ証明書の生成と管理が自動化され、通信の信頼性が強化されました。

- **その他の改善**
  - 開発プロセス向上のため、不要ファイルの除外設定が整理されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->