### PR TITLE
🌱 ダッシュボード追加

### DIFF
--- a/frontend/pong/js/api/matches/convertMatchData.js.js
+++ b/frontend/pong/js/api/matches/convertMatchData.js.js
@@ -1,0 +1,41 @@
+import { convertStatus } from "../tournaments/convertStatus";
+
+export const convertMatchData = (match) => {
+  const {
+    id,
+    round_id,
+    status,
+    created_at,
+    updated_at,
+    participations,
+  } = match;
+
+  return {
+    matchId: id,
+    roundId: round_id,
+    status: convertStatus(status),
+    createdAt: created_at,
+    updatedAt: updated_at,
+    players: participations.map((participation) =>
+      convertParticipationToPlayer(participation),
+    ),
+  };
+};
+
+const convertParticipationToPlayer = (participation) => {
+  const { user_id, team, is_win, scores } = participation;
+
+  return {
+    userId: user_id,
+    team,
+    isWin: is_win,
+    scores: scores.map(convertScoreData),
+    score: scores.length,
+  };
+};
+
+const convertScoreData = (score) => {
+  const { created_at, pos_x, pos_y } = score;
+
+  return { createdAt: created_at, posX: pos_x, posY: pos_y };
+};

--- a/frontend/pong/js/api/matches/getMatch.js
+++ b/frontend/pong/js/api/matches/getMatch.js
@@ -1,0 +1,20 @@
+import { Endpoints } from "../../constants/Endpoints";
+import { isValidId } from "../../utils/isValidId";
+import { fetchAuthenticatedData } from "../utils/fetchAuthenticatedData";
+import { convertMatchData } from "./convertMatchData.js";
+
+export async function getMatch(matchId) {
+  if (!isValidId(matchId)) {
+    return {
+      match: null,
+      error: new Error("matchId: not a positive integer"),
+    };
+  }
+
+  const { data, error } = await fetchAuthenticatedData(
+    Endpoints.MATCHES.withId(matchId).href,
+  );
+
+  const match = error ? null : convertMatchData(data);
+  return { match, error };
+}

--- a/frontend/pong/js/api/tournaments/convertTournamentData.js
+++ b/frontend/pong/js/api/tournaments/convertTournamentData.js
@@ -17,19 +17,20 @@ const convertRoundData = (round, tournamentId) => {
   const { round_number, status, created_at, updated_at, matches } =
     round;
 
+  const roundNumber = round_number;
   return {
     tournamentId,
-    roundNumber: round_number,
+    roundNumber,
     status: convertStatus(status),
     createdAt: created_at,
     updatedAt: updated_at,
     matches: matches.map((match) =>
-      convertMatchData(match, tournamentId),
+      convertMatchData(match, tournamentId, roundNumber),
     ),
   };
 };
 
