### PR TITLE
🌱 (FE) オンラインステータス表示

### DIFF
--- a/frontend/pong/js/api/users/convertFriendData.js
+++ b/frontend/pong/js/api/users/convertFriendData.js
@@ -3,5 +3,5 @@ import { convertUserData } from "./convertUserData";
 export const convertFriendData = (friendData) => {
   const { friend: userData } = friendData;
 
-  return convertUserData(userData);
+  return { ...convertUserData(userData), isDisplayingStatus: true };
 };

--- a/frontend/pong/js/api/users/deleteFriends.js
+++ b/frontend/pong/js/api/users/deleteFriends.js
@@ -1,5 +1,6 @@
 import { Endpoints } from "../../constants/Endpoints";
 import { isValidId } from "../../utils/isValidId";
+import { deleteStatus } from "../../utils/user/deleteStatus";
 import { deleteAuthenticated } from "../utils/deleteAuthenticated";
 
 export async function deleteFriends(userId) {
@@ -8,7 +9,9 @@ export async function deleteFriends(userId) {
       error: new Error("userId: not a valid Id"),
     };
   }
-  return await deleteAuthenticated(
+  const { error } = await deleteAuthenticated(
     Endpoints.FRIENDS.withId(userId).href,
   );
+  if (!error) deleteStatus(userId);
+  return { error };
 }

--- a/frontend/pong/js/api/users/getFriends.js
+++ b/frontend/pong/js/api/users/getFriends.js
@@ -1,5 +1,6 @@
 import { Endpoints } from "../../constants/Endpoints";
 import { fetchAuthenticatedAllData } from "../utils/fetchAuthenticatedAllData";
+import { requestStatus } from "../../utils/user/requestStatus";
 import { convertFriendData } from "./convertFriendData";
 
 export async function getFriends() {
@@ -8,5 +9,6 @@ export async function getFriends() {
   );
 
   const users = error ? [] : data.map(convertFriendData);
+  users.map((user) => requestStatus(user.id));
   return { users, error };
 }

--- a/frontend/pong/js/api/users/getFriends.js
+++ b/frontend/pong/js/api/users/getFriends.js
@@ -1,6 +1,6 @@
 import { Endpoints } from "../../constants/Endpoints";
-import { fetchAuthenticatedAllData } from "../utils/fetchAuthenticatedAllData";
 import { requestStatus } from "../../utils/user/requestStatus";
+import { fetchAuthenticatedAllData } from "../utils/fetchAuthenticatedAllData";
 import { convertFriendData } from "./convertFriendData";
 
 export async function getFriends() {

--- a/frontend/pong/js/api/users/postFriends.js
+++ b/frontend/pong/js/api/users/postFriends.js
@@ -1,5 +1,6 @@
 import { Endpoints } from "../../constants/Endpoints";
 import { isValidId } from "../../utils/isValidId";
+import { requestStatus } from "../../utils/user/requestStatus";
 import { createPostMethodOption } from "../utils/createPostMethodOption";
 import { fetchAuthenticatedData } from "../utils/fetchAuthenticatedData";
 import { convertFriendData } from "./convertFriendData";
@@ -18,5 +19,6 @@ export async function postFriends(userId) {
   );
 
   const user = error ? null : convertFriendData(data);
+  if (user) requestStatus(user.id);
   return { user, error };
 }

--- a/frontend/pong/js/bootstrap/utilities/helpers.js
+++ b/frontend/pong/js/bootstrap/utilities/helpers.js
@@ -1,0 +1,9 @@
+import { setClassNames } from "../../utils/elements/setClassNames";
+
+const setVisuallyHidden = (element) => {
+  return setClassNames(element, "visually-hidden");
+};
+
+export const BootstrapHelpers = {
+  setVisuallyHidden,
+};

--- a/frontend/pong/js/bootstrap/utilities/position.js
+++ b/frontend/pong/js/bootstrap/utilities/position.js
@@ -4,26 +4,41 @@ const setFixed = (element) => {
   return setClassNames(element, "position-fixed");
 };
 
