### PR TITLE
🐛 [avatar,test] sample.pngが削除されてしまう問題修正 

### DIFF
--- a/backend/pong/accounts/create_account/test_create_account.py
+++ b/backend/pong/accounts/create_account/test_create_account.py
@@ -10,7 +10,7 @@ from rest_framework import serializers
 from ..player import models
 from . import create_account
 
-MOCK_AVATAR_NAME: Final[str] = "avatars/sample.png"
+MOCK_AVATAR_NAME: Final[str] = "avatars/test.png"
 
 
 @dataclasses.dataclass(frozen=True)

--- a/backend/pong/accounts/player/tests/test_player_model.py
+++ b/backend/pong/accounts/player/tests/test_player_model.py
@@ -7,7 +7,7 @@ from django.test import TestCase
 from ... import constants
 from .. import models
 
-MOCK_AVATAR_NAME: Final[str] = "avatars/sample.png"
+MOCK_AVATAR_NAME: Final[str] = "avatars/test.png"
 
 
 # todo: PlayerModelにフィールドが追加された際にテストも追加

--- a/backend/pong/accounts/player/tests/test_player_serializer.py
+++ b/backend/pong/accounts/player/tests/test_player_serializer.py
@@ -18,7 +18,7 @@ USER: Final[str] = constants.PlayerFields.USER
 DISPLAY_NAME: Final[str] = constants.PlayerFields.DISPLAY_NAME
 AVATAR: Final[str] = constants.PlayerFields.AVATAR
 
-MOCK_AVATAR_NAME: Final[str] = "avatars/sample.png"
+MOCK_AVATAR_NAME: Final[str] = "avatars/test.png"
 
 
 class PlayerSerializerTests(TestCase):

--- a/backend/pong/accounts/tests/test_accounts.py
+++ b/backend/pong/accounts/tests/test_accounts.py
@@ -23,7 +23,7 @@ CODE_ALREADY_EXISTS: Final[str] = constants.Code.ALREADY_EXISTS
 CODE_INVALID_EMAIL: Final[str] = constants.Code.INVALID_EMAIL
 CODE_INVALID_PASSWORD: Final[str] = constants.Code.INVALID_PASSWORD
 
-MOCK_AVATAR_NAME: Final[str] = "avatars/sample.png"
+MOCK_AVATAR_NAME: Final[str] = "avatars/test.png"
 
 
 class AccountsTests(test.APITestCase):

