### PR TITLE
:bug: ログイン・ログアウト時にフレンド追加しているユーザーへ通知できるように修正

### DIFF
--- a/backend/pong/ws/login/handler.py
+++ b/backend/pong/ws/login/handler.py
@@ -106,11 +106,13 @@ class LoginHandler:
             login_constants.CHANNEL_RESOURCE,
             self.channel_handler.channel_name,
         )
-        self.user_id = None
 
         # 接続数が1->0の時だけfollowerに通知する
         if connection_cnt == 0:
             await self._notify_followers(False)
+
+        # この後切断するだけだからNoneを入れる必要ないかも？
+        self.user_id = None
 
     async def _validate_user_id(self, input_user_id: int) -> None:
         """
@@ -154,7 +156,7 @@ class LoginHandler:
         # オンライン状態でフレンド登録している人をイテレーションで順に処理
         async for follower_id in (
             friend_models.Friendship.objects.filter(friend_id=self.user_id)
-            .values_list("id", flat=True)
+            .values_list("user_id", flat=True)
             .aiterator()
         ):
             # followerのうちがオンライン状態であるユーザーのchannel名の集合を取得


### PR DESCRIPTION
- logoutを知らせる前に保存していたuser_idをNoneで上書きしていたのでそれも修正

## タスクやディスカッションのリンク
<!-- - URLをここに貼る -->
- Closes #487 

## やったこと
<!-- - このタスクでやったことはなにか？ -->
- バグの修正
  - friendshipテーブルからuser_idを取得しないといけないところをidを取得してしまっていた
  - logout時に先にフレンド追加している人へ伝えてから保存しているuser_idを削除するように変更

## やらないこと
<!-- - このタスクでやらないことはなにか？（やらない場合いつやるのか？無ければ「なし」を記述） -->
- バグ修正以外のこと

## 動作確認
<!-- - どのような動作確認を行い、結果はどうだったのか？(適宜スクショ等添付) -->
- 2人のユーザーA,Bを用意。
- Aをフレンド追加したBで複数タブでログインし、フレンド一覧を開いて、Aがまだログインしていないことを確認。
- Aでログインしたときに、Bのフレンド一覧でのAの表示がリロードせずに緑に変わることを確認。

- 確認する際に、redisの方がバグ修正前でうまくデータを消せていないことがあるのでdown -> build upしてください。

## 特にレビューをお願いしたい箇所
<!-- - 特にチェックをお願いしたいポイントを簡潔に記述する -->

## その他
<!-- - 実装上の懸念点、注意点等あれば記載する -->

## 参考リンク
<!-- - 実装に際し参考にした、記事やサイトのリンクを記載する -->
