### PR TITLE
🐛 [users] pagination に渡すクエリセットをソートするように

### DIFF
--- a/backend/pong/pong/custom_pagination/custom_pagination.py
+++ b/backend/pong/pong/custom_pagination/custom_pagination.py
@@ -1,9 +1,13 @@
 import dataclasses
+from typing import Final
 
 from django.core.exceptions import ObjectDoesNotExist
 from rest_framework import pagination, response, status
 
 from ..custom_response import custom_response
+
+# 1ページあたりのアイテム数のデフォルト値
+DEFAULT_PAGE_SIZE: Final[int] = 20
 
 
 @dataclasses.dataclass(frozen=True)
@@ -23,7 +27,7 @@ class CustomPagination(pagination.PageNumberPagination):
         page_size: 1ページあたりのアイテム数
     """
 
-    def __init__(self, page_size: int = 20) -> None:
+    def __init__(self, page_size: int = DEFAULT_PAGE_SIZE) -> None:
         self.page_size = page_size
 
     def get_paginated_response(

--- a/backend/pong/users/blocks/views.py
+++ b/backend/pong/users/blocks/views.py
@@ -385,7 +385,7 @@ class BlocksViewSet(viewsets.ViewSet):
         # 自分のブロック一覧を取得
         block_users: QuerySet[models.BlockRelationship] = self.queryset.filter(
             user=user
-        )
+        ).order_by(constants.BlockRelationshipFields.CREATED_AT)
         paginator: custom_pagination.CustomPagination = (
             custom_pagination.CustomPagination()
         )

--- a/backend/pong/users/friends/views.py
+++ b/backend/pong/users/friends/views.py
@@ -379,7 +379,9 @@ class FriendsViewSet(viewsets.ModelViewSet):
         user: User = self._get_authenticated_user(request.user)
 
         # 自分のフレンド一覧を取得
-        friends: QuerySet[models.Friendship] = self.queryset.filter(user=user)
+        friends: QuerySet[models.Friendship] = self.queryset.filter(
+            user=user
+        ).order_by(constants.FriendshipFields.CREATED_AT)
         paginator: custom_pagination.CustomPagination = (
             custom_pagination.CustomPagination()
         )

--- a/backend/pong/users/views/list.py
+++ b/backend/pong/users/views/list.py
@@ -181,7 +181,9 @@ class UsersListView(views.APIView):
         all_players_with_users: QuerySet[player_models.Player] = (
             player_models.Player.objects.select_related(
                 accounts_constants.PlayerFields.USER
-            ).all()
+            )
+            .all()
+            .order_by(accounts_constants.PlayerFields.ID)
         )
         paginator: custom_pagination.CustomPagination = (
             custom_pagination.CustomPagination()


### PR DESCRIPTION
## タスクやディスカッションのリンク
<!-- - URLをここに貼る -->
- #445 

## やったこと
<!-- - このタスクでやったことはなにか？ -->
ページネーションで返す一覧系のレスポンスのクエリセットがソートされていなかったため、複数ページに同じユーザーが複数回返る、という問題が発生していてそれを修正しました
具体的には `users`, `users.friends`, `users.blocks` の 3 つの list view でクエリセットをソートしてカスタムページネーションクラスに渡すようにしました

## やらないこと
<!-- - このタスクでやらないことはなにか？（やらない場合いつやるのか？無ければ「なし」を記述） -->
テスト追加 : 多めの User を作る必要がある、かつ必ず複数回 複数ページに同じユーザーが返るか不明なため、失敗ケースの正確なテストはできなさそうだと判断しました。成功ケースは時間があれば…というところです

## 動作確認
<!-- - どのような動作確認を行い、結果はどうだったのか？(適宜スクショ等添付) -->
お手数ですが、コードを少し変更していただき swagger-ui で上記 3 つの app の一覧取得 GET にリクエストを送って確認してください

以下のファイルのカスタムページネーションを作成してる部分に引数を追加し、
- `pong/users/views/list.py` : 189 行目
- `pong/users/friends/views.py` : 386 行目
- `pong/users/blocks/views.py` : 390 行目

```py
        paginator: custom_pagination.CustomPagination = (
            custom_pagination.CustomPagination(page_size=2)   # 引数追加。1ページ2件などの小さい数字にする
        )
```
dev branch では 3 ～ 4 ページくらい試すと重複があったので、ユーザー・フレンド・ブロックをそれぞれ 8 件くらい作成していただき、swagger-ui でページ数を指定して一覧取得をし、各ページのレスポンスに重複がないことを確認していただきたいです


## 特にレビューをお願いしたい箇所
<!-- - 特にチェックをお願いしたいポイントを簡潔に記述する -->
動作確認

## その他
<!-- - 実装上の懸念点、注意点等あれば記載する -->
特になし

## 参考リンク
<!-- - 実装に際し参考にした、記事やサイトのリンクを記載する -->
特になし

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- ブロック済みユーザー一覧がブロック日時順に表示されるよう改善しました。
	- 友達一覧が登録日時順に整理され、一貫した順序で表示されます。
	- ユーザーのプレイヤーデータがID順に整列され、より統一感のある出力となりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->