### PR TITLE
⚡ js からのリクエスト先のポートが env より決まるように拡張

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -5,6 +5,8 @@ services:
     build:
       context: ./frontend
       dockerfile: Dockerfile
+      args:
+        SERVER_PORT: ${FRONT_SERVER_PORT}
     depends_on:
       backend:
         condition: service_healthy

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -7,6 +7,9 @@ FROM node:${NODE_TAG} AS builder
 
 # src directory
 ARG SRC_DIR=./pong
+ARG SERVER_PORT
+
+ENV VITE_PORT=${SERVER_PORT}
 
 WORKDIR /app
 

--- a/frontend/pong/js/constants/Endpoints.js
+++ b/frontend/pong/js/constants/Endpoints.js
@@ -1,5 +1,5 @@
-// TODO: バックエンドのエントポイントベースを環境変数からのものになるように改善
-const HOST = "localhost:8080";
+const PORT = import.meta.env.VITE_PORT || 8080;
+const HOST = `localhost:${PORT}`;
 const BASE_URL = new URL(`https://${HOST}`);
 const WEBSOCKET_BASE_URL = new URL(`wss://${HOST}`);
 


### PR DESCRIPTION
## タスクやディスカッションのリンク
特になし

## やったこと
- js からリクエストを送る先のポートが env より決まるように拡張

## やらないこと
特になし

## 動作確認
- `.env` の `FRONT_SERVER_PORT` を `8090`, `443` などに変更して接続できる url を確認

## 特にレビューをお願いしたい箇所
特になし

## その他
特になし

## 参考リンク
https://vite.dev/guide/env-and-mode


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- フロントエンドサービスのビルドプロセスで、環境変数からサーバーポートを指定できるようになりました。これにより、運用環境に合わせた柔軟な設定が可能になります。
	- Dockerイメージのビルド時に、指定したポートに基づいてViteサーバーの設定が動的に行われるよう改善されました。
	- アプリケーションのバックエンド接続先が、環境変数に応じて動的に構成されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->