### PR TITLE
🌱 (FE) OAuth 2.0 入口と出口を対応

### DIFF
--- a/frontend/pong/js/api/utils/startOauth.js
+++ b/frontend/pong/js/api/utils/startOauth.js
@@ -1,0 +1,11 @@
+import { Endpoints } from "../../constants/Endpoints";
+
+export async function startOauth() {
+  const response = await fetch(Endpoints.OAUTH.href, {
+    redirect: "manual",
+  });
+  if (response.type === "opaqueredirect") {
+    window.location.href = response.url;
+  }
+  return response;
+}

--- a/frontend/pong/js/components/auth/LoginContainer.js
+++ b/frontend/pong/js/components/auth/LoginContainer.js
@@ -76,8 +76,9 @@ export class LoginContainer extends Component {
     const submitButton = document.createElement("button");
     submitButton.type = "submit";
     submitButton.textContent = "サインイン";
-    BootstrapButtons.setOutlinePrimary(submitButton);
+    BootstrapButtons.setPrimary(submitButton);
     BootstrapSpacing.setMargin(submitButton);
+    BootstrapSizing.setWidth25(submitButton);
 
     // ゲストボタン作成
     const guestButton = new LinkButton({
@@ -86,14 +87,18 @@ export class LoginContainer extends Component {
     });
     guestButton.setSecondary();
     BootstrapSpacing.setMargin(guestButton);
+    BootstrapSizing.setWidth25(guestButton);
 
     // 42 OAuth2.0ボタン作成
     const oauthButton = new OauthButton();
     BootstrapSpacing.setMargin(oauthButton);
+    BootstrapSizing.setWidth25(oauthButton);
 
     // サインアップボタン作成
     const signupButton = new SignUpButton();
+    signupButton.setOutlinePrimary();
     BootstrapSpacing.setMargin(signupButton);
+    BootstrapSizing.setWidth25(signupButton);
 
     form.append(
       this.#loginError,

--- a/frontend/pong/js/components/auth/LoginContainer.js
+++ b/frontend/pong/js/components/auth/LoginContainer.js
@@ -12,6 +12,7 @@ import { UserSessionManager } from "../../session/UserSessionManager";
 import { setClassNames } from "../../utils/elements/setClassNames";
 import { createTextElement } from "../../utils/elements/span/createTextElement";
 import { LinkButton } from "../utils/LinkButton";
+import { OauthButton } from "./OauthButton";
 import { SignUpButton } from "./SignUpButton";
 
 export class LoginContainer extends Component {
@@ -87,11 +88,8 @@ export class LoginContainer extends Component {
     BootstrapSpacing.setMargin(guestButton);
 
     // 42 OAuth2.0ボタン作成
-    const oauth2Button = document.createElement("button");
-    oauth2Button.type = "button";
-    oauth2Button.textContent = "42 OAuth 2.0";
-    BootstrapButtons.setSecondary(oauth2Button);
-    BootstrapSpacing.setMargin(oauth2Button);
+    const oauthButton = new OauthButton();
+    BootstrapSpacing.setMargin(oauthButton);
 
     // サインアップボタン作成
     const signupButton = new SignUpButton();
@@ -103,7 +101,7 @@ export class LoginContainer extends Component {
       passwordInput,
       submitButton,
       signupButton,
-      oauth2Button,
+      oauthButton,
       guestButton,
     );
 

--- a/frontend/pong/js/components/auth/OauthButton.js
+++ b/frontend/pong/js/components/auth/OauthButton.js
@@ -1,0 +1,22 @@
+import { startOauth } from "../../api/utils/startOauth";
+import { StyledButton } from "../../core/StyledButton";
+
+export class OauthButton extends StyledButton {
+  constructor(state = {}, attributes = {}) {
+    super(
+      { textContent: "42 OAuth 2.0", ...state },
+      { type: "button", ...attributes },
+    );
+  }
+
+  _setStyle() {
+    this.setSuccess();
+  }
+
+  _onConnect() {
+    this._attachEventListener("click", async (event) => {
+      event.preventDefault();
+      await startOauth();
+    });
+  }
+}

--- a/frontend/pong/js/components/auth/SignInButton.js
+++ b/frontend/pong/js/components/auth/SignInButton.js
@@ -10,10 +10,6 @@ export class SignInButton extends StyledButton {
     );
   }
 
-  _setStyle() {
-    this.setOutlinePrimary();
-  }
-
   _onConnect() {
     this._attachEventListener("click", (event) => {
       event.preventDefault();

--- a/frontend/pong/js/components/auth/SignUpButton.js
+++ b/frontend/pong/js/components/auth/SignUpButton.js
@@ -10,10 +10,6 @@ export class SignUpButton extends StyledButton {
     );
   }
 
-  _setStyle() {
-    this.setPrimary();
-  }
-
   _onConnect() {
     this._attachEventListener("click", (event) => {
       event.preventDefault();

--- a/frontend/pong/js/components/auth/SignUpContainer.js
+++ b/frontend/pong/js/components/auth/SignUpContainer.js
@@ -90,6 +90,7 @@ export class SignUpContainer extends Component {
     submitButton.type = "submit";
     submitButton.textContent = "サインアップ";
     BootstrapButtons.setPrimary(submitButton);
+    BootstrapSizing.setWidth25(submitButton);
 
     form.append(
       this.#loginError,

--- a/frontend/pong/js/components/index.js
+++ b/frontend/pong/js/components/index.js
@@ -1,4 +1,5 @@
 import { LoginContainer } from "./auth/LoginContainer";
+import { OauthButton } from "./auth/OauthButton";
 import { SignInButton } from "./auth/SignInButton";
 import { SignOutButton } from "./auth/SignOutButton";
 import { SignUpButton } from "./auth/SignUpButton";
@@ -65,6 +66,7 @@ import { TournamentsView } from "./views/TournamentsView";
 import { UsersView } from "./views/UsersView";
 
 customElements.define("login-container", LoginContainer, {});
+customElements.define("oauth-button", OauthButton, {});
 customElements.define("sign-in-button", SignInButton, {});
 customElements.define("sign-out-button", SignOutButton, {});
 customElements.define("sign-up-button", SignUpButton, {});

--- a/frontend/pong/js/components/user/UserProfileHeader.js
+++ b/frontend/pong/js/components/user/UserProfileHeader.js
@@ -43,8 +43,10 @@ export class UserProfileHeader extends Component {
     const { user } = this._getState();
     if (!user) {
       const signIn = new SignInButton();
+      signIn.setOutlinePrimary();
       signIn.setSmall();
       const signUp = new SignUpButton();
+      signUp.setPrimary();
       signUp.setSmall();
       BootstrapSpacing.setMarginLeft(signUp, 3);
       this.append(signIn, signUp);

--- a/frontend/pong/js/constants/Endpoints.js
+++ b/frontend/pong/js/constants/Endpoints.js
@@ -44,4 +44,5 @@ export const Endpoints = Object.freeze({
   },
 
   ACCOUNTS: new URL("/api/accounts/", BASE_URL),
+  OAUTH: new URL("/api/oauth2/authorize/", BASE_URL),
 });

--- a/frontend/pong/js/constants/Paths.js
+++ b/frontend/pong/js/constants/Paths.js
@@ -7,4 +7,5 @@ export const Paths = Object.freeze({
   DASHBOARD: "/dashboard",
   MYPAGE: "/mypage",
   TOURNAMENTS: "/tournaments",
+  OAUTH: "/oauth2/",
 });

--- a/frontend/pong/js/main.js
+++ b/frontend/pong/js/main.js
@@ -5,13 +5,15 @@ import { PongEvents } from "./constants/PongEvents";
 import { Route } from "./core/Route";
 import { appRouter } from "./routers/appRouter";
 import { UserSessionManager } from "./session/UserSessionManager";
+import { handleAuthPath } from "./utils/handleAuthPath";
 
 function main() {
   const app = document.getElementById("app");
   const appLocal = document.getElementById("app-local");
   const appGlobal = document.getElementById("app-global");
   const router = appRouter(appLocal);
-  const updateWindowPath = () => {
+  const updateWindowPath = async () => {
+    if (await handleAuthPath()) return;
     router.update(window.location.pathname);
   };
   window.addEventListener("popstate", updateWindowPath);

--- a/frontend/pong/js/session/UserSession.js
+++ b/frontend/pong/js/session/UserSession.js
@@ -31,9 +31,9 @@ export class UserSession {
     app.dispatchEvent(PongEvents.UPDATE_ROUTER.create(path));
   }
 
-  updateWindowPath() {
+  async updateWindowPath() {
     const { updateWindowPath } = this.#apps;
-    updateWindowPath();
+    await updateWindowPath();
   }
 
   async main(apps) {
@@ -42,7 +42,7 @@ export class UserSession {
     const isValid = await this.#reset();
     if (isValid) {
       await this.signIn();
-      this.updateWindowPath();
+      await this.updateWindowPath();
     }
     return isValid;
   }
@@ -81,6 +81,8 @@ export class UserSession {
         user_id: id,
       });
       // initGlobalFeatures(appGlobal);
+    } else {
+      this.#clearTokens();
     }
     return isVerified;
   }
@@ -88,7 +90,7 @@ export class UserSession {
   async signOut() {
     this.#clearTokens();
     const isValid = await this.#reset();
-    if (isValid) this.updateWindowPath();
+    if (isValid) await this.updateWindowPath();
     return isValid;
   }
 

--- a/frontend/pong/js/utils/handleAuthPath.js
+++ b/frontend/pong/js/utils/handleAuthPath.js
@@ -1,0 +1,24 @@
+import { Paths } from "../constants/Paths";
+import { UserSessionManager } from "../session/UserSessionManager";
+
+export const handleAuthPath = async () => {
+  if (window.location.pathname !== Paths.OAUTH) return false;
+
+  const params = new URLSearchParams(window.location.search);
+  const access = params.get("access");
+  const refresh = params.get("refresh");
+
+  window.history.replaceState(null, "", "/");
+
+  const isVerified =
+    access &&
+    refresh &&
+    (await UserSessionManager.getInstance().signIn({
+      access,
+      refresh,
+    }));
+  const nextPath = isVerified ? Paths.HOME : Paths.LOGIN;
+  UserSessionManager.getInstance().redirect(nextPath);
+
+  return true;
+};


### PR DESCRIPTION
## タスクやディスカッションのリンク
- #415 

## やったこと
- OAuth 2.0 の入口ボタンを追加
- 結果の認証データをハンドリングし、ホームやログインにリダイレクトさせる出口の対応も追加
- ログインページの色変更

## やらないこと
特になし

## 動作確認
`make` 後、ログインの [42 OAuth 2.0] よりサインインできるか確認

## 特にレビューをお願いしたい箇所
特になし

## その他
特になし

## 参考リンク
特になし


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - OAuth認証を利用したログインが導入され、専用のOAuthボタンで認証フローが改善されました。
  - 認証時のリダイレクトやトークン確認がスムーズになり、ログイン・サインアップの体験が向上しています。

- **スタイル**
  - ログインやサインアップ時のボタンの幅やデザインが統一・改善され、ユーザーインターフェースの見た目が一層洗練されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->