### PR TITLE
⚡ [https] 静的ファイル共有

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -8,6 +8,7 @@ __pycache__/
 # Django stuff:
 db.sqlite3
 media/
+staticfiles/
 
 # Environments
 env/

--- a/backend/pong/pong/settings.py
+++ b/backend/pong/pong/settings.py
@@ -198,6 +198,7 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/5.1/howto/static-files/
 
 STATIC_URL = "static/"
+STATIC_ROOT = os.path.join(BASE_DIR, "staticfiles")
 
 MEDIA_URL = "/media/"
 MEDIA_ROOT = os.path.join(BASE_DIR, "media")

--- a/backend/pong/pong/urls.py
+++ b/backend/pong/pong/urls.py
@@ -15,8 +15,6 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 
-from django.conf import settings
-from django.conf.urls.static import static
 from django.contrib import admin
 from django.urls import include, path
 
@@ -41,9 +39,3 @@ urlpatterns = [
     # matches
     path("api/matches/", include("matches.urls")),
 ]
-
-if settings.DEBUG:
-    # 開発時のみmediaファイルを提供する
-    urlpatterns += static(
-        settings.MEDIA_URL, document_root=settings.MEDIA_ROOT
-    )

--- a/backend/tools/entrypoint.sh
+++ b/backend/tools/entrypoint.sh
@@ -6,6 +6,7 @@ set -eux
 migrate_db() {
     python3 manage.py makemigrations --noinput
     python3 manage.py migrate --noinput
+    python3 manage.py collectstatic --noinput
 }
 
 create_superuser() {

--- a/compose.yaml
+++ b/compose.yaml
@@ -12,6 +12,7 @@ services:
         condition: service_healthy
     volumes:
       - ./backend/pong/media:/usr/share/nginx/html/media
+      - ./backend/pong/staticfiles:/usr/share/nginx/html/static
     restart: always
     ports:
       - "${FRONT_SERVER_PORT}:443"

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -45,6 +45,11 @@ http {
         alias /usr/share/nginx/html/media/;
     }
 
+    # FE-BE間の静的ファイルの配信設定
+    location /static/ {
+        alias /usr/share/nginx/html/static/;
+    }
+
     # FE-BE間のwebsocketのプロキシ設定
     location /ws/ {
         proxy_pass http://backend:8000/ws/;

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -25,7 +25,7 @@ http {
 
     # TODO: SERVER_NAME などで環境変数より定まるように設定
     server_name localhost;
-  
+
     location / {
         root /usr/share/nginx/html;
         try_files $uri $uri/ /index.html;


### PR DESCRIPTION
## タスクやディスカッションのリンク
<!-- - URLをここに貼る -->
- #403 

## やったこと
<!-- - このタスクでやったことはなにか？ -->
swagger-ui を `https://localhost:{FRONT_SERVER_PORT}/api/schema/swagger-ui/` で使用できるようにしました
今までは静的ファイルを frontend に配信・共有していなかったため、swagger-ui が https だと見れない状況でした

具体的には、backend の admin サイトや swagger-ui で使用している静的ファイルを staticfiles ディレクトリに集め (`python manage.py collectstatic`)、`/media` と同様に volume を介して frontend でも使用できるようにしました

## やらないこと
<!-- - このタスクでやらないことはなにか？（やらない場合いつやるのか？無ければ「なし」を記述） -->

## 動作確認
<!-- - どのような動作確認を行い、結果はどうだったのか？(適宜スクショ等添付) -->
https で swagger-ui が見れて使えること

## 特にレビューをお願いしたい箇所
<!-- - 特にチェックをお願いしたいポイントを簡潔に記述する -->

## その他
<!-- - 実装上の懸念点、注意点等あれば記載する -->

## 参考リンク
<!-- - 実装に際し参考にした、記事やサイトのリンクを記載する -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- 本番環境向けに静的コンテンツの収集・配信が自動化され、サイトのパフォーマンス向上を実現しました。
	- バックエンドとフロントエンド間でのリソース連携が強化され、利用時の表示がよりスムーズになりました。

- **Chores**
	- 開発環境向けの不要な静的ファイル提供設定が整理され、システム設定が一層クリーンになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->