### PR TITLE
⚡ ♻️ [test] mock 作成 Command のエラー処理追加

### DIFF
--- a/backend/pong/pong/management/commands/create_mock_players.py
+++ b/backend/pong/pong/management/commands/create_mock_players.py
@@ -1,5 +1,6 @@
 from django.contrib.auth.models import User
 from django.core.management.base import BaseCommand, CommandParser
+from django.db import transaction
 
 from accounts.player.models import Player
 
@@ -25,12 +26,22 @@ class Command(BaseCommand):
 
         # Create users and players
         for i in range(1, num + 1):  # type: ignore
-            user: User = User.objects.create_user(
-                username=f"mock{i}",
-                email=f"mock{i}@example.com",
-                password="test12345",
-            )
-            Player.objects.create(user=user, display_name=f"player_{i}")
+            try:
+                with transaction.atomic():
+                    user: User = User.objects.create_user(
+                        username=f"mock{i}",
+                        email=f"mock{i}@example.com",
+                        password="test12345",
+                    )
+                    Player.objects.create(
+                        user=user, display_name=f"player_{i}"
+                    )
+            except Exception as e:
+                self.stderr.write(
+                    self.style.ERROR(
+                        f"Failed to create mock player_{i}: {str(e)}"
+                    )
+                )
 
         self.stdout.write(
             self.style.SUCCESS("Successfully created mock players")

--- a/backend/pong/pong/management/commands/create_mock_players.py
+++ b/backend/pong/pong/management/commands/create_mock_players.py
@@ -23,6 +23,7 @@ class Command(BaseCommand):
 
     def handle(self, *args: tuple, **kwargs: dict) -> None:
         num = kwargs["num_players"]
+        created_players: set[int] = set()
 
         # Create users and players
         for i in range(1, num + 1):  # type: ignore
@@ -36,6 +37,7 @@ class Command(BaseCommand):
                     Player.objects.create(
                         user=user, display_name=f"player_{i}"
                     )
+                created_players.add(i)
             except Exception as e:
                 self.stderr.write(
                     self.style.ERROR(
@@ -43,6 +45,9 @@ class Command(BaseCommand):
                     )
                 )
 
-        self.stdout.write(
-            self.style.SUCCESS("Successfully created mock players")
-        )
+        if created_players:
+            self.stdout.write(
+                self.style.SUCCESS(
+                    f"Successfully created mock players {",".join(map(str, created_players))}"
+                )
+            )


### PR DESCRIPTION
## タスクやディスカッションのリンク
<!-- - URLをここに貼る -->
- #484 

## やったこと
<!-- - このタスクでやったことはなにか？ -->
mock の player, tournament 作成コマンド `make create_mock_players`, `make create_mock_games` にトランザクション処理を追加し、エラー時に中途半端なレコードを DB に保存しないようにしました

## やらないこと
<!-- - このタスクでやらないことはなにか？（やらない場合いつやるのか？無ければ「なし」を記述） -->

## 動作確認
<!-- - どのような動作確認を行い、結果はどうだったのか？(適宜スクショ等添付) -->
`make create_mock_players NUM=1` -> 成功
`make create_mock_players NUM=3` -> 1 が既に DB に存在するので失敗、2,3 のみ成功


## 特にレビューをお願いしたい箇所
<!-- - 特にチェックをお願いしたいポイントを簡潔に記述する -->

## その他
<!-- - 実装上の懸念点、注意点等あれば記載する -->

## 参考リンク
<!-- - 実装に際し参考にした、記事やサイトのリンクを記載する -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **リファクタリング**
  - プレイヤーおよびトーナメント作成処理の整合性が向上し、エラー発生時には全体の処理を中断して明確なエラーメッセージが表示されます。
- **新機能**
  - 作成成功時のフィードバックが改善され、生成されたプレイヤー一覧やトーナメント識別情報が提供されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->