### PR TITLE
:zap: オンラインステータスのためのログインハンドラー実装

### DIFF
--- a/backend/pong/ws/consumers.py
+++ b/backend/pong/ws/consumers.py
@@ -27,6 +27,7 @@ class MultiEventConsumer(AsyncJsonWebsocketConsumer):
         await self.accept()
 
     async def disconnect(self, close_code: int) -> None:
+        await self.login_handler.logout()
         await self.match_handler.cleanup()
 
     async def receive_json(self, message: dict) -> None:

--- a/backend/pong/ws/consumers.py
+++ b/backend/pong/ws/consumers.py
@@ -39,7 +39,6 @@ class MultiEventConsumer(AsyncJsonWebsocketConsumer):
             ]
             payload: dict = serializer.validated_data[ws_constants.PAYLOAD_KEY]
 
-            # TODO: LOGINメッセージルール確定したら追加
             match category:
                 case (
                     ws_constants.Category.LOGIN.value

--- a/backend/pong/ws/login/constants.py
+++ b/backend/pong/ws/login/constants.py
@@ -6,6 +6,8 @@ USER_NAMESPACE: Final[str] = "user"
 CHANNEL_RESOURCE: Final[str] = "channels"
 
 USER_ID: Final[str] = "user_id"
+ONLINE_FRIEND_IDS: Final[str] = "online_friend_ids"
+ONLINE: Final[str] = "online"
 
 
 class Status(ws_constants.BaseEnum):

--- a/backend/pong/ws/login/handler.py
+++ b/backend/pong/ws/login/handler.py
@@ -95,7 +95,7 @@ class LoginHandler:
     async def _send_login_result(self, login_status: str) -> None:
         online_friend_list: list[int] = await self.get_friends_online_status()
         message = {
-            ws_constants.Category.key(): ws_constants.Category.LOGIN,
+            ws_constants.Category.key(): ws_constants.Category.LOGIN.value,
             ws_constants.PAYLOAD_KEY: {
                 login_constants.Status.key(): login_status,
                 login_constants.ONLINE_FRIEND_IDS: online_friend_list,
@@ -107,11 +107,12 @@ class LoginHandler:
 
     # TODO: ログインかログアウトかを引数で受け取る
     async def _notify_followers(self) -> None:
-        # TODO: 決定したmessageに変更
-        message = {
-            ws_constants.Category.key(): ws_constants.Category.LOGIN,
-            ws_constants.PAYLOAD_KEY: {login_constants.USER_ID: self.user_id},
-        }
+        # 型チェックで必要なチェック
+        if self.user_id is None:
+            return
+
+        message = self._build_a_user_online_status_message(self.user_id, True)
+
         # オンライン状態でフレンド登録している人をイテレーションで順に処理
         async for follower_id in (
             friend_models.Friendship.objects.filter(friend_id=self.user_id)

--- a/backend/pong/ws/login/handler.py
+++ b/backend/pong/ws/login/handler.py
@@ -141,7 +141,6 @@ class LoginHandler:
             message, self.channel_handler.channel_name
         )
 
-    # TODO: ログインかログアウトかを引数で受け取る
     async def _notify_followers(self, is_login: bool) -> None:
         # 型チェックで必要なチェック
         if self.user_id is None:

--- a/backend/pong/ws/login/handler.py
+++ b/backend/pong/ws/login/handler.py
@@ -159,3 +159,15 @@ class LoginHandler:
                 online_friends.append(friend_id)
 
         return online_friends
+
+    def _build_a_user_online_status_message(
+        self, user_id: int, is_online: bool
+    ) -> dict:
+        message = {
+            ws_constants.Category.key(): ws_constants.Category.STATUS.value,
+            ws_constants.PAYLOAD_KEY: {
+                login_constants.USER_ID: user_id,
+                login_constants.ONLINE: is_online,
+            },
+        }
+        return message

--- a/backend/pong/ws/login/handler.py
+++ b/backend/pong/ws/login/handler.py
@@ -58,6 +58,10 @@ class LoginHandler:
         # 存在しないユーザーであれば例外を投げる
         await self._validate_user_id(input_user_id)
 
+        # もし自分のオンライン状態を確認しようとしていたら無視
+        if input_user_id == self.user_id:
+            return
+
         exist = await AsyncRedisClient.exists(
             login_constants.USER_NAMESPACE,
             input_user_id,

--- a/backend/pong/ws/share/async_redis_client.py
+++ b/backend/pong/ws/share/async_redis_client.py
@@ -50,7 +50,7 @@ class AsyncRedisClient:
     @classmethod
     async def sadd_value(
         cls, namespace: str, identifier: str, resource: str, value: str
-    ) -> None:
+    ) -> int:
         """
         指定したキーの Set に値を追加する。
         - `namespace="user", identifier="123", resource="channels"` → `"user:123:channels"` に `value` を追加
@@ -63,10 +63,12 @@ class AsyncRedisClient:
         key = cls._generate_key(namespace, identifier, resource)
         await client.sadd(key, value)
 
+        return await client.scard(key)
+
     @classmethod
     async def srem_value(
         cls, namespace: str, identifier: str, resource: str, value: str
-    ) -> None:
+    ) -> int:
         """
         指定したキーの Set から値を削除し、空ならキーごと削除する。
 
@@ -80,6 +82,8 @@ class AsyncRedisClient:
 
         if not await client.scard(key):  # セットが空ならキーを削除
             await client.delete(key)
+
+        return await client.scard(key)
 
     @classmethod
     async def smembers_value(

--- a/backend/pong/ws/share/async_redis_client.py
+++ b/backend/pong/ws/share/async_redis_client.py
@@ -80,10 +80,11 @@ class AsyncRedisClient:
         key = cls._generate_key(namespace, identifier, resource)
         await client.srem(key, value)
 
-        if not await client.scard(key):  # セットが空ならキーを削除
+        count = await client.scard(key)
+        if count == 0:  # セットが空ならキーを削除
             await client.delete(key)
 
-        return await client.scard(key)
+        return count
 
     @classmethod
     async def smembers_value(

--- a/backend/pong/ws/share/constants.py
+++ b/backend/pong/ws/share/constants.py
@@ -10,6 +10,7 @@ class BaseEnum(Enum):
 
 class Category(BaseEnum):
     LOGIN = "LOGIN"
+    STATUS = "STATUS"
     MATCH = "MATCH"
     # TODO: 他のカテゴリーは順次追加する
 


### PR DESCRIPTION
## タスクやディスカッションのリンク
<!-- - URLをここに貼る -->
- Closes #338 
- [notion login messageルール](https://www.notion.so/Websocket-2ec8362722664e50b94486599d01328e)

## やったこと
<!-- - このタスクでやったことはなにか？ -->
- 前回メッセージルールが確定していなかった部分を修正、追加しました。これでオンラインステータスは完成です。
- consumerからも使用されるようになりました。
- 前回で大枠の実装はできていたので、少し追加で必要になったメッセージ機能を増やしたくらいです。

## やらないこと
<!-- - このタスクでやらないことはなにか？（やらない場合いつやるのか？無ければ「なし」を記述） -->
- これ以外のこと

## 動作確認
<!-- - どのような動作確認を行い、結果はどうだったのか？(適宜スクショ等添付) -->
- まだテストは書けていないので、動かしてみてということになるかもしれません。

## 特にレビューをお願いしたい箇所
<!-- - 特にチェックをお願いしたいポイントを簡潔に記述する -->
- 処理的におかしな点がございましたら教えてください。

## その他
<!-- - 実装上の懸念点、注意点等あれば記載する -->
## 参考リンク
<!-- - 実装に際し参考にした、記事やサイトのリンクを記載する -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **新機能**
	- ログイン時、友達のオンライン状態がリアルタイムで通知され、よりインタラクティブな体験が実現されました。
	- 新しいログインハンドラーが追加され、ログインおよびステータスメッセージの処理が強化されました。
- **バグ修正**
	- 接続数の追跡がより正確になり、ログイン・ログアウトの動作管理と通知の精度が向上しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->