-const convertMatchData = (match, tournamentId) => {
+const convertMatchData = (match, tournamentId, roundNumber) => {
   const {
     id,
     round_id,
@@ -43,6 +44,7 @@ const convertMatchData = (match, tournamentId) => {
     tournamentId,
     matchId: id,
     roundId: round_id,
+    roundNumber,
     status: convertStatus(status),
     createdAt: created_at,
     updatedAt: updated_at,

--- a/frontend/pong/js/api/tournaments/getTournaments.js
+++ b/frontend/pong/js/api/tournaments/getTournaments.js
@@ -1,0 +1,21 @@
+import { Endpoints } from "../../constants/Endpoints";
+import { isNullOrValidId } from "../../utils/isNullOrValidId";
+import { fetchAuthenticatedAllData } from "../utils/fetchAuthenticatedAllData";
+import { convertTournamentData } from "./convertTournamentData.js";
+
+export async function getTournaments(userId = null) {
+  if (!isNullOrValidId(userId))
+    return {
+      tournaments: [],
+      error: new Error("id: not a positive integer"),
+    };
+
+  const tournamentsUrl = new URL(Endpoints.TOURNAMENTS.default.href);
+  if (userId) tournamentsUrl.searchParams.append("user-id", userId);
+
+  const { data, error } =
+    await fetchAuthenticatedAllData(tournamentsUrl);
+
+  const tournaments = error ? [] : data.map(convertTournamentData);
+  return { tournaments, error };
+}

--- a/frontend/pong/js/api/users/convertMyInfoData.js
+++ b/frontend/pong/js/api/users/convertMyInfoData.js
@@ -1,11 +1,10 @@
+import { convertUserData } from "./convertUserData";
+
 export const convertMyInfoData = (userData) => {
-  const { id, username, email, display_name, avatar } = userData;
+  const { email } = userData;
 
   return {
-    id,
-    username,
     email,
-    displayName: display_name,
-    avatar,
+    ...convertUserData(userData),
   };
 };

--- a/frontend/pong/js/components/dashboard/DashboardContainer.js
+++ b/frontend/pong/js/components/dashboard/DashboardContainer.js
@@ -1,3 +1,4 @@
+import { BootstrapBadge } from "../../bootstrap/components/badge";
 import { BootstrapGrid } from "../../bootstrap/layout/grid";
 import { BootstrapDisplay } from "../../bootstrap/utilities/display";
 import { BootstrapFlex } from "../../bootstrap/utilities/flex";
@@ -5,8 +6,13 @@ import { BootstrapSizing } from "../../bootstrap/utilities/sizing";
 import { BootstrapSpacing } from "../../bootstrap/utilities/spacing";
 import { Component } from "../../core/Component";
 import { UserSessionManager } from "../../session/UserSessionManager";
-import { createAroundFlexBox } from "../../utils/elements/div/createFlexBox";
+import {
+  createAroundFlexBox,
+  createCenterFlexBox,
+  createDefaultFlexBox,
+} from "../../utils/elements/div/createFlexBox";
 import { createInlineListItem } from "../../utils/elements/li/createListItem";
+import { createTextElement } from "../../utils/elements/span/createTextElement";
 import { setHeight } from "../../utils/elements/style/setHeight";
 import { MatchCard } from "../match/MatchCard";
 import { UserProfile } from "../user/UserProfile";
@@ -51,16 +57,57 @@ export class DashboardContainer extends Component {
     BootstrapFlex.setFlexColumn(dashboardCard);
     BootstrapSizing.setHeight75(dashboardCard);
 
-    const matchHistory = new ListContainer({
-      ListItem: MatchCard,
-      items: matches,
-      createListItem: createInlineListItem,
-    });
+    const matchHistoryContainer =
+      createMatchHistoryContainer(matches);
 
-    setHeight(matchHistory, "75vh");
     BootstrapGrid.setCol(dashboardCard, 4);
-    BootstrapGrid.setCol(matchHistory, 6);
+    BootstrapGrid.setCol(matchHistoryContainer, 6);
 
-    this.append(dashboardCard, matchHistory);
+    this.append(dashboardCard, matchHistoryContainer);
   }
 }
+
+const createMatchHistoryContainer = (matches) => {
+  const title = createTextElement(
+    "マッチ履歴",
+    5,
+    BootstrapBadge.setPrimary,
+  );
+  BootstrapSpacing.setMargin(title, 3);
+
+  const matchHistoryPanel =
+    matches.length > 0 ? createMatchList(matches) : noMatchHistory();
+
+  const layout = createCenterFlexBox(title, matchHistoryPanel);
+  BootstrapFlex.setFlexColumn(layout);
+  BootstrapSizing.setHeight100(layout);
+
+  return layout;
+};
+
+const noMatchHistory = () => {
+  const content = createTextElement(
+    "マッチが見つかりませんでした。",
+    5,
+    BootstrapBadge.setSecondary,
+  );
+
+  const wrapper = createDefaultFlexBox(content);
+  setHeight(wrapper, "65vh");
+  BootstrapSpacing.setMargin(wrapper);
+
+  return wrapper;
+};
+
+const createMatchList = (matches) => {
+  const matchHistory = new ListContainer({
+    ListItem: MatchCard,
+    items: matches,
+    createListItem: createInlineListItem,
+  });
+  setHeight(matchHistory, "65vh");
+  BootstrapSizing.setWidth100(matchHistory);
+  BootstrapSpacing.setMargin(matchHistory);
+
+  return matchHistory;
+};

--- a/frontend/pong/js/components/dashboard/DashboardContainer.js
+++ b/frontend/pong/js/components/dashboard/DashboardContainer.js
@@ -1,0 +1,66 @@
+import { BootstrapGrid } from "../../bootstrap/layout/grid";
+import { BootstrapDisplay } from "../../bootstrap/utilities/display";
+import { BootstrapFlex } from "../../bootstrap/utilities/flex";
+import { BootstrapSizing } from "../../bootstrap/utilities/sizing";
+import { BootstrapSpacing } from "../../bootstrap/utilities/spacing";
+import { Component } from "../../core/Component";
+import { UserSessionManager } from "../../session/UserSessionManager";
+import { createAroundFlexBox } from "../../utils/elements/div/createFlexBox";
+import { createInlineListItem } from "../../utils/elements/li/createListItem";
+import { setHeight } from "../../utils/elements/style/setHeight";
+import { MatchCard } from "../match/MatchCard";
+import { UserProfile } from "../user/UserProfile";
+import { ErrorContainer } from "../utils/ErrorContainer";
+import { ListContainer } from "../utils/ListContainer";
+import { DashboardStats } from "./DashboardStats";
+
+export class DashboardContainer extends Component {
+  constructor(state = {}) {
+    super({ userId: null, tournaments: [], matches: [], ...state });
+  }
+
+  _setStyle() {
+    BootstrapDisplay.setFlex(this);
+    BootstrapFlex.setAlignItemsCenter(this);
+    BootstrapFlex.setJustifyContentAround(this);
+    BootstrapSizing.setWidth100(this);
+    BootstrapSizing.setHeight100(this);
+  }
+
+  _render() {
+    const { userId, tournaments, matches } = this._getState();
+    if (!userId) {
+      this._append(new ErrorContainer());
+      return;
+    }
+
+    const myInfo = UserSessionManager.getInstance().myInfo.observe(
+      (data) => data,
+    );
+    const profile = new UserProfile({ user: myInfo });
+    BootstrapSpacing.setMargin(profile, 3);
+
+    const stats = new DashboardStats({
+      userId,
+      matches,
+      tournaments,
+    });
+    BootstrapSpacing.setMargin(stats, 3);
+
+    const dashboardCard = createAroundFlexBox(profile, stats);
+    BootstrapFlex.setFlexColumn(dashboardCard);
+    BootstrapSizing.setHeight75(dashboardCard);
+
+    const matchHistory = new ListContainer({
+      ListItem: MatchCard,
+      items: matches,
+      createListItem: createInlineListItem,
+    });
+
+    setHeight(matchHistory, "75vh");
+    BootstrapGrid.setCol(dashboardCard, 4);
+    BootstrapGrid.setCol(matchHistory, 6);
+
+    this.append(dashboardCard, matchHistory);
+  }
+}

--- a/frontend/pong/js/components/dashboard/DashboardStats.js
+++ b/frontend/pong/js/components/dashboard/DashboardStats.js
@@ -51,9 +51,12 @@ export class DashboardStats extends Component {
     );
     BootstrapSpacing.setMargin(wonTournamentsIndex, 2);
 
-    const recentResults = createRecentResults(matches, userId);
+    this.append(winRate, wonTournamentsIndex);
 
-    this.append(winRate, wonTournamentsIndex, recentResults);
+    if (matches.length === 0) return;
+
+    const recentResults = createRecentResults(matches, userId);
+    this.append(recentResults);
   }
 }
 

--- a/frontend/pong/js/components/dashboard/DashboardStats.js
+++ b/frontend/pong/js/components/dashboard/DashboardStats.js
@@ -1,0 +1,112 @@
+import { BootstrapBadge } from "../../bootstrap/components/badge";
+import { BootstrapDisplay } from "../../bootstrap/utilities/display";
+import { BootstrapFlex } from "../../bootstrap/utilities/flex";
+import { BootstrapSizing } from "../../bootstrap/utilities/sizing";
+import { BootstrapSpacing } from "../../bootstrap/utilities/spacing";
+import { Component } from "../../core/Component";
+import { MatchEnums } from "../../enums/MatchEnums";
+import { TournamentEnums } from "../../enums/TournamentEnums";
+import { createCenterFlexBox } from "../../utils/elements/div/createFlexBox";
+import { createTextElement } from "../../utils/elements/span/createTextElement";
+import { getMatchResult } from "../../utils/match/getMatchResult";
+import { createScore } from "../match/createScore";
+import { ErrorContainer } from "../utils/ErrorContainer";
+
+export class DashboardStats extends Component {
+  constructor(state = {}) {
+    super({ userId: null, tournaments: [], matches: [], ...state });
+  }
+
+  _setStyle() {
+    BootstrapDisplay.setFlex(this);
+    BootstrapFlex.setFlexColumn(this);
+    BootstrapFlex.setAlignItemsCenter(this);
+    BootstrapFlex.setJustifyContentAround(this);
+    BootstrapSizing.setWidth100(this);
+    BootstrapSizing.setHeight100(this);
+  }
+
+  _render() {
+    const { userId, tournaments, matches } = this._getState();
+    if (!userId) {
+      this._append(new ErrorContainer());
+      return;
+    }
+
+    const wonMatches = matches.filter((match) =>
+      isWin(match, userId),
+    );
+    const winRate = createTextElement(
+      `マッチ勝率: ${(getRate(wonMatches.length, matches.length) * 100).toFixed(2)} %`,
+      4,
+      BootstrapBadge.setPrimary,
+    );
+    BootstrapSpacing.setMargin(winRate, 2);
+
+    const wonTournaments = getWonTournaments(tournaments, userId);
+    const wonTournamentsIndex = createTextElement(
+      `トーナメント優勝: ${wonTournaments.length} / ${tournaments.length}`,
+      4,
+      BootstrapBadge.setSecondary,
+    );
+    BootstrapSpacing.setMargin(wonTournamentsIndex, 2);
+
+    const recentResults = createRecentResults(matches, userId);
+
+    this.append(winRate, wonTournamentsIndex, recentResults);
+  }
+}
+
+const getScore = (match, userId) => {
+  const [player1, player2] = match.players;
+  switch (userId) {
+    case player1.userId:
+      return player1.score;
+    case player2.userId:
+      return player2.score;
+    default:
+      return 0;
+  }
+};
+
+const getResult = (match, userId) => {
+  const [player1, player2] = match.players;
+  const [result1, result2] = getMatchResult(player1, player2);
+  switch (userId) {
+    case player1.userId:
+      return result1;
+    case player2.userId:
+      return result2;
+    default:
+      return MatchEnums.Result.PENDING;
+  }
+};
+
+const isWin = (match, userId) =>
+  getResult(match, userId) === MatchEnums.Result.WIN;
+
+const isFinalMatch = (match) =>
+  match.status === TournamentEnums.Status.FINISHED &&
+  match.roundNumber === 2;
+
+const getWonTournaments = (matches, userId) =>
+  matches.filter(
+    (match) => isFinalMatch(match) && isWin(match, userId),
+  );
+
+const createRecentResults = (matches, userId) => {
+  const recentMatches = matches
+    .filter(
+      (match) => match.status === TournamentEnums.Status.FINISHED,
+    )
+    .slice()
+    .sort((a, b) => b.createdAt - a.createdAt)
+    .slice(0, 10);
+  const recentResults = recentMatches.map((match) =>
+    createScore(getScore(match, userId), getResult(match, userId)),
+  );
+  const results = createCenterFlexBox(...recentResults);
+  return results;
+};
+
+const getRate = (num, total) => (total === 0 ? 0 : num / total);

--- a/frontend/pong/js/components/dashboard/DashboardStats.js
+++ b/frontend/pong/js/components/dashboard/DashboardStats.js
@@ -43,7 +43,7 @@ export class DashboardStats extends Component {
     );
     BootstrapSpacing.setMargin(winRate, 2);
 
-    const wonTournaments = getWonTournaments(tournaments, userId);
+    const wonTournaments = getWonTournaments(matches, userId);
     const wonTournamentsIndex = createTextElement(
       `トーナメント優勝: ${wonTournaments.length} / ${tournaments.length}`,
       4,

--- a/frontend/pong/js/components/index.js
+++ b/frontend/pong/js/components/index.js
@@ -14,16 +14,19 @@ import { ChatGlobal } from "./chat/ChatGlobal";
 import { ChatInputForm } from "./chat/ChatInputForm";
 import { ChatMessageListItem } from "./chat/ChatMessageListItem";
 import { ChatPanel } from "./chat/ChatPanel";
+import { DashboardContainer } from "./dashboard/DashboardContainer";
+import { DashboardStats } from "./dashboard/DashboardStats";
 import { AddFriendButton } from "./friend/AddFriendButton";
 import { RemoveFriendButton } from "./friend/RemoveFriendButton";
 import { GameStartPanel } from "./game/GameStartPanel";
+import { MatchBoard } from "./match/MatchBoard";
+import { MatchCard } from "./match/MatchCard";
 import { MatchContainer } from "./match/MatchContainer";
 import { MatchRenderer } from "./match/MatchRenderer";
 import { MatchRenderer3D } from "./match/MatchRenderer3D";
+import { PlayerProfile } from "./match/PlayerProfile";
 import { MainNavbar } from "./navigation/MainNavbar";
-import { MatchCard } from "./tournament/MatchCard";
 import { ParticipationProfile } from "./tournament/ParticipationProfile";
-import { PlayerProfile } from "./tournament/PlayerProfile";
 import { RoundCard } from "./tournament/RoundCard";
 import { TournamentContainer } from "./tournament/TournamentContainer";
 import { TournamentEntrance } from "./tournament/TournamentEntrance";
@@ -85,20 +88,23 @@ customElements.define(
   {},
 );
 customElements.define("chat-panel", ChatPanel, {});
+customElements.define("dashboard-container", DashboardContainer, {});
+customElements.define("dashboard-stats", DashboardStats, {});
 customElements.define("add-friend-button", AddFriendButton, {});
 customElements.define("remove-friend-button", RemoveFriendButton, {});
 customElements.define("game-start-panel", GameStartPanel, {});
+customElements.define("match-board", MatchBoard, {});
+customElements.define("match-card", MatchCard, {});
 customElements.define("match-container", MatchContainer, {});
 customElements.define("match-renderer", MatchRenderer, {});
 customElements.define("match-renderer-3d", MatchRenderer3D, {});
+customElements.define("player-profile", PlayerProfile, {});
 customElements.define("main-navbar", MainNavbar, {});
-customElements.define("match-card", MatchCard, {});
 customElements.define(
   "participation-profile",
   ParticipationProfile,
   {},
 );
-customElements.define("player-profile", PlayerProfile, {});
 customElements.define("round-card", RoundCard, {});
 customElements.define(
   "tournament-container",

--- a/frontend/pong/js/components/index.js
+++ b/frontend/pong/js/components/index.js
@@ -48,6 +48,7 @@ import { EventDispatchingButton } from "./utils/EventDispatchingButton";
 import { LinkButton } from "./utils/LinkButton";
 import { ListContainer } from "./utils/ListContainer";
 import { ObservableInput } from "./utils/ObservableInput";
+import { DashboardView } from "./views/DashboardView";
 import { ErrorView } from "./views/ErrorView";
 import { FriendsView } from "./views/FriendsView";
 import { HomeView } from "./views/HomeView";
@@ -154,6 +155,7 @@ customElements.define(
 customElements.define("link-button", LinkButton, {});
 customElements.define("list-container", ListContainer, {});
 customElements.define("observable-input", ObservableInput, {});
+customElements.define("dashboard-view", DashboardView, {});
 customElements.define("error-view", ErrorView, {});
 customElements.define("friends-view", FriendsView, {});
 customElements.define("home-view", HomeView, {});

--- a/frontend/pong/js/components/match/MatchBoard.js
+++ b/frontend/pong/js/components/match/MatchBoard.js
@@ -1,0 +1,104 @@
+import { getMatch } from "../../api/matches/getMatch";
+import { BootstrapBackground } from "../../bootstrap/utilities/background";
+import { BootstrapBorders } from "../../bootstrap/utilities/borders";
+import { BootstrapDisplay } from "../../bootstrap/utilities/display";
+import { BootstrapFlex } from "../../bootstrap/utilities/flex";
+import { BootstrapSizing } from "../../bootstrap/utilities/sizing";
+import { BootstrapSpacing } from "../../bootstrap/utilities/spacing";
+import { Component } from "../../core/Component";
+import { createEndFlexBox } from "../../utils/elements/div/createFlexBox";
+import { createTextElement } from "../../utils/elements/span/createTextElement";
+import { createMatchCanvas } from "../../utils/match/createMatchCanvas";
+import { CanvasEntity } from "../../utils/match/entity/CanvasEntity";
+import { createInitialMatchEntities } from "../../utils/match/entity/createInitialMatchEntities";
+import { createScoreHistoryEntities } from "../../utils/match/entity/createScoreHistoryEntities";
+
+export class MatchBoard extends Component {
+  #isHidden;
+  #canvas;
+  #entities;
+  #headerBar;
+
+  constructor(state = {}) {
+    super({ matchId: null, entities: [], ...state });
+    this.#isHidden = true;
+  }
+
+  _setStyle() {
+    BootstrapDisplay.setFlex(this);
+    BootstrapFlex.setFlexColumn(this);
+    BootstrapFlex.setAlignItemsCenter(this);
+    BootstrapFlex.setJustifyContentCenter(this);
+
+    BootstrapBackground.setDarkSubtle(this.#headerBar);
+    BootstrapBorders.setRounded(this.#headerBar);
+    BootstrapSizing.setWidth100(this.#headerBar);
+    BootstrapSpacing.setMargin(this.#headerBar);
+  }
+
+  _onConnect() {
+    this.#canvas = createMatchCanvas();
+    this.#entities = createInitialMatchEntities();
+
+    const { createdAt } = this._getState();
+    const createdTimestamp = createTextElement(
+      new Date(createdAt).toLocaleString(),
+      6,
+    );
+
+    const detailScores = createTextElement("ℹ️", 6);
+    BootstrapSpacing.setMarginLeft(detailScores, 3);
+    BootstrapSpacing.setMargin(detailScores, 1);
+    this.#headerBar = createEndFlexBox(
+      createdTimestamp,
+      detailScores,
+    );
+    this.#headerBar.setAttribute("role", "button");
+
+    this._attachEventListener("click", (event) => {
+      event.preventDefault();
+      this.#isHidden = !this.#isHidden;
+      if (!this.#isHidden) this.reload();
+      else this._updateState();
+    });
+  }
+
+  _onDisconnect() {
+    this.#canvas = null;
+  }
+
+  _render() {
+    this.append(this.#headerBar);
+    if (this.#isHidden) return;
+
+    draw(this.#canvas, this.#entities);
+    this.append(this.#canvas);
+  }
+
+  reload() {
+    const { matchId } = this._getState();
+    getMatch(matchId).then(({ match, error }) => {
+      if (error) return;
+
+      const ratio = this.#canvas.height / this.#canvas.width;
+      this.#canvas.width = this.clientWidth;
+      this.#canvas.height = this.clientWidth * ratio;
+
+      const { players } = match;
+      const scores = players.flatMap(({ scores }) => scores);
+      this.#entities = createScoreHistoryEntities(
+        this.#canvas.width,
+        ...scores,
+      );
+      this._updateState();
+    });
+  }
+}
+
+const draw = (canvas, entities) => {
+  const ctx = canvas.getContext("2d");
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  for (const entity of entities) {
+    if (entity instanceof CanvasEntity) entity.draw(ctx);
+  }
+};

--- a/frontend/pong/js/components/match/MatchCard.js
+++ b/frontend/pong/js/components/match/MatchCard.js
@@ -5,9 +5,19 @@ import { createEndFlexBox } from "../../utils/elements/div/createFlexBox";
 import { createThreeColumnLayout } from "../../utils/elements/div/createThreeColumnLayout";
 import { getMatchResult } from "../../utils/match/getMatchResult";
 import { createStatusBadge } from "../../utils/tournament/createStatusBadge";
+import { MatchBoard } from "./MatchBoard";
 import { PlayerProfile } from "./PlayerProfile";
 
 export class MatchCard extends Component {
+  #matchBoard;
+
+  _onConnect() {
+    const {
+      item: { matchId, createdAt },
+    } = this._getState();
+    this.#matchBoard = new MatchBoard({ matchId, createdAt });
+  }
+
   _render() {
     const {
       item: { players, status },
@@ -32,6 +42,6 @@ export class MatchCard extends Component {
       2,
     );
     const card = createDefaultCard({ text });
-    this.append(card);
+    this.append(card, this.#matchBoard);
   }
 }

--- a/frontend/pong/js/components/match/PlayerProfile.js
+++ b/frontend/pong/js/components/match/PlayerProfile.js
@@ -1,12 +1,9 @@
 import { getParticipations } from "../../api/participations/getParticipations";
-import { BootstrapBadge } from "../../bootstrap/components/badge";
 import { BootstrapSpacing } from "../../bootstrap/utilities/spacing";
-import { BootstrapText } from "../../bootstrap/utilities/text";
 import { Component } from "../../core/Component";
-import { MatchEnums } from "../../enums/MatchEnums";
-import { createElement } from "../../utils/elements/createElement";
 import { createStartFlexBox } from "../../utils/elements/div/createFlexBox";
-import { ParticipationProfile } from "./ParticipationProfile";
+import { ParticipationProfile } from "../tournament/ParticipationProfile";
+import { createScore } from "./createScore";
 
 export class PlayerProfile extends Component {
   static #DEFAULT_HEIGHT = "max(15px, 3vh)";
@@ -45,25 +42,3 @@ export class PlayerProfile extends Component {
     this.append(container);
   }
 }
-
-const createScore = (scoreNum, matchResult) => {
-  const score = createElement("div", { textContent: `${scoreNum}` });
-
-  BootstrapText.setFontSize(score, 4);
-
-  switch (matchResult) {
-    case MatchEnums.Result.WIN:
-      BootstrapBadge.setSuccess(score);
-      break;
-    case MatchEnums.Result.LOSE:
-      BootstrapBadge.setDanger(score);
-      break;
-    case MatchEnums.Result.PENDING:
-      BootstrapBadge.setSecondary(score);
-      break;
-    default:
-      BootstrapBadge.setSecondary(score);
-      break;
-  }
-  return score;
-};

--- a/frontend/pong/js/components/match/createScore.js
+++ b/frontend/pong/js/components/match/createScore.js
@@ -1,0 +1,26 @@
+import { BootstrapBadge } from "../../bootstrap/components/badge";
+import { BootstrapText } from "../../bootstrap/utilities/text";
+import { MatchEnums } from "../../enums/MatchEnums";
+import { createElement } from "../../utils/elements/createElement";
+
+export const createScore = (scoreNum, matchResult) => {
+  const score = createElement("div", { textContent: `${scoreNum}` });
+
+  BootstrapText.setFontSize(score, 4);
+
+  switch (matchResult) {
+    case MatchEnums.Result.WIN:
+      BootstrapBadge.setSuccess(score);
+      break;
+    case MatchEnums.Result.LOSE:
+      BootstrapBadge.setDanger(score);
+      break;
+    case MatchEnums.Result.PENDING:
+      BootstrapBadge.setSecondary(score);
+      break;
+    default:
+      BootstrapBadge.setSecondary(score);
+      break;
+  }
+  return score;
+};

--- a/frontend/pong/js/components/navigation/MainNavbar.js
+++ b/frontend/pong/js/components/navigation/MainNavbar.js
@@ -10,6 +10,7 @@ export class MainNavbar extends Component {
     { name: "ホーム", path: Paths.HOME },
     { name: "ユーザー一覧", path: Paths.USERS },
     { name: "フレンド一覧", path: Paths.FRIENDS },
+    { name: "ダッシュボード", path: Paths.DASHBOARD },
     { name: "マイページ", path: Paths.MYPAGE },
   ]);
 

--- a/frontend/pong/js/components/tournament/RoundCard.js
+++ b/frontend/pong/js/components/tournament/RoundCard.js
@@ -6,8 +6,8 @@ import { createDefaultCard } from "../../utils/elements/div/createDefaultCard";
 import { createStartFlexBox } from "../../utils/elements/div/createFlexBox";
 import { createInlineListItem } from "../../utils/elements/li/createListItem";
 import { createStatusBadge } from "../../utils/tournament/createStatusBadge";
+import { MatchCard } from "../match/MatchCard";
 import { ListContainer } from "../utils/ListContainer";
-import { MatchCard } from "./MatchCard";
 
 export class RoundCard extends Component {
   _setStyle() {

--- a/frontend/pong/js/components/user/UserProfile.js
+++ b/frontend/pong/js/components/user/UserProfile.js
@@ -6,6 +6,7 @@ import { BootstrapSizing } from "../../bootstrap/utilities/sizing";
 import { BootstrapSpacing } from "../../bootstrap/utilities/spacing";
 import { BootstrapText } from "../../bootstrap/utilities/text";
 import { Component } from "../../core/Component";
+import { UserSessionManager } from "../../session/UserSessionManager";
 import { createElement } from "../../utils/elements/createElement";
 import { createDefaultCard } from "../../utils/elements/div/createDefaultCard";
 import { createNameplate } from "../../utils/elements/div/createNameplate";
@@ -38,7 +39,6 @@ export class UserProfile extends Component {
 
   _render() {
     const { user } = this._getState();
-
     if (!user) {
       const placeholderText = createTextElement(
         "ユーザーを選択してください",
@@ -50,6 +50,10 @@ export class UserProfile extends Component {
     }
 
     const nameplate = createNameplate(user, "8vh");
+    const isMe =
+      UserSessionManager.getInstance().myInfo.observe(
+        ({ id }) => id,
+      ) === user.id;
 
     const matchResult = createTextElement(
       `勝: ${user.matchWins} | 敗 : ${user.matchLosses}`,
@@ -62,7 +66,7 @@ export class UserProfile extends Component {
       createDefaultCard({
         title: nameplate,
         text: matchResult,
-        others: [profileButtonPanel],
+        others: isMe ? [] : [profileButtonPanel],
       }),
     );
   }

--- a/frontend/pong/js/components/views/DashboardView.js
+++ b/frontend/pong/js/components/views/DashboardView.js
@@ -1,0 +1,9 @@
+import { AuthView } from "../../core/AuthView";
+
+export class DashboardView extends AuthView {
+  _onConnect() {}
+
+  _render() {
+    this.append("dashboard");
+  }
+}

--- a/frontend/pong/js/components/views/MainView.js
+++ b/frontend/pong/js/components/views/MainView.js
@@ -17,6 +17,7 @@ export class MainView extends View {
     HOME: "/",
     USERS: "/users",
     FRIENDS: "/friends",
+    DASHBOARD: "/dashboard",
     MYPAGE: "/mypage",
     TOURNAMENTS: "/tournaments",
     NOT_FOUND: "/not-found",

--- a/frontend/pong/js/constants/Endpoints.js
+++ b/frontend/pong/js/constants/Endpoints.js
@@ -37,6 +37,11 @@ export const Endpoints = Object.freeze({
     withId: (tournamentId) =>
       new URL(`${tournamentId}/`, Endpoints.TOURNAMENTS.default),
   },
+  MATCHES: {
+    default: new URL("/api/matches/", BASE_URL),
+    withId: (matchId) =>
+      new URL(`${matchId}/`, Endpoints.MATCHES.default),
+  },
 
   ACCOUNTS: new URL("/api/accounts/", BASE_URL),
 });

--- a/frontend/pong/js/constants/Paths.js
+++ b/frontend/pong/js/constants/Paths.js
@@ -4,6 +4,7 @@ export const Paths = Object.freeze({
   HOME: "/",
   USERS: "/users",
   FRIENDS: "/friends",
+  DASHBOARD: "/dashboard",
   MYPAGE: "/mypage",
   TOURNAMENTS: "/tournaments",
 });

--- a/frontend/pong/js/mocks/handlers/participations.js
+++ b/frontend/pong/js/mocks/handlers/participations.js
@@ -34,7 +34,12 @@ export const handlers = [
 
       return HttpResponse.json({
         status: "ok",
-        data: participations,
+        data: {
+          count: participations.length,
+          next: null,
+          previous: null,
+          results: participations,
+        },
       });
     },
   ),

--- a/frontend/pong/js/routers/appRouter.js
+++ b/frontend/pong/js/routers/appRouter.js
@@ -1,3 +1,4 @@
+import { DashboardView } from "../components/views/DashboardView";
 import { LoginView } from "../components/views/LoginView";
 import { MainView } from "../components/views/MainView";
 import { SignUpView } from "../components/views/SignUpView";
@@ -15,6 +16,10 @@ export const appRouter = (target) => {
     [Paths.FRIENDS]: Route.createRoute(
       MainView,
       MainView.Paths.FRIENDS,
+    ),
+    [Paths.DASHBOARD]: Route.createRoute(
+      MainView,
+      MainView.Paths.DASHBOARD,
     ),
     [Paths.MYPAGE]: Route.createRoute(
       MainView,

--- a/frontend/pong/js/routers/mainRouter.js
+++ b/frontend/pong/js/routers/mainRouter.js
@@ -1,3 +1,4 @@
+import { DashboardView } from "../components/views/DashboardView";
 import { ErrorView } from "../components/views/ErrorView";
 import { FriendsView } from "../components/views/FriendsView";
 import { HomeView } from "../components/views/HomeView";
@@ -15,6 +16,7 @@ export const mainRouter = (target) => {
     [MainView.Paths.HOME]: Route.defaultRoute(HomeView),
     [MainView.Paths.USERS]: Route.defaultRoute(UsersView),
     [MainView.Paths.FRIENDS]: Route.defaultRoute(FriendsView),
+    [MainView.Paths.DASHBOARD]: Route.defaultRoute(DashboardView),
     [MainView.Paths.MYPAGE]: Route.defaultRoute(MyPageView),
     [MainView.Paths.TOURNAMENTS]: Route.defaultRoute(TournamentsView),
     [MainView.Paths.NOT_FOUND]: Route.defaultRoute(NotFoundView),

--- a/frontend/pong/js/utils/match/entity/ScoreHistoryEntity.js
+++ b/frontend/pong/js/utils/match/entity/ScoreHistoryEntity.js
@@ -1,0 +1,28 @@
+import { CanvasEntity } from "./CanvasEntity";
+
+export class ScoreHistoryEntity extends CanvasEntity {
+  #pos;
+  #label;
+  #color;
+
+  constructor(x, y, label, color = "red") {
+    super(color);
+    this.#pos = { x, y };
+    this.#label = label;
+    this.#color = color;
+  }
+
+  _draw(ctx) {
+    ctx.beginPath();
+    ctx.arc(this.#pos.x, this.#pos.y, 5, 0, 2 * Math.PI);
+    ctx.fillStyle = this.#color;
+    ctx.fill();
+
+    ctx.fillStyle = "black";
+    ctx.font = "14px Arial";
+    ctx.textAlign = "center";
+    ctx.textBaseline = "top";
+    ctx.fillText(this.#label, this.#pos.x + 10, this.#pos.y - 10);
+    return;
+  }
+}

--- a/frontend/pong/js/utils/match/entity/createScoreHistoryEntities.js
+++ b/frontend/pong/js/utils/match/entity/createScoreHistoryEntities.js
@@ -1,0 +1,30 @@
+import { MatchConstants } from "../../../constants/MatchConstants";
+import { BorderEntity } from "./BorderEntity";
+import { ScoreHistoryEntity } from "./ScoreHistoryEntity";
+
+export const createScoreHistoryEntities = (width, ...scores) => {
+  const ratio = width / MatchConstants.BOARD_WIDTH;
+  const offsetX = 0.05 * width;
+  const offsetY = 0.05 * ratio * MatchConstants.BOARD_HEIGHT;
+  const scale = 0.9 * ratio;
+
+  const border = new BorderEntity(
+    offsetX,
+    offsetY,
+    MatchConstants.BOARD_WIDTH * scale,
+    MatchConstants.BOARD_HEIGHT * scale,
+  );
+  return [
+    border,
+    ...scores
+      .sort((a, b) => a.createdAt - b.createdAt)
+      .map(
+        ({ posX, posY }, index) =>
+          new ScoreHistoryEntity(
+            offsetX + posX * scale,
+            offsetY + posY * scale,
+            index + 1,
+          ),
+      ),
+  ];
+};

--- a/frontend/pong/js/utils/match/extractMatches.js
+++ b/frontend/pong/js/utils/match/extractMatches.js
@@ -1,0 +1,11 @@
+export const extractMatches = (tournaments, userId) =>
+  tournaments
+    .map((tournament) =>
+      tournament.rounds.map((round) =>
+        round.matches.filter((match) => hasRelation(match, userId)),
+      ),
+    )
+    .flat(Number.POSITIVE_INFINITY);
+
+const hasRelation = (match, userId) =>
+  match.players.some((player) => player.userId === userId);


### PR DESCRIPTION
## タスクやディスカッションのリンク
- #409 

## やったこと
- ダッシュボードを追加
  - マッチ勝率
  - トーナメント優勝情報
  - 直近のマッチ結果をタイル表示
  - マッチ履歴: スコアが発生したポジション情報の視覚化

## やらないこと
特になし

## 動作確認
- `make` 後、ホームよりダッシュボードを確認

## 特にレビューをお願いしたい箇所
特になし

## その他
特になし

## 参考リンク
- https://www.notion.so/Dashboard-610e35a0650e4a20bfa7dbec832eb22e?pvs=4