### PR TITLE
🔥 [redis] 公開する必要がなかったので compose.yaml から ports 削除

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,7 +51,6 @@ ADMINER_PORT="12345"
 # -------------------------------------------------------
 # redis
 # -------------------------------------------------------
-REDIS_PORT="6378"
 REDIS_PASSWORD="password"
 REDIS_CHANNEL_LAYER_DB="0"
 REDIS_STORE_DB="1"

--- a/.github/workflows/backend_code_check.yml
+++ b/.github/workflows/backend_code_check.yml
@@ -27,7 +27,6 @@ jobs:
       DB_PASSWORD: "${{ secrets.DB_PASSWORD }}"
       JWS_SECRET_KEY: "${{ secrets.JWS_SECRET_KEY }}"
       REDIS_PASSWORD: "${{ secrets.REDIS_PASSWORD }}"
-      REDIS_PORT: "${{ secrets.REDIS_PORT}}"
       REDIS_CHANNEL_LAYER_DB: "${{ secrets.REDIS_CHANNEL_LAYER_DB }}"
       REDIS_STORE_DB: "${{ secrets.REDIS_STORE_DB }}"
 

--- a/.github/workflows/backend_test.yml
+++ b/.github/workflows/backend_test.yml
@@ -38,7 +38,6 @@ jobs:
             DB_PASSWORD="${{ secrets.DB_PASSWORD }}"
             JWS_SECRET_KEY="${{ secrets.JWS_SECRET_KEY }}"
             REDIS_PASSWORD="${{ secrets.REDIS_PASSWORD }}"
-            REDIS_PORT="${{ secrets.REDIS_PORT }}"
             REDIS_CHANNEL_LAYER_DB="${{ secrets.REDIS_CHANNEL_LAYER_DB }}"
             REDIS_STORE_DB="${{ secrets.REDIS_STORE_DB }}"
           EOF

--- a/backend/pong/pong/settings.py
+++ b/backend/pong/pong/settings.py
@@ -70,7 +70,6 @@ OAUTH2_TOKEN_ENDPOINT = get_valid_str_env("OAUTH2_TOKEN_ENDPOINT")
 JWS_SECRET_KEY = get_valid_str_env("JWS_SECRET_KEY")
 FRONT_SERVER_PORT = get_valid_str_env("FRONT_SERVER_PORT")
 REDIS_PASSWORD = get_valid_str_env("REDIS_PASSWORD")
-# REDIS_PORT = get_valid_str_env("REDIS_PORT")
 REDIS_CHANNEL_LAYER_DB = get_valid_str_env("REDIS_CHANNEL_LAYER_DB")
 REDIS_STORE_DB = get_valid_str_env("REDIS_STORE_DB")
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -92,8 +92,6 @@ services:
     container_name: redis
     restart: always
     command: [ "sh", "-c", "redis-server /usr/local/etc/redis/redis.conf --requirepass ${REDIS_PASSWORD}" ]
-    ports:
-      - "${REDIS_PORT}:6379"
     volumes:
       - ./redis/redis.conf:/usr/local/etc/redis/redis.conf
     networks:


### PR DESCRIPTION
## タスクやディスカッションのリンク
<!-- - URLをここに貼る -->
- #477

## やったこと
<!-- - このタスクでやったことはなにか？ -->
redis はコンテナネットワーク内でしか使用していなかったので、port の公開している部分を削除しました

## やらないこと
<!-- - このタスクでやらないことはなにか？（やらない場合いつやるのか？無ければ「なし」を記述） -->

## 動作確認
<!-- - どのような動作確認を行い、結果はどうだったのか？(適宜スクショ等添付) -->
変わらず websocket を使用したローカル対戦ができること

## 特にレビューをお願いしたい箇所
<!-- - 特にチェックをお願いしたいポイントを簡潔に記述する -->

## その他
<!-- - 実装上の懸念点、注意点等あれば記載する -->

## 参考リンク
<!-- - 実装に際し参考にした、記事やサイトのリンクを記載する -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - 環境設定ファイルおよび自動化ワークフローから、Redisのポート設定（REDIS_PORT）の記述を削除し、構成を整理しました。
  - Docker Compose設定からRedisサービスの外部ポートマッピングを削除し、外部アクセスを制限する変更を実施しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->