### PR TITLE
⚡ [setting] docker 関連をきれいに削除するルール追加 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,11 @@ SSL_CNF_PATH	:=	frontend/openssl.cnf
 .PHONY: all
 all: gen_ssl_cert up
 
+# rm container,volume,network,image,build cache,avatars,ssl_cert
+.PHONY: clean
+clean: down_v clean_docker rm_avatars rm_ssl_cert
+	@echo "All containers, volume, network, images, build cache, avatars, ssl_cert are removed."
+
 # -------------------------------------------------------
 # docker compose
 # -------------------------------------------------------
@@ -100,6 +105,9 @@ rm_images:
 .PHONY: rm_builder_cache
 rm_builder_cache:
 	@-docker builder prune -af
+
+.PHONY: clean_docker
+clean_docker: rm_images rm_builder_cache
 
 # デフォルト画像"sample.png"以外のアバター画像を削除
 .PHONY: rm_avatars

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,14 @@
 COMPOSE_FILE		:=	compose.yaml
 DOCKER_COMPOSE		:=	docker compose -f $(COMPOSE_FILE)
 
+FRONTEND_SERVICE	:=	frontend
 BACKEND_SERVICE		:=	backend
-DATABASE_SERVICE	:=	db
+DATABASE_SERVICE	:=	postgres
+ADMINER_SERVICE		:=	adminer
+REDIS_SERVICE		:=	redis
+
+SERVICES	:=	$(FRONTEND_SERVICE) $(BACKEND_SERVICE) \
+				$(DATABASE_SERVICE) $(ADMINER_SERVICE) $(REDIS_SERVICE)
 
 # ssl
 DOMAIN_NAME		:=	localhost
@@ -79,6 +85,15 @@ logs-be:
 .PHONY: logs-db
 logs-db:
 	@$(DOCKER_COMPOSE) logs $(DATABASE_SERVICE)
+
+# -------------------------------------------------------
+# cleanup
+# -------------------------------------------------------
+.PHONY: rm_images
+rm_images:
+	@for service in $(SERVICES); do \
+        docker rmi -f $$(docker images -q --filter "reference=$$service") || true; \
+    done
 
 # -------------------------------------------------------
 # ssl

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,8 @@ REDIS_SERVICE		:=	redis
 SERVICES	:=	$(FRONTEND_SERVICE) $(BACKEND_SERVICE) \
 				$(DATABASE_SERVICE) $(ADMINER_SERVICE) $(REDIS_SERVICE)
 
+AVATARS_DIR	:=	backend/pong/media/avatars
+
 # ssl
 DOMAIN_NAME		:=	localhost
 SSL_DIR			:=	frontend/ssl
@@ -98,6 +100,11 @@ rm_images:
 .PHONY: rm_builder_cache
 rm_builder_cache:
 	@-docker builder prune -af
+
+# デフォルト画像"sample.png"以外のアバター画像を削除
+.PHONY: rm_avatars
+rm_avatars:
+	@find $(AVATARS_DIR) -type f ! -name "sample.png" -delete
 
 # -------------------------------------------------------
 # ssl

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,11 @@ up:
 down:
 	@$(DOCKER_COMPOSE) down
 
+# rm container,volume,network
+.PHONY: down_v
+down_v:
+	@$(DOCKER_COMPOSE) down -v
+
 .PHONY: build-up
 build-up:
 	@$(DOCKER_COMPOSE) up --build -d

--- a/Makefile
+++ b/Makefile
@@ -95,6 +95,10 @@ rm_images:
         docker rmi -f $$(docker images -q --filter "reference=$$service") || true; \
     done
 
+.PHONY: rm_builder_cache
+rm_builder_cache:
+	@-docker builder prune -af
+
 # -------------------------------------------------------
 # ssl
 # -------------------------------------------------------


### PR DESCRIPTION
## タスクやディスカッションのリンク
<!-- - URLをここに貼る -->
- #476 

## やったこと
<!-- - このタスクでやったことはなにか？ -->
`make clean`  で以下を全部削除するコマンド・ルールを Makefile に追加しました
- docker の conatiner, volume, network, image, build cache
- デフォルトの `sample.png` 以外のアバター画像
- ssl 証明書

## やらないこと
<!-- - このタスクでやらないことはなにか？（やらない場合いつやるのか？無ければ「なし」を記述） -->

## 動作確認
<!-- - どのような動作確認を行い、結果はどうだったのか？(適宜スクショ等添付) -->
`make clean` で上記が全部削除されること

## 特にレビューをお願いしたい箇所
<!-- - 特にチェックをお願いしたいポイントを簡潔に記述する -->

## その他
<!-- - 実装上の懸念点、注意点等あれば記載する -->

## 参考リンク
<!-- - 実装に際し参考にした、記事やサイトのリンクを記載する -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- 複数のシステムコンポーネントの構成が強化され、サービス管理がより一元化されました。

- **雑務**
	- 自動クリーンアップ操作が追加され、不要なリソース（コンテナ、画像、キャッシュなど）の削除が簡単になりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->