-const setTop = (element) => {
-  return setClassNames(element, "top-0");
+const setRelative = (element) => {
+  return setClassNames(element, "position-relative");
 };
 
-const setBottom = (element) => {
-  return setClassNames(element, "bottom-0");
+const setAbsolute = (element) => {
+  return setClassNames(element, "position-absolute");
 };
 
-const setStart = (element) => {
-  return setClassNames(element, "start-0");
+const setTop = (element, position = 0) => {
+  return setClassNames(element, `top-${position}`);
 };
 
-const setEnd = (element) => {
-  return setClassNames(element, "end-0");
+const setBottom = (element, position = 0) => {
+  return setClassNames(element, `bottom-${position}`);
+};
+
+const setStart = (element, position = 0) => {
+  return setClassNames(element, `start-${position}`);
+};
+
+const setEnd = (element, position = 0) => {
+  return setClassNames(element, `end-${position}`);
+};
+
+const setTranslateMiddle = (element) => {
+  return setClassNames(element, "translate-middle");
 };
 
 export const BootstrapPosition = {
   setFixed,
+  setRelative,
+  setAbsolute,
   setTop,
   setBottom,
   setStart,
   setEnd,
+  setTranslateMiddle,
 };

--- a/frontend/pong/js/components/user/UserListContainer.js
+++ b/frontend/pong/js/components/user/UserListContainer.js
@@ -86,4 +86,8 @@ export class UserListContainer extends Component {
     Object.assign(this.#userList._getState(), { items: users });
     this.append(this.#userList, this.#userProfileContainer);
   }
+
+  reloadList() {
+    if (this.#userList) this.#userList._updateState();
+  }
 }

--- a/frontend/pong/js/components/views/FriendsView.js
+++ b/frontend/pong/js/components/views/FriendsView.js
@@ -3,10 +3,12 @@ import { BootstrapDisplay } from "../../bootstrap/utilities/display";
 import { BootstrapFlex } from "../../bootstrap/utilities/flex";
 import { BootstrapSizing } from "../../bootstrap/utilities/sizing";
 import { AuthView } from "../../core/AuthView";
+import { UserSessionManager } from "../../session/UserSessionManager";
 import { UserListContainer } from "../user/UserListContainer";
 
 export class FriendsView extends AuthView {
   #friendsListContainer;
+  #reloadList;
 
   _setStyle() {
     BootstrapDisplay.setFlex(this);
@@ -21,6 +23,14 @@ export class FriendsView extends AuthView {
     this.#friendsListContainer = new UserListContainer({
       fetchUsers: getFriends,
     });
+    this.#reloadList = () => {
+      this.#friendsListContainer.reloadList();
+    };
+    UserSessionManager.getInstance().status.attach(this.#reloadList);
+  }
+
+  _onDisconnect() {
+    UserSessionManager.getInstance().status.detach(this.#reloadList);
   }
 
   _render() {

--- a/frontend/pong/js/enums/WebSocketEnums.js
+++ b/frontend/pong/js/enums/WebSocketEnums.js
@@ -2,6 +2,7 @@ const Category = {
   MATCH: "MATCH",
   TOURNAMENT: "TOURNAMENT",
   CHAT: "CHAT",
+  LOGIN: "LOGIN",
 };
 
 const Tournament = {

--- a/frontend/pong/js/enums/WebSocketEnums.js
+++ b/frontend/pong/js/enums/WebSocketEnums.js
@@ -3,6 +3,7 @@ const Category = {
   TOURNAMENT: "TOURNAMENT",
   CHAT: "CHAT",
   LOGIN: "LOGIN",
+  STATUS: "STATUS",
 };
 
 const Tournament = {

--- a/frontend/pong/js/mocks/handlers/webSocket.js
+++ b/frontend/pong/js/mocks/handlers/webSocket.js
@@ -2,6 +2,7 @@ import { ws } from "msw";
 import { Endpoints } from "../../constants/Endpoints";
 import { WebSocketEnums } from "../../enums/WebSocketEnums";
 import { chatPayloadHandler } from "../utils/websocket/chatPayloadHandler";
+import { loginPayloadHandler } from "../utils/websocket/loginPayloadHandler";
 import { matchPayloadHandler } from "../utils/websocket/matchPayloadHandler";
 import { tournamentPayloadHandler } from "../utils/websocket/tournamentPayloadHandler";
 
@@ -21,6 +22,9 @@ export const handlers = [
           break;
         case WebSocketEnums.Category.CHAT:
           chatPayloadHandler(client, payload);
+          break;
+        case WebSocketEnums.Category.LOGIN:
+          loginPayloadHandler(client, payload);
           break;
         default:
           return;

--- a/frontend/pong/js/mocks/utils/websocket/loginPayloadHandler.js
+++ b/frontend/pong/js/mocks/utils/websocket/loginPayloadHandler.js
@@ -1,8 +1,8 @@
 import { sendLogin } from "./sendPayloads";
 
-export const loginPayloadHandler = async (client, payload) => {
+export const loginPayloadHandler = (client) => {
   sendLogin(client, {
     status: "OK",
-    online_status_ids: [3, 4, 8, 7],
+    online_status_ids: [],
   });
 };

--- a/frontend/pong/js/mocks/utils/websocket/loginPayloadHandler.js
+++ b/frontend/pong/js/mocks/utils/websocket/loginPayloadHandler.js
@@ -1,0 +1,8 @@
+import { sendLogin } from "./sendPayloads";
+
+export const loginPayloadHandler = async (client, payload) => {
+  sendLogin(client, {
+    status: "OK",
+    online_status_ids: [3, 4, 8, 7],
+  });
+};

--- a/frontend/pong/js/mocks/utils/websocket/sendPayloads.js
+++ b/frontend/pong/js/mocks/utils/websocket/sendPayloads.js
@@ -18,4 +18,7 @@ const sendTournament = (client, type, data) =>
 const sendChat = (client, type, data) =>
   send(client, WebSocketEnums.Category.CHAT, { type, data });
 
-export { sendMatch, sendTournament, sendChat };
+const sendLogin = (client, payload) =>
+  send(client, WebSocketEnums.Category.LOGIN, payload);
+
+export { sendMatch, sendTournament, sendChat, sendLogin };

--- a/frontend/pong/js/session/UserSession.js
+++ b/frontend/pong/js/session/UserSession.js
@@ -17,7 +17,11 @@ export class UserSession {
   constructor() {
     this.#apps = {};
     this.#myInfo = new DataSubject();
-    this.#webSocket = new WebSocketWrapper();
+    const signOut = this.signOut.bind(this);
+    this.#webSocket = new WebSocketWrapper({
+      onClose: signOut,
+      onError: signOut,
+    });
   }
 
   redirect(path = Paths.HOME) {

--- a/frontend/pong/js/utils/elements/div/createNameplate.js
+++ b/frontend/pong/js/utils/elements/div/createNameplate.js
@@ -1,20 +1,38 @@
+import { BootstrapBadge } from "../../../bootstrap/components/badge";
+import { BootstrapBorders } from "../../../bootstrap/utilities/borders";
 import { BootstrapDisplay } from "../../../bootstrap/utilities/display";
 import { BootstrapFlex } from "../../../bootstrap/utilities/flex";
+import { BootstrapHelpers } from "../../../bootstrap/utilities/helpers";
+import { BootstrapPosition } from "../../../bootstrap/utilities/position";
 import { BootstrapSpacing } from "../../../bootstrap/utilities/spacing";
 import { BootstrapText } from "../../../bootstrap/utilities/text";
+import { UserSessionManager } from "../../../session/UserSessionManager";
+import { hasNumericKey } from "../../hasNumericKey";
 import { createAvatarImage } from "../../user/createAvatarImage";
 import { formatUserInfo } from "../../user/formatUserInfo";
 import { createElement } from "../createElement";
+import { createTextElement } from "../span/createTextElement";
 
 export const createNameplate = (user, avatarHeight = "") => {
-  const { nameTagText, avatarPathname, avatarAlt } =
-    formatUserInfo(user);
+  const {
+    nameTagText,
+    avatarPathname,
+    avatarAlt,
+    isDisplayingStatus,
+    id,
+  } = formatUserInfo(user);
 
-  const avatar = createAvatarImage({
+  const avatarImage = createAvatarImage({
     pathname: avatarPathname,
     alt: avatarAlt,
     height: avatarHeight,
   });
+  const avatar = createAvatar({
+    avatarImage,
+    isDisplayingStatus,
+    id,
+  });
+
   const nameTag = createElement("span", {
     textContent: nameTagText,
   });
@@ -26,4 +44,51 @@ export const createNameplate = (user, avatarHeight = "") => {
   BootstrapSpacing.setGap(nameplate);
   nameplate.append(avatar, nameTag);
   return nameplate;
+};
+
+const createAvatar = (params) => {
+  const { avatarImage, isDisplayingStatus, id } = params;
+  const container = createElement("div");
+  container.append(avatarImage);
+  if (!isDisplayingStatus) return container;
+
+  const isOnline = getIsOnline(id);
+
+  const badgeContainer = createElement("div");
+
+  BootstrapPosition.setRelative(container);
+  BootstrapPosition.setAbsolute(badgeContainer);
+  BootstrapPosition.setStart(badgeContainer, 100);
+  BootstrapPosition.setTop(badgeContainer, 100);
+  BootstrapPosition.setTranslateMiddle(badgeContainer);
+
+  const badge = createOnlineBadge(isOnline);
+
+  badgeContainer.append(badge);
+  container.append(badgeContainer);
+  return container;
+};
+
+const getIsOnline = (id) =>
+  UserSessionManager.getInstance().status.observe(
+    (statusData) =>
+      hasNumericKey(statusData, id) && statusData[id].isOnline,
+  );
+
+const createOnlineBadge = (isOnline) => {
+  const onlineBadge = createElement("div");
+  const setBgStyle = isOnline
+    ? BootstrapBadge.setSuccess
+    : BootstrapBadge.setSecondary;
+  setBgStyle(onlineBadge);
+
+  BootstrapBorders.setRoundedCircle(onlineBadge);
+  BootstrapSpacing.setPadding(onlineBadge, 2);
+
+  const hiddenText = createTextElement(
+    isOnline ? "online" : "offline",
+  );
+  BootstrapHelpers.setVisuallyHidden(hiddenText);
+  onlineBadge.append(hiddenText);
+  return onlineBadge;
 };

--- a/frontend/pong/js/utils/hasNumericKey.js
+++ b/frontend/pong/js/utils/hasNumericKey.js
@@ -1,0 +1,2 @@
+export const hasNumericKey = (obj, numericKey) =>
+  Object.keys(obj).includes(numericKey.toString());

--- a/frontend/pong/js/utils/user/deleteStatus.js
+++ b/frontend/pong/js/utils/user/deleteStatus.js
@@ -1,0 +1,10 @@
+import { UserSessionManager } from "../../session/UserSessionManager";
+import { hasNumericKey } from "../hasNumericKey";
+
+export const deleteStatus = (userId) => {
+  const statusData = UserSessionManager.getInstance().status.observe(
+    (data) => data,
+  );
+  if (!hasNumericKey(statusData, userId)) return;
+  delete statusData[userId];
+};

--- a/frontend/pong/js/utils/user/formatUserInfo.js
+++ b/frontend/pong/js/utils/user/formatUserInfo.js
@@ -6,9 +6,13 @@ export const formatUserInfo = (user) =>
         nameTagText: `${user.displayName}#${user.username}`,
         avatarPathname: user.avatar,
         avatarAlt: `${user.displayName}#${user.username}'s avatar`,
+        isDisplayingStatus: user.isDisplayingStatus ?? false,
+        id: user.id,
       }
     : {
         nameTagText: "...",
         avatarPathname: Endpoints.USERS.defaultAvatar.href,
         avatarAlt: "placeholder",
+        isDisplayingStatus: false,
+        id: null,
       };

--- a/frontend/pong/js/utils/user/requestStatus.js
+++ b/frontend/pong/js/utils/user/requestStatus.js
@@ -1,0 +1,15 @@
+import { WebSocketEnums } from "../../enums/WebSocketEnums";
+import { UserSessionManager } from "../../session/UserSessionManager";
+import { hasNumericKey } from "../hasNumericKey";
+
+export const requestStatus = (userId) => {
+  if (!userId) return;
+  const statusData = UserSessionManager.getInstance().status.observe(
+    (data) => data,
+  );
+  if (hasNumericKey(statusData, userId)) return;
+  UserSessionManager.getInstance().webSocket.send(
+    WebSocketEnums.Category.STATUS,
+    { user_id: userId },
+  );
+};

--- a/frontend/pong/js/websocket/WebSocketWrapper.js
+++ b/frontend/pong/js/websocket/WebSocketWrapper.js
@@ -5,7 +5,6 @@ import { customDelay } from "../utils/customDelay";
 export class WebSocketWrapper {
   #socket;
   #handlers;
-  #onOpen;
   #onClose;
   #onError;
   #onMessage;
@@ -55,7 +54,6 @@ export class WebSocketWrapper {
 
   async connect() {
     const socket = new WebSocket(Endpoints.WEBSOCKET);
-    socket.addEventListener("open", this.#onOpen);
     socket.addEventListener("close", this.#onClose);
     socket.addEventListener("error", this.#onError);
     socket.addEventListener("message", this.#onMessage);
@@ -68,7 +66,6 @@ export class WebSocketWrapper {
   close() {
     if (this.#socket === null) return;
 
-    this.#socket.removeEventListener("open", this.#onOpen);
     this.#socket.removeEventListener("close", this.#onClose);
     this.#socket.removeEventListener("error", this.#onError);
     this.#socket.removeEventListener("message", this.#onMessage);

--- a/frontend/pong/js/websocket/WebSocketWrapper.js
+++ b/frontend/pong/js/websocket/WebSocketWrapper.js
@@ -40,7 +40,7 @@ export class WebSocketWrapper {
     });
     this.attachHandler(WebSocketEnums.Category.STATUS, (payload) => {
       const { user_id, online } = payload;
-      this.#status.updateData({ [user_id]: online });
+      this.#status.updateData({ [user_id]: { isOnline: online } });
     });
   }
 

--- a/frontend/pong/js/websocket/WebSocketWrapper.js
+++ b/frontend/pong/js/websocket/WebSocketWrapper.js
@@ -38,6 +38,10 @@ export class WebSocketWrapper {
       }
       this.#status.updateData(newData);
     });
+    this.attachHandler(WebSocketEnums.Category.STATUS, (payload) => {
+      const { user_id, online } = payload;
+      this.#status.updateData({ [user_id]: online });
+    });
   }
 
   get readyState() {

--- a/frontend/pong/js/websocket/WebSocketWrapper.js
+++ b/frontend/pong/js/websocket/WebSocketWrapper.js
@@ -9,9 +9,10 @@ export class WebSocketWrapper {
   #onClose;
   #onError;
   #onMessage;
+  #status;
 
-  constructor({ onClose, onError }) {
-    this.#onOpen = () => {};
+  constructor({ status, onClose, onError }) {
+    this.#status = status;
     this.#onClose = onClose;
     this.#onError = onError;
     this.#onMessage = (event) => {
@@ -27,6 +28,16 @@ export class WebSocketWrapper {
     this.#handlers = {};
     for (const category of Object.values(WebSocketEnums.Category))
       this.#handlers[category] = new Set();
+
+    this.attachHandler(WebSocketEnums.Category.LOGIN, (payload) => {
+      const { status, online_status_ids } = payload;
+      if (status !== "OK") return;
+      const newData = {};
+      for (const online_status_id of online_status_ids) {
+        newData[online_status_id] = { isOnline: true };
+      }
+      this.#status.updateData(newData);
+    });
   }
 
   get readyState() {


### PR DESCRIPTION
## タスクやディスカッションのリンク
- #410 

## やったこと
- WebSocket の決めたルールどおりバックエンドと連携し、ステータス情報の管理
- フレンド一覧にオンラインステータスを表示

## やらないこと
特になし

## 動作確認
- `make` 後、フレンド一覧から、二種類のオンライン表示を確認 (別タブを使って異なるユーザーのサインインなどで試せるかと思います。)

## 特にレビューをお願いしたい箇所
特になし

## その他
特になし

## 参考リンク
https://www.notion.so/Websocket-2ec8362722664e50b94486599d01328e?pvs=4


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 友達データにオンライン状態が反映され、フレンドリストがリアルタイムに更新されるようになりました。
  - ユーザーのログインや状態に関するメッセージがWebSocket経由で処理され、プロフィールにオンラインバッジが追加されました。
  - UI面では、動的なレイアウト配置やアクセシブルな表示が強化されています。

- **リファクタリング**
  - APIおよびWebSocket通信の内部処理が整理され、エラーハンドリングとモジュール化が改善されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->