### PR TITLE
🐛 [mock] mock tornament の team 番号修正

### DIFF
--- a/backend/pong/pong/management/commands/create_mock_tournament.py
+++ b/backend/pong/pong/management/commands/create_mock_tournament.py
@@ -136,11 +136,11 @@ class Command(BaseCommand):
         self, match: Match, players: list[Player]
     ) -> list[MatchParticipation]:
         match_participations: list[MatchParticipation] = []
-        for player in players:
+        for team_number, player in enumerate(players, start=1):
             participation = MatchParticipation.objects.create(
                 match=match,
                 player=player,
-                team="1",
+                team=str(team_number),
             )
             match_participations.append(participation)
         return match_participations


### PR DESCRIPTION
## タスクやディスカッションのリンク
<!-- - URLをここに貼る -->
- #492 

## やったこと
<!-- - このタスクでやったことはなにか？ -->
mock tournament で team 番号を適当につけてしまっていたので、1, 2 とつけるように修正

## やらないこと
<!-- - このタスクでやらないことはなにか？（やらない場合いつやるのか？無ければ「なし」を記述） -->

## 動作確認
<!-- - どのような動作確認を行い、結果はどうだったのか？(適宜スクショ等添付) -->

## 特にレビューをお願いしたい箇所
<!-- - 特にチェックをお願いしたいポイントを簡潔に記述する -->

## その他
<!-- - 実装上の懸念点、注意点等あれば記載する -->

## 参考リンク
<!-- - 実装に際し参考にした、記事やサイトのリンクを記載する -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - トーナメント作成時に、各参加者へ参加順に基づくユニークなチーム番号が正しく割り当てられるよう改善しました。これにより、試合のチーム構成がより正確かつ信頼性のあるものになっています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->