### PR TITLE
⚡ [users] /users/me/, PATCH 時に application/json で display_name がない場合にエラーにする

### DIFF
--- a/backend/pong/users/serializers.py
+++ b/backend/pong/users/serializers.py
@@ -219,22 +219,14 @@ class UsersSerializer(serializers.Serializer):
         """
         validate()のオーバーライド
         """
-        # avatar更新時(self.instanceが存在する場合のみ)
-        if (
-            accounts_constants.PlayerFields.AVATAR in data
-            and self.instance is not None
-        ):
-            avatar: Optional[UploadedFile] = data[
+        # 更新時のバリデーション
+        if self.instance is not None:
+            avatar: Optional[UploadedFile] = data.get(
                 accounts_constants.PlayerFields.AVATAR
-            ]
-            # 更新時Noneの場合はエラー
-            if avatar is None:
-                raise serializers.ValidationError(
-                    {
-                        accounts_constants.PlayerFields.AVATAR: "This field may not be blank."
-                    }
-                )
-            self._validate_avatar(avatar)
+            )
+            # avatar更新時のバリデーション
+            if avatar is not None:
+                self._validate_avatar(avatar)
         return data
 
     def _update_avatar(

--- a/backend/pong/users/serializers.py
+++ b/backend/pong/users/serializers.py
@@ -221,9 +221,19 @@ class UsersSerializer(serializers.Serializer):
         """
         # 更新時のバリデーション
         if self.instance is not None:
+            display_name: Optional[str] = data.get(
+                accounts_constants.PlayerFields.DISPLAY_NAME
+            )
             avatar: Optional[UploadedFile] = data.get(
                 accounts_constants.PlayerFields.AVATAR
             )
+            # display_nameとavatarのどちらかが必須
+            if display_name is None and avatar is None:
+                raise serializers.ValidationError(
+                    "Either display_name or avatar must be provided."
+                )
+
+            # display_nameが空文字列の場合は他でバリデーションされるためここではチェックしない
             # avatar更新時のバリデーション
             if avatar is not None:
                 self._validate_avatar(avatar)

--- a/backend/pong/users/tests/integration/test_me.py
+++ b/backend/pong/users/tests/integration/test_me.py
@@ -263,3 +263,24 @@ class UsersMeViewTests(test.APITestCase):
         # 最新のDBの情報に更新し、DBの値が変更されていないことを確認
         self.player.refresh_from_db()
         self.assertEqual(self.player.avatar.name, MOCK_AVATAR_NAME)
+
+    def test_patch_400_update_with_non_field(self) -> None:
+        """
+        display_nameとavatarのどちらも送らずに更新しようとするとエラーになることを確認
+        """
+        response: drf_response.Response = self.client.patch(
+            self.url,
+            {},  # 空のbody
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data[CODE], [constants.Code.INVALID])
+        errors: dict = response.data[ERRORS]
+        self.assertIn("non_field_errors", errors)
+        # 最新のDBの情報に更新し、DBの値が変更されていないことを確認
+        self.player.refresh_from_db()
+        self.assertEqual(
+            self.player.display_name, self.player_data[DISPLAY_NAME]
+        )
+        self.assertEqual(self.player.avatar.name, MOCK_AVATAR_NAME)

--- a/backend/pong/users/tests/integration/test_me.py
+++ b/backend/pong/users/tests/integration/test_me.py
@@ -284,3 +284,22 @@ class UsersMeViewTests(test.APITestCase):
             self.player.display_name, self.player_data[DISPLAY_NAME]
         )
         self.assertEqual(self.player.avatar.name, MOCK_AVATAR_NAME)
+
+    def test_patch_400_update_with_avatar_in_json(self) -> None:
+        """
+        avatarをjson形式で送って更新しようとするとエラーになることを確認
+        """
+        response: drf_response.Response = self.client.patch(
+            self.url,
+            {
+                AVATAR: f"/media/{MOCK_AVATAR_NAME}"  # multipart/form-dataではない形式で送る
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data[CODE], [constants.Code.INVALID])
+        self.assertIn(AVATAR, response.data[ERRORS])
+        # 最新のDBの情報に更新し、DBの値が変更されていないことを確認
+        self.player.refresh_from_db()
+        self.assertEqual(self.player.avatar.name, MOCK_AVATAR_NAME)


### PR DESCRIPTION
## タスクやディスカッションのリンク
<!-- - URLをここに貼る -->
- #449 

## やったこと
<!-- - このタスクでやったことはなにか？ -->
- `/api/users/`, `PATCH` で request body が空の場合でも 200 になっていたのを修正しました
  content-type は特に見ずに、`display_name` と `avatar` の両方とも来ていない場合にエラーで `400`, `code=invalid` を返すようにしました

## やらないこと
<!-- - このタスクでやらないことはなにか？（やらない場合いつやるのか？無ければ「なし」を記述） -->
- 本当は両方のフィールドが来ない場合は実装ミスになるので  `400`, `code=internal_error` を返したいですが、少し変更多くなるのと、FE 的には同じ `code=invalid` でも現状では問題ないと思ったため、していません 

## 動作確認
<!-- - どのような動作確認を行い、結果はどうだったのか？(適宜スクショ等添付) -->
- PR #https://github.com/42-pong/42-pong/pull/418 で試していただいたのと同じようにアバター更新・リサイズができること
- vc でお話しした時のように、PATCH メソッドの request body を変えて送ってみること
  - application/json, display_name がない -> 400, code=invalid
  - application/json, avatar がある -> 400, code=invalid
  - multipart/form-data, avatar がない -> 400, code=invalid

## 特にレビューをお願いしたい箇所
<!-- - 特にチェックをお願いしたいポイントを簡潔に記述する -->
動作確認

## その他
<!-- - 実装上の懸念点、注意点等あれば記載する -->
特になし

## 参考リンク
<!-- - 実装に際し参考にした、記事やサイトのリンクを記載する -->
特になし

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **バグ修正**
	- ユーザー情報更新時の入力チェックを改善し、「表示名」または「アバター」のいずれかの入力がない場合に適切なエラーが返るようにしました。
- **Tests**
	- 不正な入力形式や欠落した情報に対して、エラー対応と既存データの保護が行われることを確認する統合テストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->