### PR TITLE
🐛 [schema] extend_schema の type のミス修正

### DIFF
--- a/backend/pong/accounts/views.py
+++ b/backend/pong/accounts/views.py
@@ -83,7 +83,7 @@ class AccountCreateView(views.APIView):
                 response={
                     "type": "object",
                     "properties": {
-                        custom_response.STATUS: {"type": ["string"]},
+                        custom_response.STATUS: {"type": "string"},
                         custom_response.CODE: {
                             "type": "array",
                             "items": {"type": "string"},

--- a/backend/pong/accounts/views.py
+++ b/backend/pong/accounts/views.py
@@ -84,7 +84,10 @@ class AccountCreateView(views.APIView):
                     "type": "object",
                     "properties": {
                         custom_response.STATUS: {"type": ["string"]},
-                        custom_response.CODE: {"type": ["list"]},
+                        custom_response.CODE: {
+                            "type": "array",
+                            "items": {"type": "string"},
+                        },
                     },
                 },
                 examples=[
@@ -123,7 +126,10 @@ class AccountCreateView(views.APIView):
                     "type": "object",
                     "properties": {
                         custom_response.STATUS: {"type": "string"},
-                        custom_response.CODE: {"type": "list"},
+                        custom_response.CODE: {
+                            "type": "array",
+                            "items": {"type": "string"},
+                        },
                     },
                 },
                 examples=[

--- a/backend/pong/jwt/views/refresh.py
+++ b/backend/pong/jwt/views/refresh.py
@@ -46,14 +46,17 @@ class TokenRefreshView(views.APIView):
             400: utils.OpenApiResponse(
                 response={
                     "type": "object",
-                    "properties": {"detail": {"type": "string"}},
+                    "properties": {
+                        "status": {"type": "string"},
+                        "code": {"type": "array", "items": {"type": "string"}},
+                    },
                 },
                 examples=[
                     utils.OpenApiExample(
                         "Example 400 response (リクエスト形式が不正の場合)",
                         value={
                             "status": "error",
-                            "code": "internal_error",
+                            "code": ["internal_error"],
                         },
                     ),
                 ],
@@ -62,28 +65,31 @@ class TokenRefreshView(views.APIView):
                 description="",
                 response={
                     "type": "object",
-                    "properties": {"detail": {"type": "string"}},
+                    "properties": {
+                        "status": {"type": "string"},
+                        "code": {"type": "array", "items": {"type": "string"}},
+                    },
                 },
                 examples=[
                     utils.OpenApiExample(
                         "Example 401 response (トークンの形式が間違ってる場合)",
                         value={
                             "status": "error",
-                            "code": "invalid",
+                            "code": ["invalid"],
                         },
                     ),
                     utils.OpenApiExample(
                         "Example 401 response (リフレッシュトークンの有効期限が切れている場合)",
                         value={
                             "status": "error",
-                            "code": "invalid",
+                            "code": ["invalid"],
                         },
                     ),
                     utils.OpenApiExample(
                         "Example 401 response (アカウントが存在しない場合)",
                         value={
                             "status": "error",
-                            "code": "not_exists",
+                            "code": ["not_exists"],
                         },
                     ),
                 ],
@@ -92,14 +98,17 @@ class TokenRefreshView(views.APIView):
                 description="",
                 response={
                     "type": "object",
-                    "properties": {"detail": {"type": "string"}},
+                    "properties": {
+                        "status": {"type": "string"},
+                        "code": {"type": "array", "items": {"type": "string"}},
+                    },
                 },
                 examples=[
                     utils.OpenApiExample(
                         "Example 500 response (予期せぬエラーの場合)",
                         value={
                             "status": "error",
-                            "code": "internal_error",
+                            "code": ["internal_error"],
                         },
                     ),
                 ],

--- a/backend/pong/jwt/views/token.py
+++ b/backend/pong/jwt/views/token.py
@@ -64,14 +64,17 @@ class TokenObtainView(views.APIView):
             400: utils.OpenApiResponse(
                 response={
                     "type": "object",
-                    "properties": {"detail": {"type": "string"}},
+                    "properties": {
+                        "status": {"type": "string"},
+                        "code": {"type": "array", "items": {"type": "string"}},
+                    },
                 },
                 examples=[
                     utils.OpenApiExample(
                         "Example 400 response(リクエスト形式が不正の場合)",
                         value={
                             "status": "error",
-                            "code": "internal_error",
+                            "code": ["internal_error"],
                         },
                     ),
                 ],
@@ -79,21 +82,24 @@ class TokenObtainView(views.APIView):
             401: utils.OpenApiResponse(
                 response={
                     "type": "object",
-                    "properties": {"detail": {"type": "string"}},
+                    "properties": {
+                        "status": {"type": "string"},
+                        "code": {"type": "array", "items": {"type": "string"}},
+                    },
                 },
                 examples=[
                     utils.OpenApiExample(
                         "Example 401 response (アカウントが存在しない場合)",
                         value={
                             "status": "error",
-                            "code": "not_exists",
+                            "code": ["not_exists"],
                         },
                     ),
                     utils.OpenApiExample(
                         "Example 401 response (パスワードが間違っている場合)",
                         value={
                             "status": "error",
-                            "code": "incorrect_password",
+                            "code": ["incorrect_password"],
                         },
                     ),
                 ],
@@ -102,14 +108,17 @@ class TokenObtainView(views.APIView):
                 description="",
                 response={
                     "type": "object",
-                    "properties": {"detail": {"type": "string"}},
+                    "properties": {
+                        "status": {"type": "string"},
+                        "code": {"type": "array", "items": {"type": "string"}},
+                    },
                 },
                 examples=[
                     utils.OpenApiExample(
                         "Example 500 response (予期せぬエラーの場合)",
                         value={
                             "status": "error",
-                            "code": "internal_error",
+                            "code": ["internal_error"],
                         },
                     ),
                 ],

--- a/backend/pong/login/views/login.py
+++ b/backend/pong/login/views/login.py
@@ -62,14 +62,17 @@ class LoginView(views.APIView):
             400: utils.OpenApiResponse(
                 response={
                     "type": "object",
-                    "properties": {"detail": {"type": "string"}},
+                    "properties": {
+                        "status": {"type": "string"},
+                        "code": {"type": "array", "items": {"type": "string"}},
+                    },
                 },
                 examples=[
                     utils.OpenApiExample(
                         "Example 400 response(リクエスト形式が不正の場合)",
                         value={
                             "status": "error",
-                            "code": "internal_error",
+                            "code": ["internal_error"],
                         },
                     ),
                 ],
@@ -77,21 +80,24 @@ class LoginView(views.APIView):
             401: utils.OpenApiResponse(
                 response={
                     "type": "object",
-                    "properties": {"detail": {"type": "string"}},
+                    "properties": {
+                        "status": {"type": "string"},
+                        "code": {"type": "array", "items": {"type": "string"}},
+                    },
                 },
                 examples=[
                     utils.OpenApiExample(
                         "Example 401 response (アカウントが存在しない場合)",
                         value={
                             "status": "error",
-                            "code": "not_exists",
+                            "code": ["not_exists"],
                         },
                     ),
                     utils.OpenApiExample(
                         "Example 401 response (パスワードが間違っている場合)",
                         value={
                             "status": "error",
-                            "code": "incorrect_password",
+                            "code": ["incorrect_password"],
                         },
                     ),
                 ],
@@ -100,14 +106,17 @@ class LoginView(views.APIView):
                 description="",
                 response={
                     "type": "object",
-                    "properties": {"detail": {"type": "string"}},
+                    "properties": {
+                        "status": {"type": "string"},
+                        "code": {"type": "array", "items": {"type": "string"}},
+                    },
                 },
                 examples=[
                     utils.OpenApiExample(
                         "Example 500 response (予期せぬエラーの場合)",
                         value={
                             "status": "error",
-                            "code": "internal_error",
+                            "code": ["internal_error"],
                         },
                     ),
                 ],

--- a/backend/pong/login/views/totp.py
+++ b/backend/pong/login/views/totp.py
@@ -65,14 +65,17 @@ class TotpView(views.APIView):
             400: utils.OpenApiResponse(
                 response={
                     "type": "object",
-                    "properties": {"detail": {"type": "string"}},
+                    "properties": {
+                        "status": {"type": "string"},
+                        "code": {"type": "array", "items": {"type": "string"}},
+                    },
                 },
                 examples=[
                     utils.OpenApiExample(
                         "Example 400 response(リクエスト形式が不正の場合)",
                         value={
                             "status": "error",
-                            "code": "internal_error",
+                            "code": ["internal_error"],
                         },
                     ),
                 ],
@@ -80,14 +83,17 @@ class TotpView(views.APIView):
             401: utils.OpenApiResponse(
                 response={
                     "type": "object",
-                    "properties": {"detail": {"type": "string"}},
+                    "properties": {
+                        "status": {"type": "string"},
+                        "code": {"type": "array", "items": {"type": "string"}},
+                    },
                 },
                 examples=[
                     utils.OpenApiExample(
                         "Example 401 response (ワンタイムパスワードが間違っている場合)",
                         value={
                             "status": "error",
-                            "code": "incorrect_password",
+                            "code": ["incorrect_password"],
                         },
                     ),
                 ],
@@ -96,14 +102,17 @@ class TotpView(views.APIView):
                 description="",
                 response={
                     "type": "object",
-                    "properties": {"detail": {"type": "string"}},
+                    "properties": {
+                        "status": {"type": "string"},
+                        "code": {"type": "array", "items": {"type": "string"}},
+                    },
                 },
                 examples=[
                     utils.OpenApiExample(
                         "Example 500 response (予期せぬエラーの場合)",
                         value={
                             "status": "error",
-                            "code": "internal_error",
+                            "code": ["internal_error"],
                         },
                     ),
                 ],

--- a/backend/pong/matches/views.py
+++ b/backend/pong/matches/views.py
@@ -216,7 +216,10 @@ from .match import serializers
                     "type": "object",
                     "properties": {
                         custom_response.STATUS: {"type": "string"},
-                        custom_response.CODE: {"type": "list"},
+                        custom_response.CODE: {
+                            "type": "array",
+                            "items": {"type": "string"},
+                        },
                         custom_response.ERRORS: {"type": "dict"},
                     },
                 },

--- a/backend/pong/matches/views.py
+++ b/backend/pong/matches/views.py
@@ -220,7 +220,7 @@ from .match import serializers
                             "type": "array",
                             "items": {"type": "string"},
                         },
-                        custom_response.ERRORS: {"type": "dict"},
+                        custom_response.ERRORS: {"type": "object"},
                     },
                 },
                 examples=[

--- a/backend/pong/tournaments/participation/views.py
+++ b/backend/pong/tournaments/participation/views.py
@@ -151,7 +151,10 @@ from . import models, serializers
                     "type": "object",
                     "properties": {
                         custom_response.STATUS: {"type": "string"},
-                        custom_response.CODE: {"type": "list"},
+                        custom_response.CODE: {
+                            "type": "array",
+                            "items": {"type": "string"},
+                        },
                         custom_response.ERRORS: {"type": "dict"},
                     },
                 },

--- a/backend/pong/tournaments/participation/views.py
+++ b/backend/pong/tournaments/participation/views.py
@@ -155,7 +155,7 @@ from . import models, serializers
                             "type": "array",
                             "items": {"type": "string"},
                         },
-                        custom_response.ERRORS: {"type": "dict"},
+                        custom_response.ERRORS: {"type": "object"},
                     },
                 },
                 examples=[

--- a/backend/pong/tournaments/tournament/views.py
+++ b/backend/pong/tournaments/tournament/views.py
@@ -442,7 +442,10 @@ from . import models, serializers
                     "type": "object",
                     "properties": {
                         custom_response.STATUS: {"type": "string"},
-                        custom_response.CODE: {"type": "list"},
+                        custom_response.CODE: {
+                            "type": "array",
+                            "items": {"type": "string"},
+                        },
                         custom_response.ERRORS: {"type": "dict"},
                     },
                 },

--- a/backend/pong/tournaments/tournament/views.py
+++ b/backend/pong/tournaments/tournament/views.py
@@ -446,7 +446,7 @@ from . import models, serializers
                             "type": "array",
                             "items": {"type": "string"},
                         },
-                        custom_response.ERRORS: {"type": "dict"},
+                        custom_response.ERRORS: {"type": "object"},
                     },
                 },
                 examples=[

--- a/backend/pong/users/blocks/views.py
+++ b/backend/pong/users/blocks/views.py
@@ -99,7 +99,10 @@ logger = logging.getLogger(__name__)
                     "type": "object",
                     "properties": {
                         custom_response.STATUS: {"type": "string"},
-                        custom_response.CODE: {"type": "list"},
+                        custom_response.CODE: {
+                            "type": "array",
+                            "items": {"type": "string"},
+                        },
                     },
                 },
                 examples=[
@@ -159,7 +162,10 @@ logger = logging.getLogger(__name__)
                     "type": "object",
                     "properties": {
                         custom_response.STATUS: {"type": "string"},
-                        custom_response.CODE: {"type": "list"},
+                        custom_response.CODE: {
+                            "type": "array",
+                            "items": {"type": "string"},
+                        },
                     },
                 },
                 examples=[
@@ -214,7 +220,10 @@ logger = logging.getLogger(__name__)
                     "type": "object",
                     "properties": {
                         custom_response.STATUS: {"type": "string"},
-                        custom_response.CODE: {"type": "list"},
+                        custom_response.CODE: {
+                            "type": "array",
+                            "items": {"type": "string"},
+                        },
                     },
                 },
                 examples=[
@@ -257,7 +266,10 @@ logger = logging.getLogger(__name__)
                     "type": "object",
                     "properties": {
                         custom_response.STATUS: {"type": "string"},
-                        custom_response.CODE: {"type": "list"},
+                        custom_response.CODE: {
+                            "type": "array",
+                            "items": {"type": "string"},
+                        },
                     },
                 },
                 examples=[
@@ -296,7 +308,10 @@ logger = logging.getLogger(__name__)
                     "type": "object",
                     "properties": {
                         custom_response.STATUS: {"type": "string"},
-                        custom_response.CODE: {"type": "list"},
+                        custom_response.CODE: {
+                            "type": "array",
+                            "items": {"type": "string"},
+                        },
                     },
                 },
                 examples=[

--- a/backend/pong/users/friends/views.py
+++ b/backend/pong/users/friends/views.py
@@ -97,7 +97,10 @@ logger = logging.getLogger(__name__)
                     "type": "object",
                     "properties": {
                         custom_response.STATUS: {"type": "string"},
-                        custom_response.CODE: {"type": "list"},
+                        custom_response.CODE: {
+                            "type": "array",
+                            "items": {"type": "string"},
+                        },
                     },
                 },
                 examples=[
@@ -155,7 +158,10 @@ logger = logging.getLogger(__name__)
                     "type": "object",
                     "properties": {
                         custom_response.STATUS: {"type": "string"},
-                        custom_response.CODE: {"type": "list"},
+                        custom_response.CODE: {
+                            "type": "array",
+                            "items": {"type": "string"},
+                        },
                     },
                 },
                 examples=[
@@ -210,7 +216,10 @@ logger = logging.getLogger(__name__)
                     "type": "object",
                     "properties": {
                         custom_response.STATUS: {"type": "string"},
-                        custom_response.CODE: {"type": "list"},
+                        custom_response.CODE: {
+                            "type": "array",
+                            "items": {"type": "string"},
+                        },
                     },
                 },
                 examples=[
@@ -253,7 +262,10 @@ logger = logging.getLogger(__name__)
                     "type": "object",
                     "properties": {
                         custom_response.STATUS: {"type": "string"},
-                        custom_response.CODE: {"type": "list"},
+                        custom_response.CODE: {
+                            "type": "array",
+                            "items": {"type": "string"},
+                        },
                     },
                 },
                 examples=[
@@ -292,7 +304,10 @@ logger = logging.getLogger(__name__)
                     "type": "object",
                     "properties": {
                         custom_response.STATUS: {"type": "string"},
-                        custom_response.CODE: {"type": "list"},
+                        custom_response.CODE: {
+                            "type": "array",
+                            "items": {"type": "string"},
+                        },
                     },
                 },
                 examples=[

--- a/backend/pong/users/views/list.py
+++ b/backend/pong/users/views/list.py
@@ -153,7 +153,10 @@ class UsersListView(views.APIView):
                     "type": "object",
                     "properties": {
                         custom_response.STATUS: {"type": "string"},
-                        custom_response.CODE: {"type": "list"},
+                        custom_response.CODE: {
+                            "type": "array",
+                            "items": {"type": "string"},
+                        },
                     },
                 },
                 examples=[

--- a/backend/pong/users/views/me.py
+++ b/backend/pong/users/views/me.py
@@ -119,7 +119,10 @@ class UsersMeView(views.APIView):
                     "type": "object",
                     "properties": {
                         custom_response.STATUS: {"type": "string"},
-                        custom_response.CODE: {"type": "list"},
+                        custom_response.CODE: {
+                            "type": "array",
+                            "items": {"type": "string"},
+                        },
                     },
                 },
                 examples=[
@@ -208,7 +211,10 @@ class UsersMeView(views.APIView):
                     "type": "object",
                     "properties": {
                         custom_response.STATUS: {"type": "string"},
-                        custom_response.CODE: {"type": "list"},
+                        custom_response.CODE: {
+                            "type": "array",
+                            "items": {"type": "string"},
+                        },
                     },
                 },
                 examples=[
@@ -243,7 +249,10 @@ class UsersMeView(views.APIView):
                     "type": "object",
                     "properties": {
                         custom_response.STATUS: {"type": "string"},
-                        custom_response.CODE: {"type": "list"},
+                        custom_response.CODE: {
+                            "type": "array",
+                            "items": {"type": "string"},
+                        },
                     },
                 },
                 examples=[

--- a/backend/pong/users/views/retrieve.py
+++ b/backend/pong/users/views/retrieve.py
@@ -116,7 +116,10 @@ class UsersRetrieveView(views.APIView):
                     "type": "object",
                     "properties": {
                         custom_response.STATUS: {"type": "string"},
-                        custom_response.CODE: {"type": "list"},
+                        custom_response.CODE: {
+                            "type": "array",
+                            "items": {"type": "string"},
+                        },
                     },
                 },
                 examples=[
@@ -137,7 +140,10 @@ class UsersRetrieveView(views.APIView):
                     "type": "object",
                     "properties": {
                         custom_response.STATUS: {"type": "string"},
-                        custom_response.CODE: {"type": "list"},
+                        custom_response.CODE: {
+                            "type": "array",
+                            "items": {"type": "string"},
+                        },
                     },
                 },
                 examples=[


### PR DESCRIPTION
## タスクやディスカッションのリンク
<!-- - URLをここに貼る -->
- #520 

## やったこと
<!-- - このタスクでやったことはなにか？ -->
extend_schame の修正のみです

- OpenAPI の型に `list` というのはなくて、`array` だったので修正
- `dict` もなかったので `object` に修正
- examples の `"code"` がただの `string` になっていた部分を `[ string ]` に修正
- `"string"` で良いのに `["string"]` になっていた部分を修正

## やらないこと
<!-- - このタスクでやらないことはなにか？（やらない場合いつやるのか？無ければ「なし」を記述） -->

## 動作確認
<!-- - どのような動作確認を行い、結果はどうだったのか？(適宜スクショ等添付) -->
swagger-ui で直っていること

## 特にレビューをお願いしたい箇所
<!-- - 特にチェックをお願いしたいポイントを簡潔に記述する -->

## その他
<!-- - 実装上の懸念点、注意点等あれば記載する -->

## 参考リンク
<!-- - 実装に際し参考にした、記事やサイトのリンクを記載する -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **リファクタ**
	- エラー応答の形式が統一され、エラーコードが文字列の配列形式で提供されるようになりました。
	- 複数のエンドポイントでエラー情報の明瞭性と一貫性が向上し、API の利用体験が改善されました。
- **新機能**
	- 新しい依存関係 `tblib` が追加されました。
- **依存関係の更新**
	- `attrs`、`iniconfig`、`pytest-asyncio`、`types-pyyaml`、`typing-extensions` のバージョンが更新されました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->