--- a/backend/pong/matches/participation/tests/test_models.py
+++ b/backend/pong/matches/participation/tests/test_models.py
@@ -41,7 +41,7 @@ class MatchParticipationModelTest(TestCase):
 
         @mock.patch(
             "accounts.player.identicon.generate_identicon",
-            return_value="avatars/sample.png",
+            return_value="avatars/test.png",
         )
         def _create_player(
             user: User, mock_identicon: mock.MagicMock

--- a/backend/pong/matches/score/tests/test_models.py
+++ b/backend/pong/matches/score/tests/test_models.py
@@ -29,7 +29,7 @@ class ScoreModelTest(TestCase):
 
         @mock.patch(
             "accounts.player.identicon.generate_identicon",
-            return_value="avatars/sample.png",
+            return_value="avatars/test.png",
         )
         def _create_player(
             user: User, mock_identicon: mock.MagicMock

--- a/backend/pong/oauth2/tests/unit/test_create_oauth2_account.py
+++ b/backend/pong/oauth2/tests/unit/test_create_oauth2_account.py
@@ -31,7 +31,7 @@ class CreateOAuth2AccountTestCase(TestCase):
 
     @mock.patch(
         "accounts.player.identicon.generate_identicon",
-        return_value="avatars/sample.png",
+        return_value="avatars/test.png",
     )
     def test_create_oauth2_user(self, mock_identicon: mock.MagicMock) -> None:
         """

--- a/backend/pong/tournaments/participation/tests/test_command_serializers.py
+++ b/backend/pong/tournaments/participation/tests/test_command_serializers.py
@@ -26,7 +26,7 @@ class ParticipationCommandSerializerTestCase(TestCase):
 
     @mock.patch(
         "accounts.player.identicon.generate_identicon",
-        return_value="avatars/sample.png",
+        return_value="avatars/test.png",
     )
     def _create_player(
         self, user: User, display_name: str, mock_identicon: mock.MagicMock

--- a/backend/pong/tournaments/tournament/tests/test_command_serializers.py
+++ b/backend/pong/tournaments/tournament/tests/test_command_serializers.py
@@ -21,7 +21,7 @@ class TournamentCommandSerializerTest(TestCase):
 
     @mock.patch(
         "accounts.player.identicon.generate_identicon",
-        return_value="avatars/sample.png",
+        return_value="avatars/test.png",
     )
     def _create_player(
         self, user: User, display_name: str, mock_identicon: mock.MagicMock

--- a/backend/pong/users/blocks/serializers/tests/test_create_serializers.py
+++ b/backend/pong/users/blocks/serializers/tests/test_create_serializers.py
@@ -31,7 +31,7 @@ CODE_INVALID: Final[str] = users_constants.Code.INVALID
 CODE_NOT_EXISTS: Final[str] = users_constants.Code.NOT_EXISTS
 CODE_INTERNAL_ERROR: Final[str] = users_constants.Code.INTERNAL_ERROR
 
-MOCK_AVATAR_NAME: Final[str] = "avatars/sample.png"
+MOCK_AVATAR_NAME: Final[str] = "avatars/test.png"
 
 
 class BlockRelationshipCreateSerializerTests(TestCase):

--- a/backend/pong/users/blocks/serializers/tests/test_destroy_serializers.py
+++ b/backend/pong/users/blocks/serializers/tests/test_destroy_serializers.py
@@ -26,7 +26,7 @@ CODE_INVALID: Final[str] = users_constants.Code.INVALID
 CODE_NOT_EXISTS: Final[str] = users_constants.Code.NOT_EXISTS
 CODE_INTERNAL_ERROR: Final[str] = users_constants.Code.INTERNAL_ERROR
 
-MOCK_AVATAR_NAME: Final[str] = "avatars/sample.png"
+MOCK_AVATAR_NAME: Final[str] = "avatars/test.png"
 
 
 class BlockRelationshipDestroySerializerTests(TestCase):

--- a/backend/pong/users/blocks/serializers/tests/test_list_serializers.py
+++ b/backend/pong/users/blocks/serializers/tests/test_list_serializers.py
@@ -27,7 +27,7 @@ MATCH_LOSSES: Final[str] = users_constants.UsersFields.MATCH_LOSSES
 USER_ID: Final[str] = constants.BlockRelationshipFields.USER_ID
 BLOCKED_USER: Final[str] = constants.BlockRelationshipFields.BLOCKED_USER
 
-MOCK_AVATAR_NAME: Final[str] = "avatars/sample.png"
+MOCK_AVATAR_NAME: Final[str] = "avatars/test.png"
 
 
 class BlockRelationshipListSerializerTests(TestCase):

--- a/backend/pong/users/blocks/tests/integration/test_create_views.py
+++ b/backend/pong/users/blocks/tests/integration/test_create_views.py
@@ -32,7 +32,7 @@ BLOCKED_USER: Final[str] = constants.BlockRelationshipFields.BLOCKED_USER
 DATA: Final[str] = custom_response.DATA
 CODE: Final[str] = custom_response.CODE
 
-MOCK_AVATAR_NAME: Final[str] = "avatars/sample.png"
+MOCK_AVATAR_NAME: Final[str] = "avatars/test.png"
 
 
 class BlocksCreateViewTests(test.APITestCase):

--- a/backend/pong/users/blocks/tests/integration/test_destroy_views.py
+++ b/backend/pong/users/blocks/tests/integration/test_destroy_views.py
@@ -26,7 +26,7 @@ CODE_INVALID: Final[str] = users_constants.Code.INVALID
 CODE_NOT_EXISTS: Final[str] = users_constants.Code.NOT_EXISTS
 CODE_INTERNAL_ERROR: Final[str] = users_constants.Code.INTERNAL_ERROR
 
-MOCK_AVATAR_NAME: Final[str] = "avatars/sample.png"
+MOCK_AVATAR_NAME: Final[str] = "avatars/test.png"
 
 
 class BlocksDestroyViewTests(test.APITestCase):

--- a/backend/pong/users/blocks/tests/integration/test_list_views.py
+++ b/backend/pong/users/blocks/tests/integration/test_list_views.py
@@ -35,7 +35,7 @@ NEXT: Final[str] = custom_pagination.PaginationFields.NEXT
 PREVIOUS: Final[str] = custom_pagination.PaginationFields.PREVIOUS
 RESULTS: Final[str] = custom_pagination.PaginationFields.RESULTS
 
-MOCK_AVATAR_NAME: Final[str] = "avatars/sample.png"
+MOCK_AVATAR_NAME: Final[str] = "avatars/test.png"
 
 
 class BlocksListViewTests(test.APITestCase):

--- a/backend/pong/users/friends/serializers/tests/test_create_serializers.py
+++ b/backend/pong/users/friends/serializers/tests/test_create_serializers.py
@@ -31,7 +31,7 @@ CODE_INVALID: Final[str] = users_constants.Code.INVALID
 CODE_NOT_EXISTS: Final[str] = users_constants.Code.NOT_EXISTS
 CODE_INTERNAL_ERROR: Final[str] = users_constants.Code.INTERNAL_ERROR
 
-MOCK_AVATAR_NAME: Final[str] = "avatars/sample.png"
+MOCK_AVATAR_NAME: Final[str] = "avatars/test.png"
 
 
 class FriendshipCreateSerializerTests(TestCase):

--- a/backend/pong/users/friends/serializers/tests/test_destroy_serializer.py
+++ b/backend/pong/users/friends/serializers/tests/test_destroy_serializer.py
@@ -26,7 +26,7 @@ CODE_INVALID: Final[str] = users_constants.Code.INVALID
 CODE_NOT_EXISTS: Final[str] = users_constants.Code.NOT_EXISTS
 CODE_INTERNAL_ERROR: Final[str] = users_constants.Code.INTERNAL_ERROR
 
-MOCK_AVATAR_NAME: Final[str] = "avatars/sample.png"
+MOCK_AVATAR_NAME: Final[str] = "avatars/test.png"
 
 
 class FriendshipDestroySerializerTests(TestCase):

--- a/backend/pong/users/friends/serializers/tests/test_list_serializers.py
+++ b/backend/pong/users/friends/serializers/tests/test_list_serializers.py
@@ -27,7 +27,7 @@ MATCH_LOSSES: Final[str] = users_constants.UsersFields.MATCH_LOSSES
 USER_ID: Final[str] = constants.FriendshipFields.USER_ID
 FRIEND: Final[str] = constants.FriendshipFields.FRIEND
 
-MOCK_AVATAR_NAME: Final[str] = "avatars/sample.png"
+MOCK_AVATAR_NAME: Final[str] = "avatars/test.png"
 
 
 class FriendshipListSerializerTests(TestCase):

--- a/backend/pong/users/friends/tests/integration/test_create_views.py
+++ b/backend/pong/users/friends/tests/integration/test_create_views.py
@@ -32,7 +32,7 @@ FRIEND: Final[str] = constants.FriendshipFields.FRIEND
 DATA: Final[str] = custom_response.DATA
 CODE: Final[str] = custom_response.CODE
 
-MOCK_AVATAR_NAME: Final[str] = "avatars/sample.png"
+MOCK_AVATAR_NAME: Final[str] = "avatars/test.png"
 
 
 class FriendsCreateViewTests(test.APITestCase):

--- a/backend/pong/users/friends/tests/integration/test_destroy_views.py
+++ b/backend/pong/users/friends/tests/integration/test_destroy_views.py
@@ -26,7 +26,7 @@ CODE_INVALID: Final[str] = users_constants.Code.INVALID
 CODE_NOT_EXISTS: Final[str] = users_constants.Code.NOT_EXISTS
 CODE_INTERNAL_ERROR: Final[str] = users_constants.Code.INTERNAL_ERROR
 
-MOCK_AVATAR_NAME: Final[str] = "avatars/sample.png"
+MOCK_AVATAR_NAME: Final[str] = "avatars/test.png"
 
 
 class FriendsDestroyViewTests(test.APITestCase):

--- a/backend/pong/users/friends/tests/integration/test_list_views.py
+++ b/backend/pong/users/friends/tests/integration/test_list_views.py
@@ -35,7 +35,7 @@ NEXT: Final[str] = custom_pagination.PaginationFields.NEXT
 PREVIOUS: Final[str] = custom_pagination.PaginationFields.PREVIOUS
 RESULTS: Final[str] = custom_pagination.PaginationFields.RESULTS
 
-MOCK_AVATAR_NAME: Final[str] = "avatars/sample.png"
+MOCK_AVATAR_NAME: Final[str] = "avatars/test.png"
 
 
 class FriendsListViewTests(test.APITestCase):

--- a/backend/pong/users/tests/integration/test_list.py
+++ b/backend/pong/users/tests/integration/test_list.py
@@ -32,7 +32,7 @@ NEXT: Final[str] = custom_pagination.PaginationFields.NEXT
 PREVIOUS: Final[str] = custom_pagination.PaginationFields.PREVIOUS
 RESULTS: Final[str] = custom_pagination.PaginationFields.RESULTS
 
-MOCK_AVATAR_NAME: Final[str] = "avatars/sample.png"
+MOCK_AVATAR_NAME: Final[str] = "avatars/test.png"
 
 
 class UsersListViewTests(test.APITestCase):

--- a/backend/pong/users/tests/integration/test_me.py
+++ b/backend/pong/users/tests/integration/test_me.py
@@ -33,7 +33,7 @@ CODE: Final[str] = custom_response.CODE
 ERRORS: Final[str] = custom_response.ERRORS
 
 AVATAR_DIR: Final[str] = "media/avatars/"
-MOCK_AVATAR_NAME: Final[str] = "avatars/sample.png"
+MOCK_AVATAR_NAME: Final[str] = "avatars/test.png"
 
 
 class UsersMeViewTests(test.APITestCase):

--- a/backend/pong/users/tests/integration/test_retrieve.py
+++ b/backend/pong/users/tests/integration/test_retrieve.py
@@ -28,7 +28,7 @@ DATA: Final[str] = custom_response.DATA
 CODE: Final[str] = custom_response.CODE
 ERRORS: Final[str] = custom_response.ERRORS
 
-MOCK_AVATAR_NAME: Final[str] = "avatars/sample.png"
+MOCK_AVATAR_NAME: Final[str] = "avatars/test.png"
 
 
 class UsersRetrieveViewTests(test.APITestCase):

--- a/backend/pong/users/tests/unit/test_users_serializer.py
+++ b/backend/pong/users/tests/unit/test_users_serializer.py
@@ -31,7 +31,7 @@ MATCH_LOSSES: Final[str] = constants.UsersFields.MATCH_LOSSES
 
 USER_ID: Final[str] = friends_constants.FriendshipFields.USER_ID
 
-MOCK_AVATAR_NAME: Final[str] = "avatars/sample.png"
+MOCK_AVATAR_NAME: Final[str] = "avatars/test.png"
 
 
 class UsersSerializerTests(TestCase):

--- a/backend/pong/users/tests/unit/test_users_serializers_related_matches.py
+++ b/backend/pong/users/tests/unit/test_users_serializers_related_matches.py
@@ -25,7 +25,7 @@ MATCH_LOSSES: Final[str] = constants.UsersFields.MATCH_LOSSES
 
 USER_ID: Final[str] = friends_constants.FriendshipFields.USER_ID
 
-MOCK_AVATAR_NAME: Final[str] = "avatars/sample.png"
+MOCK_AVATAR_NAME: Final[str] = "avatars/test.png"
 
 
 class UsersSerializerTests(TestCase):

--- a/backend/pong/ws/match/tests/pytest_async_db_service.py
+++ b/backend/pong/ws/match/tests/pytest_async_db_service.py
@@ -40,7 +40,7 @@ def create_tournament_and_round() -> tuple[Tournament, Round]:
 
 @mock.patch(
     "accounts.player.identicon.generate_identicon",
-    return_value="avatars/sample.png",
+    return_value="avatars/test.png",
 )
 @database_sync_to_async
 def create_user_and_player(


### PR DESCRIPTION
## タスクやディスカッションのリンク
<!-- - URLをここに貼る -->
- #527 

## やったこと
<!-- - このタスクでやったことはなにか？ -->
テストでアバター画像に `sample.png` というファイル名を使っていると、テストの後処理で player が削除される時に `sample.png` も一緒に削除されてしまうので、今まで削除されたアバター画像をコミットしてしまうという事態が起きていたようです
ファイル名をテスト用に変更したので問題なくなったと思います

## やらないこと
<!-- - このタスクでやらないことはなにか？（やらない場合いつやるのか？無ければ「なし」を記述） -->

## 動作確認
<!-- - どのような動作確認を行い、結果はどうだったのか？(適宜スクショ等添付) -->
ローカルで `make test` し、`media/avatars/sample.png` が削除されていなかったら ok

## 特にレビューをお願いしたい箇所
<!-- - 特にチェックをお願いしたいポイントを簡潔に記述する -->

## その他
<!-- - 実装上の懸念点、注意点等あれば記載する -->

## 参考リンク
<!-- - 実装に際し参考にした、記事やサイトのリンクを記載する -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **テスト**
  - ユーザーおよびプレイヤー向けテストで使用するモックアバターの画像参照先を、新しいパスに統一して更新しました。これにより、テストの一貫性と信頼性が向上しています。
- **依存関係の更新**
  - 新しい依存関係 `tblib` を追加しました。
  - いくつかのパッケージのバージョンを更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->